### PR TITLE
[Data] MetadataStore + Tx interfaces in plane/data/store (ADR-006, ADR-017)

### DIFF
--- a/plane/data/outbox/wiring/wiring.go
+++ b/plane/data/outbox/wiring/wiring.go
@@ -9,12 +9,13 @@ import (
 
 	kafkadata "github.com/gitscale-platform/gitscale/plane/data/kafka"
 	"github.com/gitscale-platform/gitscale/plane/data/outbox"
+	"github.com/gitscale-platform/gitscale/plane/data/store"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
 // DomainConfig maps one domain's table and topic names to a consumer config.
 type DomainConfig struct {
-	Domain string
+	Domain store.Domain
 	Table  string
 	Topic  string
 }
@@ -23,28 +24,28 @@ type DomainConfig struct {
 // their corresponding outbox tables and Kafka topics.
 var AllDomains = []DomainConfig{
 	{
-		Domain: "identity",
-		Table:  "identity.identity_outbox",
+		Domain: store.DomainIdentity,
+		Table:  store.DomainIdentity.OutboxTable(),
 		Topic:  kafkadata.TopicIdentityEvents,
 	},
 	{
-		Domain: "repositories",
-		Table:  "repositories.repositories_outbox",
+		Domain: store.DomainRepositories,
+		Table:  store.DomainRepositories.OutboxTable(),
 		Topic:  kafkadata.TopicRepositoriesEvents,
 	},
 	{
-		Domain: "collaboration",
-		Table:  "collaboration.collaboration_outbox",
+		Domain: store.DomainCollaboration,
+		Table:  store.DomainCollaboration.OutboxTable(),
 		Topic:  kafkadata.TopicCollaborationEvents,
 	},
 	{
-		Domain: "ci",
-		Table:  "ci.ci_outbox",
+		Domain: store.DomainCI,
+		Table:  store.DomainCI.OutboxTable(),
 		Topic:  kafkadata.TopicCIEvents,
 	},
 	{
-		Domain: "billing",
-		Table:  "billing.billing_outbox",
+		Domain: store.DomainBilling,
+		Table:  store.DomainBilling.OutboxTable(),
 		Topic:  kafkadata.TopicBillingEvents,
 	},
 }
@@ -70,7 +71,7 @@ func StartAll(
 
 	for _, d := range domains {
 		cfg := outbox.Config{
-			Domain:   d.Domain,
+			Domain:   string(d.Domain),
 			Table:    d.Table,
 			Topic:    d.Topic,
 			DB:       db,

--- a/plane/data/store/domain.go
+++ b/plane/data/store/domain.go
@@ -1,0 +1,32 @@
+package store
+
+import "fmt"
+
+// Domain identifies one of the five GitScale schema domains.
+type Domain string
+
+const (
+	DomainIdentity      Domain = "identity"
+	DomainRepositories  Domain = "repositories"
+	DomainCollaboration Domain = "collaboration"
+	DomainCI            Domain = "ci"
+	DomainBilling       Domain = "billing"
+)
+
+// Valid reports whether d is a known domain constant.
+func (d Domain) Valid() bool {
+	switch d {
+	case DomainIdentity, DomainRepositories, DomainCollaboration, DomainCI, DomainBilling:
+		return true
+	}
+	return false
+}
+
+// OutboxTable returns the schema-qualified outbox table name for d.
+// Panics if d is not a valid domain.
+func (d Domain) OutboxTable() string {
+	if !d.Valid() {
+		panic(fmt.Sprintf("store: invalid domain %q", d))
+	}
+	return string(d) + "." + string(d) + "_outbox"
+}

--- a/plane/data/store/eventid.go
+++ b/plane/data/store/eventid.go
@@ -1,0 +1,16 @@
+package store
+
+import "github.com/google/uuid"
+
+// NewEventID returns a new monotonic UUIDv7 suitable for use as an outbox
+// event_id. UUIDv7 embeds a millisecond timestamp in the high bits, giving
+// monotonic ordering within a process and low collision risk under concurrent
+// inserts (unlike UUIDv4 which has no ordering guarantee).
+func NewEventID() uuid.UUID {
+	id, err := uuid.NewV7()
+	if err != nil {
+		// NewV7 only fails if the clock source fails; fall back to v4.
+		return uuid.New()
+	}
+	return id
+}

--- a/plane/data/store/metadata.go
+++ b/plane/data/store/metadata.go
@@ -1,0 +1,149 @@
+// Package store defines the MetadataStore and Tx interfaces that abstract all
+// SQL operations across the five GitScale schema domains. Concrete
+// implementations (postgres, stub) satisfy these interfaces; application code
+// receives injected instances and never imports a driver directly (ADR-017).
+package store
+
+import (
+	"context"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// MetadataStore is the top-level entry point for all SQL operations.
+// Implementations must be safe for concurrent use.
+type MetadataStore interface {
+	// Transact runs fn inside a serializable transaction. If fn returns a
+	// non-nil error the transaction is rolled back; otherwise it is committed.
+	// A serialization-failure (SQLSTATE 40001) is surfaced to the caller so
+	// retry logic can be applied; use IsRetryable to detect it.
+	Transact(ctx context.Context, fn func(Tx) error) error
+
+	// Identity returns a reader for the identity domain. The returned reader
+	// is usable outside a transaction for read-only queries.
+	Identity() IdentityReader
+
+	// Repositories returns a reader for the repositories domain.
+	Repositories() RepositoryReader
+}
+
+// Tx is a handle for the active transaction passed to Transact callbacks.
+// It exposes both read and write operations bounded to the transaction scope.
+type Tx interface {
+	// Identity returns the identity writer for this transaction.
+	Identity() IdentityWriter
+
+	// Repositories returns the repository writer for this transaction.
+	Repositories() RepositoryWriter
+
+	// WriteOutbox appends a row to the domain's outbox table within this
+	// transaction. The row is removed if the transaction rolls back.
+	// payload is JSON-marshalled; it must be a serialisable value.
+	WriteOutbox(
+		ctx context.Context,
+		domain Domain,
+		aggregateType string,
+		aggregateID uuid.UUID,
+		eventType string,
+		payload any,
+	) error
+}
+
+// HumanUser is the identity.human_users row model.
+type HumanUser struct {
+	ID             uuid.UUID
+	Email          string
+	CredentialHash string
+	RateBucket     string
+	QuotaAccountID *uuid.UUID
+	CreatedAt      time.Time
+	UpdatedAt      time.Time
+}
+
+// AgentIdentity is the identity.agent_identities row model.
+type AgentIdentity struct {
+	ID               uuid.UUID
+	DisplayName      string
+	ParentUserID     uuid.UUID
+	PermissionScope  []string
+	RateBucket       string
+	SessionQuota     *int64
+	TokensPerWeekCap *int64
+	ReputationScore  float64
+	QuotaAccountID   *uuid.UUID
+	CreatedAt        time.Time
+	UpdatedAt        time.Time
+}
+
+// OrgMembership is the identity.org_memberships row model.
+type OrgMembership struct {
+	OrgID  uuid.UUID
+	UserID uuid.UUID
+	Role   string
+}
+
+// IdentityCacheEntry is the minimal projection loaded by the edge-plane
+// identity cache for principal resolution.
+type IdentityCacheEntry struct {
+	PrincipalID uuid.UUID
+	Kind        string // "human" or "agent"
+	RateBucket  string
+	QuotaID     *uuid.UUID
+}
+
+// IdentityReader exposes read-only queries against the identity domain.
+// Methods defined here may be called both inside and outside a transaction.
+type IdentityReader interface {
+	GetUserByID(ctx context.Context, id uuid.UUID) (*HumanUser, error)
+	GetUserByEmail(ctx context.Context, email string) (*HumanUser, error)
+	GetAgentByID(ctx context.Context, id uuid.UUID) (*AgentIdentity, error)
+	GetAgentsByParentUser(ctx context.Context, userID uuid.UUID) ([]AgentIdentity, error)
+	// LookupIdentityForCache returns the minimal projection used by the edge
+	// identity cache. principalID may be a HumanUser or AgentIdentity UUID.
+	LookupIdentityForCache(ctx context.Context, principalID uuid.UUID) (*IdentityCacheEntry, error)
+}
+
+// IdentityWriter exposes write operations against the identity domain.
+// All methods must be called within a Tx; they panic if used outside one.
+type IdentityWriter interface {
+	IdentityReader
+	InsertHumanUser(ctx context.Context, u HumanUser) error
+	InsertAgentIdentity(ctx context.Context, a AgentIdentity) error
+	// SetAgentReputationScore sets the score to the given value [0.0, 1.0].
+	// Clamping is enforced by the database CHECK constraint; the caller is
+	// responsible for computing the new score outside the transaction.
+	SetAgentReputationScore(ctx context.Context, agentID uuid.UUID, score float64) error
+	// DisableUser soft-disables a human user. Not implemented until #15-revocation.
+	DisableUser(ctx context.Context, userID uuid.UUID) error
+	// RevokeAgent soft-revokes an agent identity. Not implemented until #15-revocation.
+	RevokeAgent(ctx context.Context, agentID uuid.UUID) error
+	// UpdateAgentPermissions replaces the permission_scope array. Not implemented until #15-revocation.
+	UpdateAgentPermissions(ctx context.Context, agentID uuid.UUID, scope []string) error
+	AddOrgMember(ctx context.Context, m OrgMembership) error
+	RemoveOrgMember(ctx context.Context, orgID, userID uuid.UUID) error
+}
+
+// Repository is the repositories.repositories row model (minimal projection).
+type Repository struct {
+	ID            uuid.UUID
+	Slug          string
+	OrgID         uuid.UUID
+	ReplicaSetID  string
+	HomeRegion    string
+	CreatedAt     time.Time
+}
+
+// RepositoryReader exposes read-only queries against the repositories domain.
+type RepositoryReader interface {
+	GetByID(ctx context.Context, id uuid.UUID) (*Repository, error)
+	GetBySlug(ctx context.Context, slug string) (*Repository, error)
+}
+
+// RepositoryWriter exposes write operations against the repositories domain.
+// Not implemented in #14; bodies return errNotImplemented.
+type RepositoryWriter interface {
+	RepositoryReader
+	Insert(ctx context.Context, r Repository) error
+	UpdatePermissions(ctx context.Context, repoID uuid.UUID, permissionHash string) error
+}

--- a/plane/data/store/postgres/compliance_test.go
+++ b/plane/data/store/postgres/compliance_test.go
@@ -1,0 +1,4 @@
+package postgres_test
+
+// Compliance tests for the postgres MetadataStore implementation live in
+// plane/data/compliance/; see issue #35.

--- a/plane/data/store/postgres/identity_reader.go
+++ b/plane/data/store/postgres/identity_reader.go
@@ -1,0 +1,128 @@
+package postgres
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/gitscale-platform/gitscale/plane/data/store"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+)
+
+type identityReader struct {
+	q querier
+}
+
+func (r *identityReader) GetUserByID(ctx context.Context, id uuid.UUID) (*store.HumanUser, error) {
+	const q = `
+		SELECT id, email, credential_hash, rate_bucket, quota_account_id, created_at, updated_at
+		FROM identity.human_users WHERE id = $1`
+	u := &store.HumanUser{}
+	err := r.q.QueryRow(ctx, q, id).Scan(
+		&u.ID, &u.Email, &u.CredentialHash, &u.RateBucket,
+		&u.QuotaAccountID, &u.CreatedAt, &u.UpdatedAt,
+	)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("postgres: GetUserByID: %w", err)
+	}
+	return u, nil
+}
+
+func (r *identityReader) GetUserByEmail(ctx context.Context, email string) (*store.HumanUser, error) {
+	const q = `
+		SELECT id, email, credential_hash, rate_bucket, quota_account_id, created_at, updated_at
+		FROM identity.human_users WHERE email = $1`
+	u := &store.HumanUser{}
+	err := r.q.QueryRow(ctx, q, email).Scan(
+		&u.ID, &u.Email, &u.CredentialHash, &u.RateBucket,
+		&u.QuotaAccountID, &u.CreatedAt, &u.UpdatedAt,
+	)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("postgres: GetUserByEmail: %w", err)
+	}
+	return u, nil
+}
+
+func (r *identityReader) GetAgentByID(ctx context.Context, id uuid.UUID) (*store.AgentIdentity, error) {
+	const q = `
+		SELECT id, display_name, parent_user_id, permission_scope, rate_bucket,
+		       session_quota, tokens_per_week_cap, reputation_score, quota_account_id,
+		       created_at, updated_at
+		FROM identity.agent_identities WHERE id = $1`
+	a := &store.AgentIdentity{}
+	err := r.q.QueryRow(ctx, q, id).Scan(
+		&a.ID, &a.DisplayName, &a.ParentUserID, &a.PermissionScope, &a.RateBucket,
+		&a.SessionQuota, &a.TokensPerWeekCap, &a.ReputationScore, &a.QuotaAccountID,
+		&a.CreatedAt, &a.UpdatedAt,
+	)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("postgres: GetAgentByID: %w", err)
+	}
+	return a, nil
+}
+
+func (r *identityReader) GetAgentsByParentUser(ctx context.Context, userID uuid.UUID) ([]store.AgentIdentity, error) {
+	const q = `
+		SELECT id, display_name, parent_user_id, permission_scope, rate_bucket,
+		       session_quota, tokens_per_week_cap, reputation_score, quota_account_id,
+		       created_at, updated_at
+		FROM identity.agent_identities WHERE parent_user_id = $1
+		ORDER BY created_at`
+	rows, err := r.q.Query(ctx, q, userID)
+	if err != nil {
+		return nil, fmt.Errorf("postgres: GetAgentsByParentUser: %w", err)
+	}
+	defer rows.Close()
+
+	var agents []store.AgentIdentity
+	for rows.Next() {
+		var a store.AgentIdentity
+		if err := rows.Scan(
+			&a.ID, &a.DisplayName, &a.ParentUserID, &a.PermissionScope, &a.RateBucket,
+			&a.SessionQuota, &a.TokensPerWeekCap, &a.ReputationScore, &a.QuotaAccountID,
+			&a.CreatedAt, &a.UpdatedAt,
+		); err != nil {
+			return nil, fmt.Errorf("postgres: GetAgentsByParentUser scan: %w", err)
+		}
+		agents = append(agents, a)
+	}
+	return agents, rows.Err()
+}
+
+// LookupIdentityForCache returns the minimal projection used by the edge-plane
+// identity cache. It tries human_users first, then agent_identities.
+func (r *identityReader) LookupIdentityForCache(ctx context.Context, principalID uuid.UUID) (*store.IdentityCacheEntry, error) {
+	const humanQ = `
+		SELECT id, rate_bucket, quota_account_id FROM identity.human_users WHERE id = $1`
+	entry := &store.IdentityCacheEntry{}
+	err := r.q.QueryRow(ctx, humanQ, principalID).Scan(&entry.PrincipalID, &entry.RateBucket, &entry.QuotaID)
+	if err == nil {
+		entry.Kind = "human"
+		return entry, nil
+	}
+	if !errors.Is(err, pgx.ErrNoRows) {
+		return nil, fmt.Errorf("postgres: LookupIdentityForCache (human): %w", err)
+	}
+
+	const agentQ = `
+		SELECT id, rate_bucket, quota_account_id FROM identity.agent_identities WHERE id = $1`
+	err = r.q.QueryRow(ctx, agentQ, principalID).Scan(&entry.PrincipalID, &entry.RateBucket, &entry.QuotaID)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("postgres: LookupIdentityForCache (agent): %w", err)
+	}
+	entry.Kind = "agent"
+	return entry, nil
+}

--- a/plane/data/store/postgres/identity_writer.go
+++ b/plane/data/store/postgres/identity_writer.go
@@ -1,0 +1,89 @@
+package postgres
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/gitscale-platform/gitscale/plane/data/store"
+	"github.com/google/uuid"
+)
+
+// identityWriter embeds identityReader (providing read methods) and adds
+// write operations. It must only be used within a transaction.
+type identityWriter struct {
+	identityReader
+}
+
+func (w *identityWriter) InsertHumanUser(ctx context.Context, u store.HumanUser) error {
+	const q = `
+		INSERT INTO identity.human_users
+		  (id, email, credential_hash, rate_bucket, quota_account_id)
+		VALUES ($1, $2, $3, $4, $5)`
+	_, err := w.q.Exec(ctx, q,
+		u.ID, u.Email, u.CredentialHash, u.RateBucket, u.QuotaAccountID,
+	)
+	if err != nil {
+		return fmt.Errorf("postgres: InsertHumanUser: %w", err)
+	}
+	return nil
+}
+
+func (w *identityWriter) InsertAgentIdentity(ctx context.Context, a store.AgentIdentity) error {
+	const q = `
+		INSERT INTO identity.agent_identities
+		  (id, display_name, parent_user_id, permission_scope, rate_bucket,
+		   session_quota, tokens_per_week_cap, reputation_score, quota_account_id)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)`
+	_, err := w.q.Exec(ctx, q,
+		a.ID, a.DisplayName, a.ParentUserID, a.PermissionScope, a.RateBucket,
+		a.SessionQuota, a.TokensPerWeekCap, a.ReputationScore, a.QuotaAccountID,
+	)
+	if err != nil {
+		return fmt.Errorf("postgres: InsertAgentIdentity: %w", err)
+	}
+	return nil
+}
+
+func (w *identityWriter) SetAgentReputationScore(ctx context.Context, agentID uuid.UUID, score float64) error {
+	const q = `
+		UPDATE identity.agent_identities SET reputation_score = $2, updated_at = now()
+		WHERE id = $1`
+	_, err := w.q.Exec(ctx, q, agentID, score)
+	if err != nil {
+		return fmt.Errorf("postgres: SetAgentReputationScore: %w", err)
+	}
+	return nil
+}
+
+func (w *identityWriter) DisableUser(_ context.Context, _ uuid.UUID) error {
+	return errNotImplemented
+}
+
+func (w *identityWriter) RevokeAgent(_ context.Context, _ uuid.UUID) error {
+	return errNotImplemented
+}
+
+func (w *identityWriter) UpdateAgentPermissions(_ context.Context, _ uuid.UUID, _ []string) error {
+	return errNotImplemented
+}
+
+func (w *identityWriter) AddOrgMember(ctx context.Context, m store.OrgMembership) error {
+	const q = `
+		INSERT INTO identity.org_memberships (org_id, user_id, role)
+		VALUES ($1, $2, $3)
+		ON CONFLICT (org_id, user_id) DO UPDATE SET role = EXCLUDED.role`
+	_, err := w.q.Exec(ctx, q, m.OrgID, m.UserID, m.Role)
+	if err != nil {
+		return fmt.Errorf("postgres: AddOrgMember: %w", err)
+	}
+	return nil
+}
+
+func (w *identityWriter) RemoveOrgMember(ctx context.Context, orgID, userID uuid.UUID) error {
+	const q = `DELETE FROM identity.org_memberships WHERE org_id = $1 AND user_id = $2`
+	_, err := w.q.Exec(ctx, q, orgID, userID)
+	if err != nil {
+		return fmt.Errorf("postgres: RemoveOrgMember: %w", err)
+	}
+	return nil
+}

--- a/plane/data/store/postgres/metadata.go
+++ b/plane/data/store/postgres/metadata.go
@@ -1,0 +1,117 @@
+// Package postgres implements MetadataStore against a PostgreSQL database via
+// pgx. Transactions are opened at ISOLATION LEVEL SERIALIZABLE; serialization
+// failures (SQLSTATE 40001) are surfaced to the caller for retry.
+package postgres
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/gitscale-platform/gitscale/plane/data/store"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+var errNotImplemented = errors.New("not implemented")
+
+// querier is the minimal pgx query interface satisfied by both pgxpool.Pool
+// and pgx.Tx, allowing IdentityReader to work inside and outside transactions.
+type querier interface {
+	QueryRow(ctx context.Context, sql string, args ...any) pgx.Row
+	Query(ctx context.Context, sql string, args ...any) (pgx.Rows, error)
+	Exec(ctx context.Context, sql string, args ...any) (pgconn.CommandTag, error)
+}
+
+// Store implements store.MetadataStore over a pgxpool.Pool.
+type Store struct {
+	db *pgxpool.Pool
+}
+
+// New returns a Store backed by db.
+func New(db *pgxpool.Pool) *Store {
+	return &Store{db: db}
+}
+
+// Transact opens a serializable transaction and runs fn. If fn returns nil
+// the transaction is committed; otherwise it is rolled back and the error is
+// returned. Serialization failures (40001) are returned verbatim so callers
+// can detect them via store.IsRetryable.
+func (s *Store) Transact(ctx context.Context, fn func(store.Tx) error) error {
+	txOpts := pgx.TxOptions{IsoLevel: pgx.Serializable}
+	tx, err := s.db.BeginTx(ctx, txOpts)
+	if err != nil {
+		return fmt.Errorf("postgres: begin tx: %w", err)
+	}
+	defer func() {
+		// Best-effort rollback; ignored because fn's error is already returned.
+		_ = tx.Rollback(ctx)
+	}()
+
+	wrapper := &txWrapper{tx: tx}
+	if err := fn(wrapper); err != nil {
+		return err
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return fmt.Errorf("postgres: commit: %w", err)
+	}
+	return nil
+}
+
+// Identity returns the identity reader bound to the pool (for reads outside
+// a transaction).
+func (s *Store) Identity() store.IdentityReader {
+	return &identityReader{q: s.db}
+}
+
+// Repositories returns the repository reader bound to the pool.
+func (s *Store) Repositories() store.RepositoryReader {
+	return &repositoryReader{q: s.db}
+}
+
+// txWrapper adapts a pgx.Tx to the store.Tx interface.
+type txWrapper struct {
+	tx pgx.Tx
+}
+
+func (w *txWrapper) Identity() store.IdentityWriter {
+	return &identityWriter{identityReader: identityReader{q: w.tx}}
+}
+
+func (w *txWrapper) Repositories() store.RepositoryWriter {
+	return &repositoryWriter{repositoryReader: repositoryReader{q: w.tx}}
+}
+
+// WriteOutbox inserts a row into the domain-specific outbox table within the
+// active transaction. domain must be a valid store.Domain constant.
+func (w *txWrapper) WriteOutbox(
+	ctx context.Context,
+	domain store.Domain,
+	aggregateType string,
+	aggregateID uuid.UUID,
+	eventType string,
+	payload any,
+) error {
+	if !domain.Valid() {
+		return fmt.Errorf("postgres: WriteOutbox: invalid domain %q", domain)
+	}
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("postgres: WriteOutbox: marshal payload: %w", err)
+	}
+	table := domain.OutboxTable()
+	q := fmt.Sprintf(
+		`INSERT INTO %s (event_id, aggregate_type, aggregate_id, event_type, payload)
+		 VALUES ($1, $2, $3, $4, $5)`,
+		table,
+	)
+	eventID := store.NewEventID()
+	_, err = w.tx.Exec(ctx, q, eventID, aggregateType, aggregateID, eventType, raw)
+	if err != nil {
+		return fmt.Errorf("postgres: WriteOutbox %s: %w", table, err)
+	}
+	return nil
+}

--- a/plane/data/store/postgres/postgres_test.go
+++ b/plane/data/store/postgres/postgres_test.go
@@ -1,0 +1,176 @@
+//go:build integration
+
+package postgres_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gitscale-platform/gitscale/plane/data/store"
+	pgstore "github.com/gitscale-platform/gitscale/plane/data/store/postgres"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/testcontainers/testcontainers-go"
+	pgmodule "github.com/testcontainers/testcontainers-go/modules/postgres"
+)
+
+func setupPostgres(t *testing.T) *pgxpool.Pool {
+	t.Helper()
+	ctx := context.Background()
+
+	ctr, err := pgmodule.Run(ctx,
+		"postgres:16-alpine",
+		pgmodule.WithDatabase("gitscale_test"),
+		pgmodule.WithUsername("gs"),
+		pgmodule.WithPassword("gs"),
+		testcontainers.WithWaitStrategy(pgmodule.WithWaitForReadiness()),
+	)
+	if err != nil {
+		t.Fatalf("start postgres container: %v", err)
+	}
+	t.Cleanup(func() { _ = ctr.Terminate(ctx) })
+
+	connStr, err := ctr.ConnectionString(ctx, "sslmode=disable")
+	if err != nil {
+		t.Fatalf("connection string: %v", err)
+	}
+
+	pool, err := pgxpool.New(ctx, connStr)
+	if err != nil {
+		t.Fatalf("pgxpool.New: %v", err)
+	}
+	t.Cleanup(pool.Close)
+
+	runMigrations(t, ctx, pool)
+	return pool
+}
+
+func runMigrations(t *testing.T, ctx context.Context, pool *pgxpool.Pool) {
+	t.Helper()
+	migrationsDir := filepath.Join("..", "..", "migrations")
+	files := []string{
+		"000_init.sql",
+		"001_identity.sql",
+		"002_repositories.sql",
+		"003_collaboration.sql",
+		"004_ci.sql",
+		"005_billing.sql",
+	}
+	for _, f := range files {
+		sql, err := os.ReadFile(filepath.Join(migrationsDir, f))
+		if err != nil {
+			t.Fatalf("read migration %s: %v", f, err)
+		}
+		if _, err := pool.Exec(ctx, string(sql)); err != nil {
+			t.Fatalf("run migration %s: %v", f, err)
+		}
+	}
+}
+
+func TestPostgres_WriteOutbox_TransactionalWithRollback(t *testing.T) {
+	pool := setupPostgres(t)
+	s := pgstore.New(pool)
+	ctx := context.Background()
+
+	aggID := uuid.New()
+
+	// Committed Tx: outbox row must exist.
+	if err := s.Transact(ctx, func(tx store.Tx) error {
+		return tx.WriteOutbox(ctx, store.DomainIdentity, "human_user", aggID, "user.created", map[string]string{"x": "1"})
+	}); err != nil {
+		t.Fatalf("committed Transact: %v", err)
+	}
+
+	var count int
+	if err := pool.QueryRow(ctx, `SELECT COUNT(*) FROM identity.identity_outbox WHERE aggregate_id = $1`, aggID).Scan(&count); err != nil {
+		t.Fatalf("query outbox: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("expected 1 outbox row after commit, got %d", count)
+	}
+
+	// Rolled-back Tx: outbox row must not appear.
+	aggID2 := uuid.New()
+	_ = s.Transact(ctx, func(tx store.Tx) error {
+		_ = tx.WriteOutbox(ctx, store.DomainIdentity, "human_user", aggID2, "user.created", nil)
+		return context.DeadlineExceeded // simulate failure
+	})
+
+	if err := pool.QueryRow(ctx, `SELECT COUNT(*) FROM identity.identity_outbox WHERE aggregate_id = $1`, aggID2).Scan(&count); err != nil {
+		t.Fatalf("query outbox after rollback: %v", err)
+	}
+	if count != 0 {
+		t.Fatalf("expected 0 outbox rows after rollback, got %d", count)
+	}
+}
+
+func TestPostgres_SerializationFailure_IsRetryable(t *testing.T) {
+	pool := setupPostgres(t)
+	s := pgstore.New(pool)
+	ctx := context.Background()
+
+	userID := uuid.New()
+	// Insert a user so both transactions can read it.
+	if err := s.Transact(ctx, func(tx store.Tx) error {
+		return tx.Identity().InsertHumanUser(ctx, store.HumanUser{
+			ID:         userID,
+			Email:      "serial@example.com",
+			RateBucket: "human_default",
+		})
+	}); err != nil {
+		t.Fatalf("insert user: %v", err)
+	}
+
+	var (
+		wg    sync.WaitGroup
+		mu    sync.Mutex
+		errT2 error
+	)
+	ready := make(chan struct{})
+
+	// Tx1: read the user, block, then update reputation.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		_ = s.Transact(ctx, func(tx store.Tx) error {
+			if _, err := tx.Identity().GetUserByID(ctx, userID); err != nil {
+				return err
+			}
+			close(ready)
+			time.Sleep(50 * time.Millisecond) // let Tx2 also read
+			return tx.Identity().SetAgentReputationScore(ctx, userID, 0.9)
+		})
+	}()
+
+	// Tx2: also read the user, then try to update reputation.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		<-ready
+		err := s.Transact(ctx, func(tx store.Tx) error {
+			if _, err := tx.Identity().GetUserByID(ctx, userID); err != nil {
+				return err
+			}
+			return tx.Identity().SetAgentReputationScore(ctx, userID, 0.8)
+		})
+		mu.Lock()
+		errT2 = err
+		mu.Unlock()
+	}()
+
+	wg.Wait()
+	mu.Lock()
+	err := errT2
+	mu.Unlock()
+
+	// Under serializable isolation, one of the two transactions should have
+	// received a 40001. We cannot guarantee which one fails in all PG versions,
+	// but if errT2 is non-nil it must be retryable.
+	if err != nil && !store.IsRetryable(err) {
+		t.Errorf("expected retryable error from concurrent serializable Tx, got: %v", err)
+	}
+}

--- a/plane/data/store/postgres/repository.go
+++ b/plane/data/store/postgres/repository.go
@@ -1,0 +1,32 @@
+package postgres
+
+import (
+	"context"
+
+	"github.com/gitscale-platform/gitscale/plane/data/store"
+	"github.com/google/uuid"
+)
+
+type repositoryReader struct {
+	q querier
+}
+
+func (r *repositoryReader) GetByID(_ context.Context, _ uuid.UUID) (*store.Repository, error) {
+	return nil, errNotImplemented
+}
+
+func (r *repositoryReader) GetBySlug(_ context.Context, _ string) (*store.Repository, error) {
+	return nil, errNotImplemented
+}
+
+type repositoryWriter struct {
+	repositoryReader
+}
+
+func (w *repositoryWriter) Insert(_ context.Context, _ store.Repository) error {
+	return errNotImplemented
+}
+
+func (w *repositoryWriter) UpdatePermissions(_ context.Context, _ uuid.UUID, _ string) error {
+	return errNotImplemented
+}

--- a/plane/data/store/retryable.go
+++ b/plane/data/store/retryable.go
@@ -1,0 +1,18 @@
+package store
+
+import (
+	"errors"
+
+	"github.com/jackc/pgx/v5/pgconn"
+)
+
+// IsRetryable reports whether err is a PostgreSQL serialization failure
+// (SQLSTATE 40001). Callers that use serializable transactions should retry
+// on true and surface the error otherwise.
+func IsRetryable(err error) bool {
+	var pgErr *pgconn.PgError
+	if errors.As(err, &pgErr) {
+		return pgErr.Code == "40001"
+	}
+	return false
+}

--- a/plane/data/store/retryable_test.go
+++ b/plane/data/store/retryable_test.go
@@ -1,0 +1,44 @@
+package store
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgconn"
+)
+
+func TestIsRetryable(t *testing.T) {
+	t.Run("returns true for 40001", func(t *testing.T) {
+		err := &pgconn.PgError{Code: "40001"}
+		if !IsRetryable(err) {
+			t.Fatal("expected IsRetryable to return true for SQLSTATE 40001")
+		}
+	})
+
+	t.Run("returns true for wrapped 40001", func(t *testing.T) {
+		err := fmt.Errorf("tx failed: %w", &pgconn.PgError{Code: "40001"})
+		if !IsRetryable(err) {
+			t.Fatal("expected IsRetryable to return true for wrapped 40001")
+		}
+	})
+
+	t.Run("returns false for other SQL errors", func(t *testing.T) {
+		err := &pgconn.PgError{Code: "23505"} // unique_violation
+		if IsRetryable(err) {
+			t.Fatal("expected IsRetryable to return false for 23505")
+		}
+	})
+
+	t.Run("returns false for non-pgx errors", func(t *testing.T) {
+		if IsRetryable(errors.New("some other error")) {
+			t.Fatal("expected IsRetryable to return false for non-pgx error")
+		}
+	})
+
+	t.Run("returns false for nil", func(t *testing.T) {
+		if IsRetryable(nil) {
+			t.Fatal("expected IsRetryable to return false for nil")
+		}
+	})
+}

--- a/plane/data/store/stub/compliance_test.go
+++ b/plane/data/store/stub/compliance_test.go
@@ -1,0 +1,4 @@
+package stub_test
+
+// Compliance tests for the stub MetadataStore implementation live in
+// plane/data/compliance/; see issue #35.

--- a/plane/data/store/stub/metadata.go
+++ b/plane/data/store/stub/metadata.go
@@ -1,0 +1,316 @@
+// Package stub provides an in-memory MetadataStore implementation for use in
+// unit tests. It records all writes and makes them available via Recorded().
+// Rollback semantics are simulated: ops recorded during a failed transaction
+// are discarded.
+package stub
+
+import (
+	"context"
+	"errors"
+	"sync"
+
+	"github.com/gitscale-platform/gitscale/plane/data/store"
+	"github.com/google/uuid"
+)
+
+var errNotImplemented = errors.New("stub: not implemented")
+
+// OutboxRecord captures one WriteOutbox call for test assertions.
+type OutboxRecord struct {
+	Domain        store.Domain
+	AggregateType string
+	AggregateID   uuid.UUID
+	EventType     string
+	Payload       any
+	EventID       uuid.UUID
+}
+
+// Store is the in-memory implementation of store.MetadataStore.
+type Store struct {
+	mu      sync.Mutex
+	users   map[uuid.UUID]*store.HumanUser
+	agents  map[uuid.UUID]*store.AgentIdentity
+	outbox  []OutboxRecord
+}
+
+// New returns an empty Store.
+func New() *Store {
+	return &Store{
+		users:  make(map[uuid.UUID]*store.HumanUser),
+		agents: make(map[uuid.UUID]*store.AgentIdentity),
+	}
+}
+
+// Recorded returns all committed OutboxRecords in insertion order.
+func (s *Store) Recorded() []OutboxRecord {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]OutboxRecord, len(s.outbox))
+	copy(out, s.outbox)
+	return out
+}
+
+// Transact runs fn with a transaction handle. On nil return the writes are
+// committed; on error they are discarded.
+func (s *Store) Transact(_ context.Context, fn func(store.Tx) error) error {
+	tx := &stubTx{store: s}
+	if err := fn(tx); err != nil {
+		return err
+	}
+	// Commit: apply pending writes.
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for id, u := range tx.pendingUsers {
+		s.users[id] = u
+	}
+	for id, a := range tx.pendingAgents {
+		s.agents[id] = a
+	}
+	s.outbox = append(s.outbox, tx.pendingOutbox...)
+	return nil
+}
+
+// Identity returns a reader backed by the in-memory store.
+func (s *Store) Identity() store.IdentityReader {
+	return &stubIdentityReader{store: s}
+}
+
+// Repositories returns a stub repository reader.
+func (s *Store) Repositories() store.RepositoryReader {
+	return &stubRepositoryReader{}
+}
+
+// stubTx is the transaction handle passed to Transact callbacks.
+type stubTx struct {
+	store         *Store
+	pendingUsers  map[uuid.UUID]*store.HumanUser
+	pendingAgents map[uuid.UUID]*store.AgentIdentity
+	pendingOutbox []OutboxRecord
+}
+
+func (t *stubTx) lazyInit() {
+	if t.pendingUsers == nil {
+		t.pendingUsers = make(map[uuid.UUID]*store.HumanUser)
+	}
+	if t.pendingAgents == nil {
+		t.pendingAgents = make(map[uuid.UUID]*store.AgentIdentity)
+	}
+}
+
+func (t *stubTx) Identity() store.IdentityWriter {
+	return &stubIdentityWriter{tx: t, reader: &stubIdentityReader{store: t.store}}
+}
+
+func (t *stubTx) Repositories() store.RepositoryWriter {
+	return &stubRepositoryWriter{}
+}
+
+func (t *stubTx) WriteOutbox(
+	_ context.Context,
+	domain store.Domain,
+	aggregateType string,
+	aggregateID uuid.UUID,
+	eventType string,
+	payload any,
+) error {
+	if !domain.Valid() {
+		return errors.New("stub: WriteOutbox: invalid domain")
+	}
+	t.pendingOutbox = append(t.pendingOutbox, OutboxRecord{
+		Domain:        domain,
+		AggregateType: aggregateType,
+		AggregateID:   aggregateID,
+		EventType:     eventType,
+		Payload:       payload,
+		EventID:       store.NewEventID(),
+	})
+	return nil
+}
+
+// stubIdentityReader reads from the committed store state.
+type stubIdentityReader struct {
+	store *Store
+}
+
+func (r *stubIdentityReader) GetUserByID(_ context.Context, id uuid.UUID) (*store.HumanUser, error) {
+	r.store.mu.Lock()
+	defer r.store.mu.Unlock()
+	u := r.store.users[id]
+	if u == nil {
+		return nil, nil
+	}
+	cp := *u
+	return &cp, nil
+}
+
+func (r *stubIdentityReader) GetUserByEmail(_ context.Context, email string) (*store.HumanUser, error) {
+	r.store.mu.Lock()
+	defer r.store.mu.Unlock()
+	for _, u := range r.store.users {
+		if u.Email == email {
+			cp := *u
+			return &cp, nil
+		}
+	}
+	return nil, nil
+}
+
+func (r *stubIdentityReader) GetAgentByID(_ context.Context, id uuid.UUID) (*store.AgentIdentity, error) {
+	r.store.mu.Lock()
+	defer r.store.mu.Unlock()
+	a := r.store.agents[id]
+	if a == nil {
+		return nil, nil
+	}
+	cp := *a
+	return &cp, nil
+}
+
+func (r *stubIdentityReader) GetAgentsByParentUser(_ context.Context, userID uuid.UUID) ([]store.AgentIdentity, error) {
+	r.store.mu.Lock()
+	defer r.store.mu.Unlock()
+	var agents []store.AgentIdentity
+	for _, a := range r.store.agents {
+		if a.ParentUserID == userID {
+			agents = append(agents, *a)
+		}
+	}
+	return agents, nil
+}
+
+func (r *stubIdentityReader) LookupIdentityForCache(_ context.Context, principalID uuid.UUID) (*store.IdentityCacheEntry, error) {
+	r.store.mu.Lock()
+	defer r.store.mu.Unlock()
+	if u, ok := r.store.users[principalID]; ok {
+		return &store.IdentityCacheEntry{
+			PrincipalID: u.ID,
+			Kind:        "human",
+			RateBucket:  u.RateBucket,
+			QuotaID:     u.QuotaAccountID,
+		}, nil
+	}
+	if a, ok := r.store.agents[principalID]; ok {
+		return &store.IdentityCacheEntry{
+			PrincipalID: a.ID,
+			Kind:        "agent",
+			RateBucket:  a.RateBucket,
+			QuotaID:     a.QuotaAccountID,
+		}, nil
+	}
+	return nil, nil
+}
+
+// stubIdentityWriter combines committed reads with pending writes.
+type stubIdentityWriter struct {
+	tx     *stubTx
+	reader *stubIdentityReader
+}
+
+func (w *stubIdentityWriter) GetUserByID(ctx context.Context, id uuid.UUID) (*store.HumanUser, error) {
+	w.tx.lazyInit()
+	if u, ok := w.tx.pendingUsers[id]; ok {
+		cp := *u
+		return &cp, nil
+	}
+	return w.reader.GetUserByID(ctx, id)
+}
+
+func (w *stubIdentityWriter) GetUserByEmail(ctx context.Context, email string) (*store.HumanUser, error) {
+	w.tx.lazyInit()
+	for _, u := range w.tx.pendingUsers {
+		if u.Email == email {
+			cp := *u
+			return &cp, nil
+		}
+	}
+	return w.reader.GetUserByEmail(ctx, email)
+}
+
+func (w *stubIdentityWriter) GetAgentByID(ctx context.Context, id uuid.UUID) (*store.AgentIdentity, error) {
+	w.tx.lazyInit()
+	if a, ok := w.tx.pendingAgents[id]; ok {
+		cp := *a
+		return &cp, nil
+	}
+	return w.reader.GetAgentByID(ctx, id)
+}
+
+func (w *stubIdentityWriter) GetAgentsByParentUser(ctx context.Context, userID uuid.UUID) ([]store.AgentIdentity, error) {
+	return w.reader.GetAgentsByParentUser(ctx, userID)
+}
+
+func (w *stubIdentityWriter) LookupIdentityForCache(ctx context.Context, principalID uuid.UUID) (*store.IdentityCacheEntry, error) {
+	return w.reader.LookupIdentityForCache(ctx, principalID)
+}
+
+func (w *stubIdentityWriter) InsertHumanUser(_ context.Context, u store.HumanUser) error {
+	w.tx.lazyInit()
+	cp := u
+	w.tx.pendingUsers[u.ID] = &cp
+	return nil
+}
+
+func (w *stubIdentityWriter) InsertAgentIdentity(_ context.Context, a store.AgentIdentity) error {
+	w.tx.lazyInit()
+	cp := a
+	w.tx.pendingAgents[a.ID] = &cp
+	return nil
+}
+
+func (w *stubIdentityWriter) SetAgentReputationScore(_ context.Context, agentID uuid.UUID, score float64) error {
+	w.tx.lazyInit()
+	if a, ok := w.tx.pendingAgents[agentID]; ok {
+		a.ReputationScore = score
+		return nil
+	}
+	w.reader.store.mu.Lock()
+	existing, ok := w.reader.store.agents[agentID]
+	w.reader.store.mu.Unlock()
+	if !ok {
+		return errors.New("stub: SetAgentReputationScore: agent not found")
+	}
+	cp := *existing
+	cp.ReputationScore = score
+	w.tx.pendingAgents[agentID] = &cp
+	return nil
+}
+
+func (w *stubIdentityWriter) DisableUser(_ context.Context, _ uuid.UUID) error {
+	return errNotImplemented
+}
+
+func (w *stubIdentityWriter) RevokeAgent(_ context.Context, _ uuid.UUID) error {
+	return errNotImplemented
+}
+
+func (w *stubIdentityWriter) UpdateAgentPermissions(_ context.Context, _ uuid.UUID, _ []string) error {
+	return errNotImplemented
+}
+
+func (w *stubIdentityWriter) AddOrgMember(_ context.Context, _ store.OrgMembership) error {
+	return nil
+}
+
+func (w *stubIdentityWriter) RemoveOrgMember(_ context.Context, _, _ uuid.UUID) error {
+	return nil
+}
+
+type stubRepositoryReader struct{}
+
+func (r *stubRepositoryReader) GetByID(_ context.Context, _ uuid.UUID) (*store.Repository, error) {
+	return nil, errNotImplemented
+}
+
+func (r *stubRepositoryReader) GetBySlug(_ context.Context, _ string) (*store.Repository, error) {
+	return nil, errNotImplemented
+}
+
+type stubRepositoryWriter struct{ stubRepositoryReader }
+
+func (w *stubRepositoryWriter) Insert(_ context.Context, _ store.Repository) error {
+	return errNotImplemented
+}
+
+func (w *stubRepositoryWriter) UpdatePermissions(_ context.Context, _ uuid.UUID, _ string) error {
+	return errNotImplemented
+}

--- a/plane/data/store/stub/metadata_test.go
+++ b/plane/data/store/stub/metadata_test.go
@@ -1,0 +1,121 @@
+package stub_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/gitscale-platform/gitscale/plane/data/store"
+	"github.com/gitscale-platform/gitscale/plane/data/store/stub"
+	"github.com/google/uuid"
+)
+
+func TestStub_TransactCommit(t *testing.T) {
+	s := stub.New()
+	ctx := context.Background()
+	userID := uuid.New()
+
+	err := s.Transact(ctx, func(tx store.Tx) error {
+		return tx.Identity().InsertHumanUser(ctx, store.HumanUser{
+			ID:             userID,
+			Email:          "test@example.com",
+			CredentialHash: "hash",
+			RateBucket:     "human_default",
+		})
+	})
+	if err != nil {
+		t.Fatalf("Transact: %v", err)
+	}
+
+	u, err := s.Identity().GetUserByID(ctx, userID)
+	if err != nil {
+		t.Fatalf("GetUserByID: %v", err)
+	}
+	if u == nil || u.Email != "test@example.com" {
+		t.Fatalf("expected user to be committed, got %v", u)
+	}
+}
+
+func TestStub_TransactRollback(t *testing.T) {
+	s := stub.New()
+	ctx := context.Background()
+	userID := uuid.New()
+	sentinel := errors.New("intentional rollback")
+
+	err := s.Transact(ctx, func(tx store.Tx) error {
+		_ = tx.Identity().InsertHumanUser(ctx, store.HumanUser{
+			ID:    userID,
+			Email: "rollback@example.com",
+		})
+		return sentinel
+	})
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("expected sentinel error, got %v", err)
+	}
+
+	u, err := s.Identity().GetUserByID(ctx, userID)
+	if err != nil {
+		t.Fatalf("GetUserByID after rollback: %v", err)
+	}
+	if u != nil {
+		t.Fatal("expected no user after rollback")
+	}
+}
+
+func TestStub_WriteOutbox(t *testing.T) {
+	s := stub.New()
+	ctx := context.Background()
+	aggID := uuid.New()
+
+	err := s.Transact(ctx, func(tx store.Tx) error {
+		return tx.WriteOutbox(ctx, store.DomainIdentity, "human_user", aggID, "user.created", map[string]string{"foo": "bar"})
+	})
+	if err != nil {
+		t.Fatalf("Transact with WriteOutbox: %v", err)
+	}
+
+	records := s.Recorded()
+	if len(records) != 1 {
+		t.Fatalf("expected 1 outbox record, got %d", len(records))
+	}
+	r := records[0]
+	if r.Domain != store.DomainIdentity {
+		t.Errorf("domain: got %q want %q", r.Domain, store.DomainIdentity)
+	}
+	if r.EventType != "user.created" {
+		t.Errorf("event_type: got %q want %q", r.EventType, "user.created")
+	}
+	if r.AggregateID != aggID {
+		t.Errorf("aggregate_id: got %v want %v", r.AggregateID, aggID)
+	}
+	if r.EventID == uuid.Nil {
+		t.Error("event_id should not be nil")
+	}
+}
+
+func TestStub_WriteOutbox_RollbackDiscardsRecord(t *testing.T) {
+	s := stub.New()
+	ctx := context.Background()
+	aggID := uuid.New()
+	sentinel := errors.New("rollback")
+
+	_ = s.Transact(ctx, func(tx store.Tx) error {
+		_ = tx.WriteOutbox(ctx, store.DomainIdentity, "human_user", aggID, "user.created", nil)
+		return sentinel
+	})
+
+	if len(s.Recorded()) != 0 {
+		t.Fatal("expected no outbox records after rollback")
+	}
+}
+
+func TestStub_WriteOutbox_InvalidDomain(t *testing.T) {
+	s := stub.New()
+	ctx := context.Background()
+	err := s.Transact(ctx, func(tx store.Tx) error {
+		return tx.WriteOutbox(ctx, "bogus", "t", uuid.New(), "e", nil)
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid domain")
+	}
+}


### PR DESCRIPTION
## Summary

- Adds plane/data/store/ package: Domain typed enum SSOT, MetadataStore/Tx interfaces, IdentityReader/Writer/RepositoryReader/Writer interfaces.
- Implements plane/data/store/postgres/: serializable Transact, 5-domain WriteOutbox, identity reads/writes backed by real pgx SQL.
- Implements plane/data/store/stub/: in-memory test double with Recorded() accessor and rollback simulation.
- Adds IsRetryable(err) for SQLSTATE 40001 and NewEventID() UUIDv7 generator.
- Refactors wiring.DomainConfig.Domain from string to store.Domain — Domain enum is now SSOT.
- Unit tests for stub and retryable; integration test skeleton for postgres.

## ADR-impact

conforming ADR-006 (PostgreSQL serializable transactions, 40001 to caller) and ADR-017 (interface swap surface). No EventQueue interface introduced.

## Test plan

- [x] go build ./plane/data/store/... and go build ./... exit 0
- [x] go vet ./plane/data/store/... exit 0
- [x] go test -race ./plane/data/store/... all pass
- [x] No EventQueue interface introduced
- [x] wiring.DomainConfig.Domain is now store.Domain

## References

- Plan: docs/superpowers/plans/2026-05-06-plan-issue-14-metadatastore-interfaces.md
- Spec: docs/superpowers/specs/2026-05-06-execution-plan-post-phase1.md section 13.1

Closes #14

Generated with Claude Code