### PR TITLE
[Data] Kafka topic topology + partition strategy (ADR-004, ADR-008)

### DIFF
--- a/.github/workflows/lint-events.yml
+++ b/.github/workflows/lint-events.yml
@@ -1,0 +1,24 @@
+name: lint-events
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  lint-events:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install yq
+        run: |
+          YQ_VERSION="v4.44.1"
+          curl -fsSL "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64" \
+            -o /usr/local/bin/yq && chmod +x /usr/local/bin/yq
+
+      - name: Install ajv-cli
+        run: npm install -g ajv-cli ajv-formats
+
+      - name: Run lint-events
+        run: make lint-events

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test lint lint-md install-hooks generate fmt
+.PHONY: build test lint lint-md lint-events install-hooks generate fmt
 
 build:
 	go build ./...
@@ -17,6 +17,9 @@ fmt:
 
 lint-md:
 	markdownlint-cli2 "**/*.md"
+
+lint-events:
+	bash plane/data/kafka/lint-events.sh
 
 install-hooks:
 	git config core.hooksPath .githooks

--- a/plane/data/events/billing/.gitkeep
+++ b/plane/data/events/billing/.gitkeep
@@ -1,0 +1,3 @@
+# Placeholder. Per-event-type schemas are filed under each domain's service issue.
+# Schema naming: <event_type>.schema.json  (e.g. repo.created.schema.json)
+# Fixture naming: <event_type>.testdata/<sample>.json

--- a/plane/data/events/ci/.gitkeep
+++ b/plane/data/events/ci/.gitkeep
@@ -1,0 +1,3 @@
+# Placeholder. Per-event-type schemas are filed under each domain's service issue.
+# Schema naming: <event_type>.schema.json  (e.g. repo.created.schema.json)
+# Fixture naming: <event_type>.testdata/<sample>.json

--- a/plane/data/events/collaboration/.gitkeep
+++ b/plane/data/events/collaboration/.gitkeep
@@ -1,0 +1,3 @@
+# Placeholder. Per-event-type schemas are filed under each domain's service issue.
+# Schema naming: <event_type>.schema.json  (e.g. repo.created.schema.json)
+# Fixture naming: <event_type>.testdata/<sample>.json

--- a/plane/data/events/identity/.gitkeep
+++ b/plane/data/events/identity/.gitkeep
@@ -1,0 +1,3 @@
+# Placeholder. Per-event-type schemas are filed under each domain's service issue.
+# Schema naming: <event_type>.schema.json  (e.g. repo.created.schema.json)
+# Fixture naming: <event_type>.testdata/<sample>.json

--- a/plane/data/events/repositories/.gitkeep
+++ b/plane/data/events/repositories/.gitkeep
@@ -1,0 +1,3 @@
+# Placeholder. Per-event-type schemas are filed under each domain's service issue.
+# Schema naming: <event_type>.schema.json  (e.g. repo.created.schema.json)
+# Fixture naming: <event_type>.testdata/<sample>.json

--- a/plane/data/kafka/consumer_groups.go
+++ b/plane/data/kafka/consumer_groups.go
@@ -1,0 +1,43 @@
+package kafka
+
+// Consumer group name constants.
+//
+// Each constant is annotated with:
+//   - the topics it subscribes to
+//   - the SPIFFE workload identity of the consumer service (ADR-010)
+//
+// Full Terraform ACL wiring is future work; SPIFFE IDs here match the
+// acls.consumer_spiffe_ids declared in topics.yaml so tooling can cross-check.
+const (
+	// GroupSearchIndexer consumes ALL 5 main topics.
+	// Indexes events into Vespa for customer-facing search (ADR-016).
+	// SPIFFE ID: spiffe://gitscale.dev/ns/data/sa/search-indexer
+	GroupSearchIndexer = "gitscale.search-indexer"
+
+	// GroupAuditLog consumes ALL 5 main topics.
+	// Writes immutable audit records to ClickHouse (the durable audit store per ADR-008).
+	// SPIFFE ID: spiffe://gitscale.dev/ns/data/sa/audit-log
+	GroupAuditLog = "gitscale.audit-log"
+
+	// GroupWebhookFanout consumes repositories.events, collaboration.events, ci.events.
+	// Fans out to customer-configured webhook endpoints.
+	// SPIFFE ID: spiffe://gitscale.dev/ns/data/sa/webhook-fanout
+	GroupWebhookFanout = "gitscale.webhook-fanout"
+
+	// GroupBillingAggregator consumes billing.events.
+	// Aggregates usage events into customer invoice line items.
+	// Uses envelope.RateBucket for routing to the correct billing tier.
+	// SPIFFE ID: spiffe://gitscale.dev/ns/data/sa/billing-aggregator
+	GroupBillingAggregator = "gitscale.billing-aggregator"
+
+	// GroupColdStorageMigrator consumes repositories.events.
+	// Learns which repos have crossed the hot→cold boundary (last_active_at > 30d)
+	// and triggers erasure-coding migration jobs in the workflow plane (ADR-001).
+	// SPIFFE ID: spiffe://gitscale.dev/ns/data/sa/cold-storage-migrator
+	GroupColdStorageMigrator = "gitscale.cold-storage-migrator"
+)
+
+// DefaultAutoOffsetReset is the Kafka auto.offset.reset setting for all
+// consumer groups. Late-binding consumers must backfill from the beginning,
+// not skip events they have not yet seen (D7 per issue #12 spec).
+const DefaultAutoOffsetReset = "earliest"

--- a/plane/data/kafka/envelope.go
+++ b/plane/data/kafka/envelope.go
@@ -1,0 +1,79 @@
+package kafka
+
+import (
+	"encoding/json"
+	"time"
+)
+
+// EventEnvelope is the wire format for every event published to a Kafka topic
+// by the polling outbox consumer (ADR-008).
+//
+// The partition key on every topic is AggregateID (ADR-004).
+// SchemaVersion refers to the payload schema version, not the topic version.
+// See plane/data/kafka/topics.yaml §versioning-policy for the topic versioning
+// contract (in-place compatible evolution; breaking changes roll to …events.v2).
+type EventEnvelope struct {
+	// EventID is the UUID from outbox.event_id. Consumers use this for
+	// idempotency deduplication (ADR-008).
+	EventID string `json:"event_id"`
+
+	// AggregateType names the domain aggregate, e.g. "pull_request", "repository".
+	AggregateType string `json:"aggregate_type"`
+
+	// AggregateID is the UUID of the aggregate. This is the Kafka partition key
+	// for all topics (ADR-004), preserving per-aggregate ordering.
+	AggregateID string `json:"aggregate_id"`
+
+	// EventType is the dot-separated event name, e.g. "pr.opened", "repo.archived".
+	// Pattern: ^[a-z_]+\.[a-z_]+$
+	EventType string `json:"event_type"`
+
+	// SchemaVersion is the payload schema version, e.g. "v1".
+	// Incremented only on breaking payload changes; most events remain at "v1".
+	SchemaVersion string `json:"schema_version"`
+
+	// Payload is the domain-specific event body. Shape is defined in
+	// plane/data/events/<domain>/<event_type>.schema.json.
+	Payload json.RawMessage `json:"payload"`
+
+	// OccurredAt is when the domain event occurred — copied from the source
+	// transaction timestamp, not from Kafka publish time. Use this for
+	// event-time ordering and reconciliation windows.
+	OccurredAt time.Time `json:"occurred_at"`
+
+	// PublishedAt is when the outbox consumer published the event to Kafka
+	// (RFC3339, UTC). Delta between OccurredAt and PublishedAt is the outbox
+	// consumer lag for this event.
+	PublishedAt time.Time `json:"published_at"`
+
+	// PrincipalType identifies what kind of principal caused the event:
+	// "user", "agent", or "service". Carried from the JWT-SVID claims (ADR-010)
+	// so downstream consumers (billing, CI routing) can branch without a
+	// secondary identity lookup.
+	PrincipalType string `json:"principal_type"`
+
+	// RateBucket is the billing routing key (e.g. "agent_pro", "human_default").
+	// Carried from JWT-SVID claims (ADR-010) so BillingAggregator can route
+	// usage records without re-resolving identity.
+	RateBucket string `json:"rate_bucket"`
+}
+
+// MarshalJSON encodes the envelope to JSON bytes.
+// Provided as a helper so callers don't need to import encoding/json directly.
+func (e EventEnvelope) MarshalJSON() ([]byte, error) {
+	type alias EventEnvelope
+	b, err := json.Marshal(alias(e))
+	if err != nil {
+		return nil, err
+	}
+	return b, nil
+}
+
+// UnmarshalEnvelope decodes JSON bytes into an EventEnvelope.
+func UnmarshalEnvelope(data []byte) (EventEnvelope, error) {
+	var e EventEnvelope
+	if err := json.Unmarshal(data, &e); err != nil {
+		return EventEnvelope{}, err
+	}
+	return e, nil
+}

--- a/plane/data/kafka/envelope.schema.json
+++ b/plane/data/kafka/envelope.schema.json
@@ -1,0 +1,71 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://gitscale.dev/schemas/kafka/envelope.json",
+  "title": "EventEnvelope",
+  "description": "Wire format for every event published to a GitScale Kafka topic by the polling outbox consumer (ADR-008). Partition key is aggregate_id (ADR-004).",
+  "type": "object",
+  "required": [
+    "event_id",
+    "aggregate_type",
+    "aggregate_id",
+    "event_type",
+    "schema_version",
+    "payload",
+    "occurred_at",
+    "published_at",
+    "principal_type",
+    "rate_bucket"
+  ],
+  "properties": {
+    "event_id": {
+      "type": "string",
+      "format": "uuid",
+      "description": "UUID from outbox.event_id. Used for consumer-side idempotency deduplication."
+    },
+    "aggregate_type": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Domain aggregate name, e.g. 'pull_request', 'repository'."
+    },
+    "aggregate_id": {
+      "type": "string",
+      "format": "uuid",
+      "description": "UUID of the aggregate. This is the Kafka partition key (ADR-004)."
+    },
+    "event_type": {
+      "type": "string",
+      "pattern": "^[a-z_]+\\.[a-z_]+$",
+      "description": "Dot-separated event name, e.g. 'pr.opened'. Must have a corresponding schema in plane/data/events/<domain>/<event_type>.schema.json."
+    },
+    "schema_version": {
+      "type": "string",
+      "pattern": "^v[0-9]+$",
+      "description": "Payload schema version. Incremented only on breaking payload changes."
+    },
+    "payload": {
+      "type": "object",
+      "description": "Domain-specific event body. Shape defined in plane/data/events/<domain>/<event_type>.schema.json."
+    },
+    "occurred_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "When the domain event occurred (source transaction timestamp, RFC3339 UTC). Use for event-time ordering."
+    },
+    "published_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "When the outbox consumer published the event to Kafka (RFC3339 UTC)."
+    },
+    "principal_type": {
+      "type": "string",
+      "enum": ["user", "agent", "service"],
+      "description": "Kind of principal that caused the event. Carried from JWT-SVID claims (ADR-010)."
+    },
+    "rate_bucket": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Billing routing key from JWT-SVID claims (ADR-010), e.g. 'agent_pro', 'human_default'."
+    }
+  },
+  "additionalProperties": false
+}

--- a/plane/data/kafka/lint-events.sh
+++ b/plane/data/kafka/lint-events.sh
@@ -1,0 +1,168 @@
+#!/usr/bin/env bash
+# lint-events.sh — validates the Kafka topic definitions and event envelope schema.
+#
+# Called by `make lint-events`. Required tools: yq, ajv (ajv-cli).
+# Install: npm install -g ajv-cli ajv-formats && brew install yq  (or apt-get install yq)
+#
+# Exit codes:
+#   0  all checks pass
+#   1  one or more checks failed (messages written to stderr)
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+KAFKA_DIR="${REPO_ROOT}/plane/data/kafka"
+EVENTS_DIR="${REPO_ROOT}/plane/data/events"
+
+FAIL=0
+
+# ── helpers ───────────────────────────────────────────────────────────────────
+
+log_ok()   { echo "  [ok]  $*"; }
+log_fail() { echo "  [FAIL] $*" >&2; FAIL=1; }
+
+require_tool() {
+  if ! command -v "$1" &>/dev/null; then
+    echo "ERROR: required tool '$1' not found. Install: $2" >&2
+    exit 1
+  fi
+}
+
+# ── prerequisite tools ────────────────────────────────────────────────────────
+
+require_tool yq   "brew install yq  OR  apt-get install yq"
+require_tool ajv  "npm install -g ajv-cli ajv-formats"
+
+# ── check 1: topics.yaml is valid YAML and contains required top-level keys ──
+
+echo "==> Check 1: topics.yaml structure"
+
+TOPICS_YAML="${KAFKA_DIR}/topics.yaml"
+
+if ! yq eval '.' "${TOPICS_YAML}" >/dev/null 2>&1; then
+  log_fail "topics.yaml is not valid YAML"
+else
+  log_ok "topics.yaml parses as valid YAML"
+fi
+
+# Every topic must declare key_field: aggregate_id (ADR-004)
+TOPICS_WITHOUT_KEY=$(yq eval '.topics[] | select(.key_field != "aggregate_id") | .name' "${TOPICS_YAML}" 2>/dev/null || true)
+if [[ -n "${TOPICS_WITHOUT_KEY}" ]]; then
+  log_fail "topics missing key_field: aggregate_id (ADR-004): ${TOPICS_WITHOUT_KEY}"
+else
+  log_ok "all topics declare key_field: aggregate_id"
+fi
+
+# Every main topic (not DLQ) must have an acls: block with producer_spiffe_id
+TOPICS_WITHOUT_ACLS=$(yq eval '.topics[] | select(.name | test("^(?!.*\\.dlq$)")) | select((.acls | has("producer_spiffe_id")) | not) | .name' "${TOPICS_YAML}" 2>/dev/null || true)
+if [[ -n "${TOPICS_WITHOUT_ACLS}" ]]; then
+  log_fail "main topics missing acls.producer_spiffe_id (ADR-010): ${TOPICS_WITHOUT_ACLS}"
+else
+  log_ok "all main topics declare acls.producer_spiffe_id"
+fi
+
+# No billing topic should use infinite retention (retention_ms must be finite / > 0)
+BILLING_INFINITE=$(yq eval '.topics[] | select(.name | test("billing")) | select(.retention_ms == null or .retention_ms == 0) | .name' "${TOPICS_YAML}" 2>/dev/null || true)
+if [[ -n "${BILLING_INFINITE}" ]]; then
+  log_fail "billing topics with missing/zero retention_ms (Kafka is operational-only, ADR-008): ${BILLING_INFINITE}"
+else
+  log_ok "billing topics have finite retention_ms"
+fi
+
+# ── check 2: envelope.schema.json is valid JSON ───────────────────────────────
+
+echo "==> Check 2: envelope.schema.json is valid JSON"
+
+ENVELOPE_SCHEMA="${KAFKA_DIR}/envelope.schema.json"
+
+if ! python3 -c "import json,sys; json.load(open('${ENVELOPE_SCHEMA}'))" 2>/dev/null; then
+  log_fail "envelope.schema.json is not valid JSON"
+else
+  log_ok "envelope.schema.json parses as valid JSON"
+fi
+
+# ── check 3: validate event schemas in plane/data/events/ ────────────────────
+
+echo "==> Check 3: event schemas (plane/data/events/)"
+
+if [[ -d "${EVENTS_DIR}" ]]; then
+  SCHEMA_COUNT=0
+  FIXTURE_COUNT=0
+  FIXTURE_FAIL=0
+
+  while IFS= read -r -d '' schema_file; do
+    SCHEMA_COUNT=$((SCHEMA_COUNT + 1))
+    domain_event="$(basename "${schema_file}" .schema.json)"
+    testdata_dir="$(dirname "${schema_file}")/${domain_event}.testdata"
+
+    # validate the schema is valid JSON
+    if ! python3 -c "import json,sys; json.load(open('${schema_file}'))" 2>/dev/null; then
+      log_fail "invalid JSON: ${schema_file}"
+      continue
+    fi
+
+    # every schema must have at least one fixture
+    if [[ ! -d "${testdata_dir}" ]]; then
+      log_fail "missing testdata dir for schema: ${schema_file} (expected: ${testdata_dir}/)"
+      FIXTURE_FAIL=1
+      continue
+    fi
+
+    fixture_files=("${testdata_dir}"/*.json)
+    if [[ ${#fixture_files[@]} -eq 0 ]] || [[ ! -f "${fixture_files[0]}" ]]; then
+      log_fail "no fixture files in ${testdata_dir}/ — at least one required"
+      FIXTURE_FAIL=1
+      continue
+    fi
+
+    # validate each fixture against its schema
+    for fixture in "${testdata_dir}"/*.json; do
+      FIXTURE_COUNT=$((FIXTURE_COUNT + 1))
+      if ! ajv validate --spec=draft2020 --strict=false -s "${schema_file}" -d "${fixture}" 2>/dev/null; then
+        log_fail "fixture validation failed: ${fixture} against ${schema_file}"
+        FIXTURE_FAIL=1
+      fi
+    done
+  done < <(find "${EVENTS_DIR}" -name '*.schema.json' -print0 2>/dev/null)
+
+  if [[ ${SCHEMA_COUNT} -eq 0 ]]; then
+    log_ok "no event schemas yet in ${EVENTS_DIR}/ (domain schemas filed under per-domain issues)"
+  else
+    if [[ ${FIXTURE_FAIL} -eq 0 ]]; then
+      log_ok "${SCHEMA_COUNT} schemas, ${FIXTURE_COUNT} fixtures — all valid"
+    fi
+  fi
+else
+  log_ok "plane/data/events/ not yet created — skipping event schema checks"
+fi
+
+# ── check 4: every event_type string literal in Go has a schema file ─────────
+
+echo "==> Check 4: event_type literals in Go code have corresponding schema files"
+
+if [[ -d "${EVENTS_DIR}" ]]; then
+  # Extract quoted strings assigned to event_type or EventType fields in Go files.
+  # Pattern matches: event_type: "foo.bar"  or  EventType: "foo.bar"
+  while IFS= read -r event_type; do
+    # derive domain from the first segment before the dot
+    domain="${event_type%%.*}"
+    schema_file="${EVENTS_DIR}/${domain}/${event_type}.schema.json"
+    if [[ ! -f "${schema_file}" ]]; then
+      log_fail "event_type '${event_type}' used in Go code but no schema at ${schema_file}"
+    fi
+  done < <(grep -rh --include='*.go' -oP '(?:event_type|EventType):\s*"([a-z_]+\.[a-z_]+)"' "${REPO_ROOT}/plane" 2>/dev/null \
+    | grep -oP '"[a-z_]+\.[a-z_]+"' | tr -d '"' | sort -u)
+
+  log_ok "event_type literal check complete"
+else
+  log_ok "plane/data/events/ not yet created — skipping event_type literal check"
+fi
+
+# ── result ────────────────────────────────────────────────────────────────────
+
+echo ""
+if [[ ${FAIL} -ne 0 ]]; then
+  echo "FAIL: one or more lint-events checks failed (see above)" >&2
+  exit 1
+fi
+echo "OK: all lint-events checks passed"

--- a/plane/data/kafka/topics.go
+++ b/plane/data/kafka/topics.go
@@ -1,0 +1,39 @@
+// Package kafka defines the Kafka topic and consumer-group name constants for
+// the GitScale event bus, the EventEnvelope type, and topology helpers.
+//
+// Partition key for every topic is aggregate_id (UUID) per ADR-004.
+// Events reach Kafka only through the polling outbox consumer per ADR-008.
+// No package in this tree imports a concrete Kafka driver — producers and
+// consumers wire themselves at startup and reference these constants only.
+package kafka
+
+// Topic name constants — single source of truth for string literals used
+// across the outbox consumer, Terraform data source, and topology apply CLI.
+//
+// Naming convention: gitscale.<domain>.events[.dlq]
+const (
+	TopicIdentityEvents    = "gitscale.identity.events"
+	TopicIdentityEventsDLQ = "gitscale.identity.events.dlq"
+
+	TopicRepositoriesEvents    = "gitscale.repositories.events"
+	TopicRepositoriesEventsDLQ = "gitscale.repositories.events.dlq"
+
+	TopicCollaborationEvents    = "gitscale.collaboration.events"
+	TopicCollaborationEventsDLQ = "gitscale.collaboration.events.dlq"
+
+	TopicCIEvents    = "gitscale.ci.events"
+	TopicCIEventsDLQ = "gitscale.ci.events.dlq"
+
+	TopicBillingEvents    = "gitscale.billing.events"
+	TopicBillingEventsDLQ = "gitscale.billing.events.dlq"
+)
+
+// AllMainTopics lists the five domain topics (not DLQs).
+// Useful for consumers that subscribe to all domains (e.g. SearchIndexer, AuditLog).
+var AllMainTopics = []string{
+	TopicIdentityEvents,
+	TopicRepositoriesEvents,
+	TopicCollaborationEvents,
+	TopicCIEvents,
+	TopicBillingEvents,
+}

--- a/plane/data/kafka/topics.yaml
+++ b/plane/data/kafka/topics.yaml
@@ -1,0 +1,169 @@
+# Schema version: 1
+# Versioning policy: bump schema version when adding/removing/renaming topics
+# or changing partition count, replication factor, or key strategy.
+# Breaking changes require an ADR amendment.
+#
+# Kafka is operational-only; ClickHouse is the durable audit store (ADR-008).
+# Do NOT rely on Kafka retention for reconciliation or compliance storage.
+#
+# Per ADR-004: partition key is aggregate_id (UUID) for all topics.
+# Per ADR-008: events are published only by the polling outbox consumer,
+#   never by a direct application-plane Kafka producer.
+#
+# ACLs (acls:) declare producer and consumer SPIFFE IDs (ADR-010).
+# Full Terraform ACL wiring is future work; the schema is defined here so
+# tooling can enforce it once wired.
+#
+# Topic versioning policy (breaking changes):
+#   1. Bump payload schema_version in the envelope (v1 -> v2).
+#   2. Roll topic: introduce gitscale.<domain>.events.v2 with the same config.
+#   3. Dual-publish window: outbox consumer publishes to both events and events.v2
+#      using the registered downgrade function in plane/data/events/<domain>/downgrades.go.
+#   4. Consumer groups migrate to v2 at their own pace.
+#   5. Decommission v1 30 days after the last consumer migrates.
+
+defaults:
+  replication_factor: 3
+  key_field: aggregate_id
+  configs:
+    cleanup.policy: delete
+    min.insync.replicas: 2
+    compression.type: zstd
+
+topics:
+  # ── identity ──────────────────────────────────────────────────────────────
+  - name: gitscale.identity.events
+    partitions: 12
+    retention_ms: 604800000          # 7 days
+    key_field: aggregate_id
+    rationale: >
+      User/org/agent mutations. Low volume (~100 events/sec peak). 12 partitions
+      gives ~10 events/sec per partition — generous headroom.
+    acls:
+      producer_spiffe_id: spiffe://gitscale.dev/ns/data/sa/outbox-consumer
+      consumer_spiffe_ids:
+        - spiffe://gitscale.dev/ns/data/sa/search-indexer
+        - spiffe://gitscale.dev/ns/data/sa/audit-log
+
+  - name: gitscale.identity.events.dlq
+    partitions: 1
+    retention_ms: 2592000000         # 30 days
+    key_field: aggregate_id
+    rationale: >
+      Poison messages from identity consumers. 1 partition is sufficient;
+      DLQ volume is negligible under normal operation.
+    acls:
+      producer_spiffe_id: spiffe://gitscale.dev/ns/data/sa/outbox-consumer
+      consumer_spiffe_ids:
+        - spiffe://gitscale.dev/ns/data/sa/search-indexer
+        - spiffe://gitscale.dev/ns/data/sa/audit-log
+
+  # ── repositories ──────────────────────────────────────────────────────────
+  - name: gitscale.repositories.events
+    partitions: 24
+    retention_ms: 604800000          # 7 days
+    key_field: aggregate_id
+    rationale: >
+      Repo metadata mutations. Push events drive ~½ collaboration volume.
+      Peak ~8,000 events/sec; 24 partitions => ~330 events/sec per partition (~330 KB/s).
+    acls:
+      producer_spiffe_id: spiffe://gitscale.dev/ns/data/sa/outbox-consumer
+      consumer_spiffe_ids:
+        - spiffe://gitscale.dev/ns/data/sa/search-indexer
+        - spiffe://gitscale.dev/ns/data/sa/audit-log
+        - spiffe://gitscale.dev/ns/data/sa/webhook-fanout
+        - spiffe://gitscale.dev/ns/data/sa/cold-storage-migrator
+
+  - name: gitscale.repositories.events.dlq
+    partitions: 1
+    retention_ms: 2592000000         # 30 days
+    key_field: aggregate_id
+    acls:
+      producer_spiffe_id: spiffe://gitscale.dev/ns/data/sa/outbox-consumer
+      consumer_spiffe_ids:
+        - spiffe://gitscale.dev/ns/data/sa/search-indexer
+        - spiffe://gitscale.dev/ns/data/sa/audit-log
+        - spiffe://gitscale.dev/ns/data/sa/webhook-fanout
+        - spiffe://gitscale.dev/ns/data/sa/cold-storage-migrator
+
+  # ── collaboration ──────────────────────────────────────────────────────────
+  - name: gitscale.collaboration.events
+    partitions: 48
+    retention_ms: 604800000          # 7 days
+    key_field: aggregate_id
+    rationale: >
+      PR/issue/comment events. Highest write volume — agent-driven.
+      ~100 events/min/session × 1K active sessions × 10× burst => ~16,000 events/sec peak.
+      48 partitions => ~330 events/sec per partition. Powers-of-2 multiple of 12
+      for clean rebalancing if partition count is ever increased.
+    acls:
+      producer_spiffe_id: spiffe://gitscale.dev/ns/data/sa/outbox-consumer
+      consumer_spiffe_ids:
+        - spiffe://gitscale.dev/ns/data/sa/search-indexer
+        - spiffe://gitscale.dev/ns/data/sa/audit-log
+        - spiffe://gitscale.dev/ns/data/sa/webhook-fanout
+
+  - name: gitscale.collaboration.events.dlq
+    partitions: 1
+    retention_ms: 2592000000         # 30 days
+    key_field: aggregate_id
+    acls:
+      producer_spiffe_id: spiffe://gitscale.dev/ns/data/sa/outbox-consumer
+      consumer_spiffe_ids:
+        - spiffe://gitscale.dev/ns/data/sa/search-indexer
+        - spiffe://gitscale.dev/ns/data/sa/audit-log
+        - spiffe://gitscale.dev/ns/data/sa/webhook-fanout
+
+  # ── ci ────────────────────────────────────────────────────────────────────
+  - name: gitscale.ci.events
+    partitions: 24
+    retention_ms: 604800000          # 7 days
+    key_field: aggregate_id
+    rationale: >
+      Workflow + per-job state transitions. ~20 events per pipeline ×
+      1K pipelines/min × burst => ~5,000 events/sec peak.
+      24 partitions => ~210 events/sec per partition.
+    acls:
+      producer_spiffe_id: spiffe://gitscale.dev/ns/data/sa/outbox-consumer
+      consumer_spiffe_ids:
+        - spiffe://gitscale.dev/ns/data/sa/search-indexer
+        - spiffe://gitscale.dev/ns/data/sa/audit-log
+        - spiffe://gitscale.dev/ns/data/sa/webhook-fanout
+
+  - name: gitscale.ci.events.dlq
+    partitions: 1
+    retention_ms: 2592000000         # 30 days
+    key_field: aggregate_id
+    acls:
+      producer_spiffe_id: spiffe://gitscale.dev/ns/data/sa/outbox-consumer
+      consumer_spiffe_ids:
+        - spiffe://gitscale.dev/ns/data/sa/search-indexer
+        - spiffe://gitscale.dev/ns/data/sa/audit-log
+        - spiffe://gitscale.dev/ns/data/sa/webhook-fanout
+
+  # ── billing ───────────────────────────────────────────────────────────────
+  - name: gitscale.billing.events
+    partitions: 12
+    retention_ms: 604800000          # 7 days — Kafka is operational-only.
+    key_field: aggregate_id
+    rationale: >
+      Usage events trail every metered operation. ~3,000 events/sec peak;
+      12 partitions => ~250 events/sec per partition.
+      Retention is 7 days (operational window only). ClickHouse is the
+      durable audit and reconciliation store (ADR-008); do not extend
+      Kafka retention for compliance purposes.
+    acls:
+      producer_spiffe_id: spiffe://gitscale.dev/ns/data/sa/outbox-consumer
+      consumer_spiffe_ids:
+        - spiffe://gitscale.dev/ns/data/sa/billing-aggregator
+        - spiffe://gitscale.dev/ns/data/sa/audit-log
+
+  - name: gitscale.billing.events.dlq
+    partitions: 1
+    retention_ms: 2592000000         # 30 days
+    key_field: aggregate_id
+    acls:
+      producer_spiffe_id: spiffe://gitscale.dev/ns/data/sa/outbox-consumer
+      consumer_spiffe_ids:
+        - spiffe://gitscale.dev/ns/data/sa/billing-aggregator
+        - spiffe://gitscale.dev/ns/data/sa/audit-log


### PR DESCRIPTION
## Summary

- Implements the complete Kafka topic topology for all 5 GitScale schema domains (identity, repositories, collaboration, ci, billing) plus per-topic DLQs.
- Adds `EventEnvelope` Go struct and matching `envelope.schema.json` with three new fields (see gap resolutions below).
- Adds `make lint-events` target backed by `plane/data/kafka/lint-events.sh` (config committed in same PR per CLAUDE.md rule).
- Adds `lint-events` CI workflow.

Closes #12
Depends on #29 (merged) — ADR-004 amendment: partition key is `aggregate_id`, not `repo_id`/`org_id`.

## Three gap resolutions

**Gap 1 — Kafka broker auth + topic ACLs**
`topics.yaml` now includes an `acls:` section on every topic declaring:
- `producer_spiffe_id`: `spiffe://gitscale.dev/ns/data/sa/outbox-consumer` (the single outbox consumer; ADR-008)
- `consumer_spiffe_ids`: list of owning consumer group SPIFFE IDs (ADR-010)

`consumer_groups.go` comments map each group constant to its SPIFFE ID.
Full Terraform ACL wiring is explicitly documented as future work; the schema is locked now so tooling can enforce it once wired.

**Gap 2 — Billing topic retention**
`gitscale.billing.events` now uses `retention_ms: 604800000` (7 days), same as all other main topics.
Rationale: Kafka is operational-only. ClickHouse is the durable audit and reconciliation store (ADR-008). The previous 30-day billing Kafka retention was treating Kafka as the audit store, which contradicts ADR-008. The `topics.yaml` header and the billing topic's `rationale:` field both document this explicitly.

**Gap 3 — EventEnvelope missing fields**
`EventEnvelope` and `envelope.schema.json` now include:
- `OccurredAt time.Time` — domain-event timestamp (source transaction time, not publish time); enables event-time ordering and reconciliation windows.
- `PrincipalType string` — `"user" | "agent" | "service"`; carried from JWT-SVID claims (ADR-010) so consumers can branch on principal type without a secondary identity lookup.
- `RateBucket string` — billing routing key (e.g. `"agent_pro"`, `"human_default"`); from JWT-SVID claims (ADR-010) so `BillingAggregator` can route usage records without re-resolving identity.

## ADR conformance

| ADR | Status | Detail |
|-----|--------|--------|
| ADR-004 | Conforming | All topics declare `key_field: aggregate_id`; `lint-events.sh` enforces it |
| ADR-008 | Conforming | `topics.yaml` header cross-references outbox consumer contract; no direct producer path; billing retention is finite/operational-only |
| ADR-010 | Gap-filling | `acls:` section documents SPIFFE IDs; full Terraform wiring is future work |
| ADR-016 | Not touched | No Vespa/Qdrant code |
| ADR-017 | Conforming | `plane/data/kafka/` exports only constants and types; no concrete driver import |

## Test plan

- [ ] `go build ./plane/data/kafka/... && go vet ./plane/data/kafka/...` passes (verified locally)
- [ ] `make lint-events` passes (verified locally — all 4 checks green)
- [ ] CI `lint-events` workflow runs on PR
- [ ] Review `topics.yaml`: all 10 topics (5 main + 5 DLQ), correct partition counts, `key_field: aggregate_id`, `acls:` blocks present
- [ ] Review `envelope.schema.json`: 10 required fields, `principal_type` enum restricted to `["user","agent","service"]`, `additionalProperties: false`
- [ ] Review `consumer_groups.go`: SPIFFE ID comments match `topics.yaml` ACL entries