### PR TITLE
[Meta] Upgrade golangci-lint-action to v9.2.0 and golangci-lint to v2.12.2

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -32,9 +32,9 @@ jobs:
           go-version: "1.24"
           cache: false
 
-      - uses: golangci/golangci-lint-action@v6
+      - uses: golangci/golangci-lint-action@v9.2.0
         with:
-          version: v1.64
+          version: v2.12.2
 
   lint-determinism:
     runs-on: ubuntu-latest

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,2 +1,4 @@
+version: "2"
+
 run:
   go: "1.24"

--- a/plane/data/ratelimit/limiter_test.go
+++ b/plane/data/ratelimit/limiter_test.go
@@ -70,7 +70,7 @@ func TestRateLimiter_Redis_Compliance(t *testing.T) {
 		client := redis.NewClient(opt)
 		inner := ratelimit.NewRedisLimiter(client)
 		lim := ratelimit.WithNamespace(inner, fmt.Sprintf("test%d", n))
-		return lim, nil, func() { client.Close() }
+		return lim, nil, func() { _ = client.Close() }
 	}
 
 	compliance.RunRateLimiterCompliance(t, factory)


### PR DESCRIPTION
## Summary

- Bump `golangci/golangci-lint-action` from `@v6` to `@v9.2.0`
- Bump linter version from `v1.64` to `v2.12.2` (latest stable)

Action v6 was redesigned for golangci-lint v2.x binaries; using it with v1.x caused CI to hang. v9.2.0 is the latest action release (2025-12-02); v2.12.2 is the latest linter (2026-05-06).

## Test plan

- [ ] CI lint job completes without hanging on this PR

Closes #59