### PR TITLE
[ADR] Amend ADR-004: Kafka partition key is aggregate_id, not repo_id/org_id

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -487,10 +487,17 @@ Consequences: <positive, negative, follow-ups>
 ### ADR-004: Adopted Kafka as the event bus
 
 - **Status:** Accepted
+- **Amended:** 2026-05-04
 - **Date:** TBD
 - **Context:** Search, webhooks, billing, and audit consumers must observe state changes asynchronously without coupling to the application plane. Synchronous fan-out is a tight-coupling failure mode.
-- **Decision:** Kafka is the canonical event bus. Per-partition ordering is preserved on `repo_id` / `org_id` partition keys. Cross-partition ordering is undefined. Topics are fed by the polling-based outbox consumer reading PostgreSQL outbox tables (ADR-008).
-- **Consequences:** Log semantics enable replay, fan-out, and audit. Consumers must be idempotent on `event_id`. Direct Kafka producer paths from application code are forbidden — see `.claude/skills/gitscale-outbox-check/`.
+- **Decision:** Kafka is the canonical event bus. Per-partition ordering is preserved per aggregate, keyed on `aggregate_id`
+  (UUID) for every topic. Repo-level or org-level ordering is not guaranteed;
+  consumers requiring it must reorder by `(aggregate_id, published_at)` after
+  consumption. The previous `repo_id`/`org_id` keying was rejected to avoid
+  hot-partition risk under agent traffic. Cross-partition ordering is undefined. Topics are fed by the polling-based outbox consumer reading PostgreSQL outbox tables (ADR-008).
+- **Consequences:** Log semantics enable replay, fan-out, and audit. Consumers must be idempotent on `event_id`. Direct Kafka producer paths from application code are forbidden — see `.claude/skills/gitscale-outbox-check/`. Cross-links: design specs for issues #11 and #12
+  (docs/superpowers/specs/2026-05-02-issue-11-outbox-consumer-design.md,
+  docs/superpowers/specs/2026-05-02-issue-12-kafka-topology-design.md).
 
 ### ADR-005: Adopted Go for the application plane
 


### PR DESCRIPTION
## Summary

- Replaces the `repo_id`/`org_id` Kafka partition key with `aggregate_id` (UUID) across all topics to eliminate hot-partition risk under agent traffic loads.
- Adds `Amended: 2026-05-04` to ADR-004 status block.
- Adds cross-links to design specs for issues #11 and #12 in the Consequences section.

## Changes

Only `docs/architecture.md` is modified. No code files changed.

## Lint

`make lint-md` reports 56 MD060 errors — all pre-existing table-column-style issues inherited from `main`. Zero new lint errors introduced by this PR.

## Test plan

- [ ] Verify ADR-004 Decision text now references `aggregate_id` and includes the hot-partition rejection rationale.
- [ ] Verify `Amended: 2026-05-04` appears under `Status: Accepted` in ADR-004.
- [ ] Verify cross-links to issue #11 and #12 spec files appear in ADR-004 Consequences.
- [ ] Confirm no other ADRs or sections were modified.

Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)