### PR TITLE
[Meta] Add pre-commit lint hook and enforce config-before-content CI rule

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if ! command -v markdownlint-cli2 &>/dev/null; then
+  echo "pre-commit: markdownlint-cli2 not found — skipping markdown lint (run 'npm install -g markdownlint-cli2' to enable)" >&2
+  exit 0
+fi
+
+make lint-md

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,4 +1,5 @@
 {
+  "_comment": "Rules config only. Ignore patterns go in .markdownlintignore; CLI options (globs, ignores) go in .markdownlint-cli2.jsonc. Unknown keys here are silently discarded.",
   "default": true,
   "MD013": false,
   "MD022": false,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,3 +74,11 @@ Avoid committing to these until the spike is resolved:
 | ADR title | `ADR-NNN: Decision in past tense` | `ADR-006: Adopt PostgreSQL for metadata layer` |
 
 Every merged PR must close at least one issue.
+
+## CI linter rule
+
+Any PR that adds a new CI linter step must include that linter's config file in the same commit. A linter without config is broken from day one — silent failures (wrong key, wrong file) are worse than no linter at all.
+
+## Local dev setup
+
+Run `make install-hooks` once after cloning to enable the pre-commit markdown lint hook. Run `make lint-md` at any time to check markdown locally.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,6 +73,8 @@ Avoid committing to these until the spike is resolved:
 | PR title | Mirror the issue title | `[Git] Design hot-tier replication quorum protocol` |
 | ADR title | `ADR-NNN: Decision in past tense` | `ADR-006: Adopt PostgreSQL for metadata layer` |
 
+Valid plane names: `edge`, `git`, `application`, `workflow`, `data`. Cross-cutting tooling (hooks, CI config, repo-wide docs) uses `meta` — e.g. `chore/meta-pre-commit-lint-hook`.
+
 Every merged PR must close at least one issue.
 
 ## CI linter rule

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test lint generate fmt
+.PHONY: build test lint lint-md install-hooks generate fmt
 
 build:
 	go build ./...
@@ -14,3 +14,9 @@ generate:
 
 fmt:
 	gofmt -w ./...
+
+lint-md:
+	markdownlint-cli2 "**/*.md"
+
+install-hooks:
+	git config core.hooksPath .githooks


### PR DESCRIPTION
## Summary

- Add `make lint-md` target (runs `markdownlint-cli2 "**/*.md"`) and `make install-hooks` (`git config core.hooksPath .githooks`)
- Add `.githooks/pre-commit` — runs `make lint-md` before each commit, skips with a warning if `markdownlint-cli2` is not installed
- Add CI linter rule to `CLAUDE.md`: any PR adding a new CI linter must include its config in the same commit
- Add `_comment` to `.markdownlint.json` clarifying it is rules-only; ignore patterns and CLI options go in `.markdownlintignore` / `.markdownlint-cli2.jsonc`
- Document valid plane names and `meta` exception for cross-cutting branch names

## Test plan

- [ ] `make install-hooks` runs without error, sets `core.hooksPath` to `.githooks`
- [ ] `make lint-md` passes on current repo state
- [ ] Committing with `markdownlint-cli2` installed triggers the hook; bad markdown blocks the commit
- [ ] Committing without `markdownlint-cli2` installed prints the skip warning and does not block

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)