### PR TITLE
[Workflow] Plane bootstrap Phase A — queues + bundle registry + determinism lint

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -35,3 +35,11 @@ jobs:
       - uses: golangci/golangci-lint-action@v6
         with:
           version: v1.64
+
+  lint-determinism:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Determinism lint (workflow plane)
+        run: make lint-determinism

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test lint lint-md lint-events install-hooks generate fmt
+.PHONY: build test lint lint-md lint-events lint-determinism install-hooks generate fmt
 
 build:
 	go build ./...
@@ -20,6 +20,9 @@ lint-md:
 
 lint-events:
 	bash plane/data/kafka/lint-events.sh
+
+lint-determinism:
+	bash plane/workflow/lint/lint-determinism.sh
 
 install-hooks:
 	git config core.hooksPath .githooks

--- a/plane/workflow/README.md
+++ b/plane/workflow/README.md
@@ -1,0 +1,113 @@
+# Workflow plane
+
+GitScale's workflow plane runs Temporal-orchestrated, durable, long-running
+workflows: billing partition rollover (#18), agent-session lifecycle, CI
+pipelines (Firecracker microVM provisioning). This README documents the
+conventions every workflow PR must follow.
+
+## Plane-boundary rule (ADR-019)
+
+Workflow activities **must not** call `MetadataStore.Transact` for state
+mutations. All domain writes route through `plane/workflow/appclient/<domain>`
+gRPC clients into the application plane, which performs the Tx + outbox
+write under uniform auth/audit context (ADR-008 + ADR-010).
+
+Two exceptions:
+
+1. **Read-only activities** MAY use `plane/data/store` and `plane/data/cache`
+   interfaces directly. A method that does not call `Transact` or
+   `WriteOutbox` is read-only.
+2. **Pure-DDL maintenance activities** (e.g. `CreatePartition` in #18) MAY
+   use `MetadataStore` directly because the operation has no outbox row and
+   no domain invariant.
+
+Cross-domain workflows compose per-domain saga steps with explicit
+compensation activities. No workflow activity writes more than one domain's
+outbox row.
+
+## Task queues
+
+Constants in [`queues.go`](./queues.go). Three queues at launch:
+
+| Queue | Owner |
+|---|---|
+| `billing-maintenance` | data operations (#18 ships first) |
+| `agent-sessions` | agent runtime (Phase 2) |
+| `ci-pipelines` | Firecracker provisioning (Phase 2) |
+
+Routing is coarse-by-workload — never per-tenant. Tenant isolation is
+workflow-id-prefix + search-attributes territory.
+
+## Bundle registry
+
+Each domain package exports a `Bundle()` function returning a `Bundle{TaskQueue, Workflows, Activities}`. The worker entrypoint
+(`cmd/workflow-worker/main.go`, ships in a follow-up PR with the Temporal
+SDK wiring) collects bundles and applies one per worker. Adding a workflow
+requires no change to `main.go`.
+
+```go
+// plane/workflow/billing/partitionrollover/bundle.go (sketch — #18)
+func Bundle(deps Deps) workflow.Bundle {
+    return workflow.Bundle{
+        TaskQueue:  workflow.QueueBillingMaintenance,
+        Workflows:  []any{PartitionRolloverWorkflow},
+        Activities: []any{deps.CreatePartition},
+    }
+}
+```
+
+## Determinism enforcement
+
+Workflow code runs deterministically across replays — no `time.Now()`, no
+`go func()`, no map-range with side effects, no I/O, no environment reads.
+
+Rules live in [`lint/determinism-rules.txt`](./lint/determinism-rules.txt)
+(one regex per line). The script
+[`lint/lint-determinism.sh`](./lint/lint-determinism.sh) reads them and
+greps every `workflow*.go` and `workflows/*.go` under `plane/workflow/`.
+Activity files (`activity*.go`) and test files (`*_test.go`) are exempt —
+activities are the I/O boundary per ADR-003.
+
+Run locally:
+
+```sh
+make lint-determinism
+```
+
+CI runs the same step in a dedicated job (`.github/workflows/go.yml`).
+The lint contract is verified by an integration test that points the
+script at `lint/testdata/bad/` (must fail) and `lint/testdata/good/`
+(must pass).
+
+Escape hatches: `workflow.SideEffect` and `workflow.MutableSideEffect` for
+sources of non-determinism that must be captured into history.
+
+## What ships in this PR vs. follow-ups
+
+This PR (#33) ships the structure that does not depend on the Temporal SDK:
+
+- task-queue constants (`queues.go`)
+- bundle registry (`registry.go`) with a `Registrar` interface satisfied by
+  `*worker.Worker` once the SDK is wired in
+- determinism rules + lint script + Makefile target + CI job + testdata
+  fixtures
+- this README
+
+The Temporal SDK wiring — `cmd/workflow-worker/main.go`, OTel interceptor,
+worker options pinning, `EnsureSchedule` helper, `DefaultRetryPolicy`,
+`ShouldContinueAsNew`, `appclient.IdentityClient` interface, canary
+workflow + integration test — ships in a follow-up issue. The split keeps
+this PR reviewable and unblocks #18-rollover (which uses the queue
+constants and bundle registration model from here) without bringing in
+the full Temporal dep tree.
+
+## Cross-references
+
+- ADR-003 — Temporal as the orchestration layer.
+- ADR-008 — outbox-based event consistency.
+- ADR-019 — workflow→app-plane boundary.
+- ADR-015 — plan approval / risky-action policy. The registry has an
+  implicit slot for a future `ApprovalActivity` Bundle that registers on
+  every queue requiring plan-approval gating.
+- `gitscale-temporal-determinism` skill, `gitscale-plane-boundary` skill —
+  enforcement at the editor.

--- a/plane/workflow/lint/determinism-rules.txt
+++ b/plane/workflow/lint/determinism-rules.txt
@@ -1,0 +1,28 @@
+# Determinism rules for GitScale workflow code (ADR-003, spec D5).
+#
+# Each non-blank, non-comment line is a regex tested against every line of every
+# workflow*.go (or workflows/*.go) file under plane/workflow/. A match fails
+# the lint. activity*.go and *_test.go files are exempt.
+#
+# Escape hatches: workflow.SideEffect, workflow.MutableSideEffect.
+
+# Time and randomness — Temporal workflows MUST use workflow.Now(ctx),
+# workflow.NewTimer(ctx, …), workflow.SideEffect for ad-hoc sources.
+\btime\.Now\(
+\btime\.After\(
+\btime\.NewTimer\(
+\btime\.Sleep\(
+\bmath/rand\b
+\bcrypto/rand\b
+\buuid\.New\(
+\buuid\.NewV7\(
+
+# I/O and config — environment reads + network calls are activity-only.
+\bos\.Getenv\(
+\bnet/http\b
+\bnet\.[A-Z]
+
+# Concurrency primitives — sync.Mutex, sync.WaitGroup, channels, goroutines.
+\bsync\.[A-Z]
+\bgo\s+func\(
+\bmake\(chan\b

--- a/plane/workflow/lint/lint-determinism.sh
+++ b/plane/workflow/lint/lint-determinism.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# lint-determinism.sh — enforces ADR-003 determinism constraints on workflow
+# code. Reads regex rules from plane/workflow/lint/determinism-rules.txt and
+# greps every workflow*.go / workflows/*.go file under plane/workflow/.
+# activity*.go and *_test.go files are exempt — activities are the I/O
+# boundary per ADR-003.
+#
+# Exit codes:
+#   0  no violations
+#   1  one or more violations (messages on stderr)
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+LINT_DIR="${REPO_ROOT}/plane/workflow/lint"
+RULES_FILE="${LINT_DIR}/determinism-rules.txt"
+SCAN_ROOT="${REPO_ROOT}/plane/workflow"
+
+# Optional override: WORKFLOW_LINT_SCAN_ROOT lets the integration test point
+# the scanner at testdata/bad/ or testdata/good/ without touching real code.
+if [[ -n "${WORKFLOW_LINT_SCAN_ROOT:-}" ]]; then
+  SCAN_ROOT="${WORKFLOW_LINT_SCAN_ROOT}"
+fi
+
+if [[ ! -f "${RULES_FILE}" ]]; then
+  echo "ERROR: rules file not found: ${RULES_FILE}" >&2
+  exit 2
+fi
+
+# Read non-blank, non-comment lines from rules file into an array.
+mapfile -t RULES < <(grep -Ev '^\s*(#|$)' "${RULES_FILE}")
+
+if [[ ${#RULES[@]} -eq 0 ]]; then
+  echo "ERROR: no rules loaded from ${RULES_FILE}" >&2
+  exit 2
+fi
+
+# Collect the set of workflow Go files. Exclude *_test.go and activity files.
+# testdata/ is excluded by default (Go toolchain convention); the integration
+# test that exercises the lint sets WORKFLOW_LINT_SCAN_ROOT to point directly
+# at testdata/bad or testdata/good — in that override mode the testdata
+# exclusion is skipped because the caller is intentionally targeting it.
+EXCLUDE_TESTDATA="-not -path */testdata/*"
+if [[ -n "${WORKFLOW_LINT_SCAN_ROOT:-}" ]]; then
+  EXCLUDE_TESTDATA=""
+fi
+
+# shellcheck disable=SC2086
+mapfile -t TARGETS < <(
+  find "${SCAN_ROOT}" -type f \
+    \( -name 'workflow*.go' -o -path '*/workflows/*.go' \) \
+    -not -name 'activity*.go' \
+    -not -name '*_test.go' \
+    ${EXCLUDE_TESTDATA} \
+    2>/dev/null | sort
+)
+
+if [[ ${#TARGETS[@]} -eq 0 ]]; then
+  echo "[ok] no workflow files to scan under ${SCAN_ROOT}"
+  exit 0
+fi
+
+FAIL=0
+for target in "${TARGETS[@]}"; do
+  for rule in "${RULES[@]}"; do
+    # -E extended regex; -n line numbers; -H filename always.
+    if matches=$(grep -EnH "${rule}" "${target}" 2>/dev/null); then
+      while IFS= read -r line; do
+        echo "[FAIL] determinism violation: ${line}" >&2
+        echo "       rule: ${rule}" >&2
+        FAIL=1
+      done <<< "${matches}"
+    fi
+  done
+done
+
+if [[ ${FAIL} -ne 0 ]]; then
+  echo "" >&2
+  echo "FAIL: workflow files contain determinism violations." >&2
+  echo "      Fix: use workflow.Now(ctx), workflow.NewTimer(ctx, …)," >&2
+  echo "           or wrap nondeterministic reads in workflow.SideEffect." >&2
+  exit 1
+fi
+
+echo "[ok] determinism lint clean (${#TARGETS[@]} files, ${#RULES[@]} rules)"
+exit 0

--- a/plane/workflow/lint/lint_test.go
+++ b/plane/workflow/lint/lint_test.go
@@ -1,0 +1,59 @@
+package lint_test
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+// TestLintDeterminism_passesOnGoodFixtures runs the lint script against
+// testdata/good/ and asserts a clean exit. Proves the rule set isn't so
+// strict that legitimate workflow code can't pass.
+func TestLintDeterminism_passesOnGoodFixtures(t *testing.T) {
+	script, scanRoot := scriptAndFixture(t, "good")
+	cmd := exec.Command("bash", script)
+	cmd.Env = append(os.Environ(), "WORKFLOW_LINT_SCAN_ROOT="+scanRoot)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("lint should have passed on good fixture but failed:\nout=%s\nerr=%v", out, err)
+	}
+}
+
+// TestLintDeterminism_failsOnBadFixtures runs the lint script against
+// testdata/bad/ and asserts non-zero exit. Proves the lint isn't silently
+// passing — the canonical sanity check on any rule-driven enforcement.
+func TestLintDeterminism_failsOnBadFixtures(t *testing.T) {
+	script, scanRoot := scriptAndFixture(t, "bad")
+	cmd := exec.Command("bash", script)
+	cmd.Env = append(os.Environ(), "WORKFLOW_LINT_SCAN_ROOT="+scanRoot)
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("lint should have failed on bad fixture but passed:\nout=%s", out)
+	}
+	exit, ok := err.(*exec.ExitError)
+	if !ok {
+		t.Fatalf("lint did not exit with ExitError: %v", err)
+	}
+	if exit.ExitCode() != 1 {
+		t.Fatalf("expected exit 1 (rule violation), got %d", exit.ExitCode())
+	}
+}
+
+func scriptAndFixture(t *testing.T, kind string) (string, string) {
+	t.Helper()
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd: %v", err)
+	}
+	// wd = …/plane/workflow/lint when go test runs from this package.
+	script := filepath.Join(wd, "lint-determinism.sh")
+	scanRoot := filepath.Join(wd, "testdata", kind)
+	if _, err := os.Stat(script); err != nil {
+		t.Fatalf("script not found at %s: %v", script, err)
+	}
+	if _, err := os.Stat(scanRoot); err != nil {
+		t.Fatalf("scan root not found at %s: %v", scanRoot, err)
+	}
+	return script, scanRoot
+}

--- a/plane/workflow/lint/testdata/bad/workflow_goroutine.go
+++ b/plane/workflow/lint/testdata/bad/workflow_goroutine.go
@@ -1,0 +1,8 @@
+// Fixture: deliberately violates determinism rules. See workflow_time_now.go.
+package bad
+
+func WorkflowGoroutine() {
+	go func() {
+		_ = 1 + 1
+	}()
+}

--- a/plane/workflow/lint/testdata/bad/workflow_time_now.go
+++ b/plane/workflow/lint/testdata/bad/workflow_time_now.go
@@ -1,0 +1,10 @@
+// This file is a fixture for plane/workflow/lint. It deliberately violates
+// the determinism rules — DO NOT compile or import. testdata/ is ignored by
+// the Go toolchain so this never reaches go build.
+package bad
+
+import "time"
+
+func WorkflowTimeNow() {
+	_ = time.Now()
+}

--- a/plane/workflow/lint/testdata/bad/workflow_uuid_new.go
+++ b/plane/workflow/lint/testdata/bad/workflow_uuid_new.go
@@ -1,0 +1,8 @@
+// Fixture: deliberately violates determinism rules. See workflow_time_now.go.
+package bad
+
+import "github.com/google/uuid"
+
+func WorkflowUUIDNew() {
+	_ = uuid.New()
+}

--- a/plane/workflow/lint/testdata/good/workflow_clean.go
+++ b/plane/workflow/lint/testdata/good/workflow_clean.go
@@ -1,0 +1,8 @@
+// Fixture: passes determinism rules. Models a workflow that uses
+// workflow.Now (would be) and avoids forbidden APIs entirely.
+package good
+
+func WorkflowClean(payload string) string {
+	// No time.Now, no uuid.New, no goroutines, no channels — clean.
+	return "processed:" + payload
+}

--- a/plane/workflow/queues.go
+++ b/plane/workflow/queues.go
@@ -1,0 +1,39 @@
+// Package workflow holds the GitScale workflow-plane bootstrap shared by
+// every Temporal workflow in the platform: task-queue constants, registration
+// scaffolding (Bundle), and the lint contract enforcing determinism on
+// workflow code (ADR-003, ADR-019).
+//
+// Task queues are partitioned by workload class — billing maintenance, agent
+// sessions, CI pipelines — not by tenant or domain. Per-tenant queues are an
+// anti-pattern at Temporal scale; tenant isolation is workflow-id-prefix +
+// search-attributes territory (Phase 2).
+//
+// State-mutating activities route through plane/workflow/appclient/<domain>
+// gRPC clients into the application plane (ADR-019). Read-only activities
+// MAY use plane/data/store and plane/data/cache interfaces directly. Pure-
+// DDL maintenance activities (e.g. CreatePartition) are exempt from the
+// app-plane routing rule because they have no outbox row.
+package workflow
+
+// Task queue constants. Bundles register against one of these per worker.
+// Adding a new queue is rare — coarse-by-workload routing is intentional.
+const (
+	// QueueBillingMaintenance hosts billing.usage_events partition rollover
+	// (#18) and future operational-analytics maintenance jobs.
+	QueueBillingMaintenance = "billing-maintenance"
+
+	// QueueAgentSessions hosts long-running agent-session lifecycle
+	// workflows. Reserved for the agent runtime epic (Phase 2).
+	QueueAgentSessions = "agent-sessions"
+
+	// QueueCIPipelines hosts CI runner provisioning workflows (Firecracker
+	// microVM lifecycle). Reserved for the CI epic (Phase 2).
+	QueueCIPipelines = "ci-pipelines"
+)
+
+// AllQueues is the canonical list of currently-defined task queues.
+var AllQueues = []string{
+	QueueBillingMaintenance,
+	QueueAgentSessions,
+	QueueCIPipelines,
+}

--- a/plane/workflow/registry.go
+++ b/plane/workflow/registry.go
@@ -1,0 +1,39 @@
+package workflow
+
+// Bundle is the unit of registration for one task queue. A worker registers
+// exactly one Bundle per queue it serves. Domain packages export a Bundle()
+// function that the worker entrypoint (cmd/workflow-worker) collects without
+// modification — adding a new workflow requires no change to main.go.
+//
+// The slice element type is any so this package compiles without depending
+// on the Temporal SDK; the worker entrypoint passes them through to
+// worker.Worker.RegisterWorkflow / RegisterActivity which accept any.
+type Bundle struct {
+	// TaskQueue must match one of the constants in queues.go.
+	TaskQueue string
+	// Workflows are workflow funcs (or struct-method pairs).
+	Workflows []any
+	// Activities are activity funcs (or struct-method pairs).
+	Activities []any
+}
+
+// Registrar is the minimal Temporal-worker interface the Bundle.Apply method
+// needs. *worker.Worker satisfies it; tests can inject a fake to assert
+// registration order without spinning a real worker.
+type Registrar interface {
+	RegisterWorkflow(any)
+	RegisterActivity(any)
+}
+
+// Apply registers all workflows and activities in this Bundle on r in the
+// order they appear in the slices. Order matters only when the same name is
+// registered twice (later wins per Temporal SDK semantics) — Bundles should
+// not register the same identifier twice.
+func (b Bundle) Apply(r Registrar) {
+	for _, wf := range b.Workflows {
+		r.RegisterWorkflow(wf)
+	}
+	for _, a := range b.Activities {
+		r.RegisterActivity(a)
+	}
+}

--- a/plane/workflow/registry_test.go
+++ b/plane/workflow/registry_test.go
@@ -1,0 +1,63 @@
+package workflow
+
+import "testing"
+
+// fakeRegistrar records the order in which workflows and activities are
+// registered so we can assert Bundle.Apply behaviour without depending on
+// the Temporal SDK.
+type fakeRegistrar struct {
+	workflows  []any
+	activities []any
+}
+
+func (f *fakeRegistrar) RegisterWorkflow(w any)  { f.workflows = append(f.workflows, w) }
+func (f *fakeRegistrar) RegisterActivity(a any)  { f.activities = append(f.activities, a) }
+
+func TestBundle_Apply_registersInOrder(t *testing.T) {
+	wf1 := func() {}
+	wf2 := func() {}
+	a1 := func() {}
+	a2 := func() {}
+
+	b := Bundle{
+		TaskQueue:  QueueBillingMaintenance,
+		Workflows:  []any{wf1, wf2},
+		Activities: []any{a1, a2},
+	}
+
+	r := &fakeRegistrar{}
+	b.Apply(r)
+
+	if len(r.workflows) != 2 || len(r.activities) != 2 {
+		t.Fatalf("counts: %d workflows, %d activities", len(r.workflows), len(r.activities))
+	}
+}
+
+func TestBundle_Apply_emptyBundle_noRegistration(t *testing.T) {
+	b := Bundle{TaskQueue: QueueBillingMaintenance}
+	r := &fakeRegistrar{}
+	b.Apply(r)
+
+	if len(r.workflows) != 0 || len(r.activities) != 0 {
+		t.Fatalf("empty bundle: %d workflows, %d activities", len(r.workflows), len(r.activities))
+	}
+}
+
+func TestAllQueues_includesAllConstants(t *testing.T) {
+	want := map[string]bool{
+		QueueBillingMaintenance: false,
+		QueueAgentSessions:      false,
+		QueueCIPipelines:        false,
+	}
+	for _, q := range AllQueues {
+		if _, ok := want[q]; !ok {
+			t.Errorf("AllQueues contains unknown queue %q", q)
+		}
+		want[q] = true
+	}
+	for q, seen := range want {
+		if !seen {
+			t.Errorf("AllQueues is missing %q", q)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

First arm of #33 split. Ships the workflow-plane scaffolding that does NOT depend on the Temporal SDK so it can land alongside #18-rollover preparation. Phase B (Temporal worker + OTel + retry policy + continue-as-new), Phase C (appclient.IdentityClient interface), Phase D (canary integration test) ship as a separate follow-up after the SDK dep is added.

- plane/workflow/queues.go: QueueBillingMaintenance, QueueAgentSessions, QueueCIPipelines + AllQueues slice. Routing is coarse-by-workload (spec D2).
- plane/workflow/registry.go: Bundle{TaskQueue, []any Workflows, []any Activities} + Registrar interface (any-typed so worker.Worker satisfies it once SDK wires) + Apply method (spec D4).
- plane/workflow/lint: determinism rules + bash script + testdata fixtures. lint_test.go runs the script against testdata/bad (must fail with exit 1) and testdata/good (must pass). Proves the lint isn't silently passing.
- Makefile + .github/workflows/go.yml: make lint-determinism target + dedicated CI job. Config + script in same PR per CLAUDE.md linter rule.
- plane/workflow/README.md: D1-D5 + ADR-019 cross-references + explicit "ships in this PR vs follow-ups" section so readers don't look for cmd/workflow-worker here.

## ADR-impact

conforming ADR-003 (Temporal as orchestration layer; activities are I/O boundary), ADR-019 (workflow-plane routing rule documented in README + lint rules align). No new ADR.

## Test plan

- [x] go build ./... exit 0
- [x] go vet ./plane/workflow/... exit 0
- [x] go test -race ./plane/workflow/... — registry tests + lint_test.go (verifies bad fixtures trip lint, good passes)
- [x] make lint-determinism on real plane/workflow/ — exit 0 (no workflow*.go files yet)
- [x] make lint-determinism with WORKFLOW_LINT_SCAN_ROOT=testdata/bad — exit 1 (rule violations detected)
- [x] make lint-md clean
- [x] CI .github/workflows/go.yml adds lint-determinism job

## References

- Plan: docs/superpowers/plans/2026-05-06-plan-issue-33-workflow-bootstrap.md
- Spec: docs/superpowers/specs/2026-05-06-issue-33-workflow-bootstrap-design.md (D1-D5 in this PR; D6-D12 in the SDK-wire follow-up)
- ADR-019: docs/architecture.md section 8

Closes #55

Generated with Claude Code