### PR TITLE
[Meta] Expand Claude Code allowed-tool permissions in settings.json

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -4,8 +4,10 @@
       "Glob",
       "Read",
       "Grep",
+      "Skill",
       "WebSearch",
       "WebFetch",
+
       "Bash(git status:*)",
       "Bash(git diff:*)",
       "Bash(git log:*)",
@@ -27,6 +29,13 @@
       "Bash(find:*)",
       "Bash(tree:*)",
       "Bash(column:*)",
+
+      "Bash(gh pr view:*)",
+      "Bash(gh pr diff:*)",
+      "Bash(gh pr checks:*)",
+      "Bash(gh pr list:*)",
+      "Bash(git fetch:*)",
+      "Bash(git show:*)",
 
       "mcp__plugin_context7_context7__*"
     ]


### PR DESCRIPTION
## Summary

- Allow `Skill` tool invocations without per-call prompts
- Allow `gh pr view/diff/checks/list` read commands
- Allow `git fetch` and `git show`

All additions are read-only or agent-UX surface. No write/destructive permissions added.

## Test plan

- [ ] Run `make install-hooks` — no regression
- [ ] Trigger a skill invocation in Claude Code — no permission prompt appears
- [ ] Run `gh pr list` via Claude — no permission prompt appears

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)