### PR TITLE
[Workflow] EnsureSchedule helper for Temporal Schedule API

### DIFF
--- a/plane/workflow/schedule.go
+++ b/plane/workflow/schedule.go
@@ -1,0 +1,60 @@
+package workflow
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"go.temporal.io/sdk/client"
+	"go.temporal.io/sdk/temporal"
+)
+
+// ScheduleClient is the subset of go.temporal.io/sdk/client.ScheduleClient
+// EnsureSchedule depends on. *client.Client.ScheduleClient() satisfies it;
+// tests inject a fake to assert idempotent behaviour without a live Temporal
+// server. Spec D6 (#33).
+type ScheduleClient interface {
+	Create(ctx context.Context, opts client.ScheduleOptions) (client.ScheduleHandle, error)
+	GetHandle(ctx context.Context, id string) client.ScheduleHandle
+}
+
+// EnsureSchedule registers a Temporal Schedule, idempotent across worker
+// restarts and across concurrent boots. On first call it issues Create; if
+// the server reports the schedule already exists, it issues an Update so the
+// running spec converges to opts. The intended caller is cmd/workflow-worker
+// at boot time and *_test.go fixtures.
+//
+// opts.ID must be set (Temporal requires a stable ID for Update to find the
+// schedule). Returns the live schedule handle in both branches so callers
+// can attach further state if needed.
+func EnsureSchedule(ctx context.Context, sc ScheduleClient, opts client.ScheduleOptions) (client.ScheduleHandle, error) {
+	if opts.ID == "" {
+		return nil, errors.New("workflow: EnsureSchedule: opts.ID is required")
+	}
+
+	handle, err := sc.Create(ctx, opts)
+	if err == nil {
+		return handle, nil
+	}
+	if !errors.Is(err, temporal.ErrScheduleAlreadyRunning) {
+		return nil, fmt.Errorf("workflow: EnsureSchedule: create %s: %w", opts.ID, err)
+	}
+
+	// Schedule already exists; converge it to opts via Update.
+	existing := sc.GetHandle(ctx, opts.ID)
+	updateErr := existing.Update(ctx, client.ScheduleUpdateOptions{
+		DoUpdate: func(in client.ScheduleUpdateInput) (*client.ScheduleUpdate, error) {
+			// Carry forward the server-side Policy/State; overwrite Spec + Action
+			// so the live schedule converges to opts.
+			next := in.Description.Schedule
+			next.Action = opts.Action
+			specCopy := opts.Spec
+			next.Spec = &specCopy
+			return &client.ScheduleUpdate{Schedule: &next}, nil
+		},
+	})
+	if updateErr != nil {
+		return nil, fmt.Errorf("workflow: EnsureSchedule: update %s: %w", opts.ID, updateErr)
+	}
+	return existing, nil
+}

--- a/plane/workflow/schedule_test.go
+++ b/plane/workflow/schedule_test.go
@@ -1,0 +1,139 @@
+package workflow
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"go.temporal.io/sdk/client"
+	"go.temporal.io/sdk/temporal"
+)
+
+type fakeSchedule struct {
+	id            string
+	updateCalls   int
+	lastUpdateIn  client.ScheduleUpdateInput
+	lastUpdateOut *client.ScheduleUpdate
+	updateErr     error
+}
+
+func (f *fakeSchedule) GetID() string                                                    { return f.id }
+func (f *fakeSchedule) Delete(_ context.Context) error                                   { return nil }
+func (f *fakeSchedule) Backfill(_ context.Context, _ client.ScheduleBackfillOptions) error { return nil }
+func (f *fakeSchedule) Update(_ context.Context, opts client.ScheduleUpdateOptions) error {
+	f.updateCalls++
+	current := client.ScheduleUpdateInput{
+		Description: client.ScheduleDescription{
+			Schedule: client.Schedule{},
+		},
+	}
+	f.lastUpdateIn = current
+	out, err := opts.DoUpdate(current)
+	if err != nil {
+		return err
+	}
+	f.lastUpdateOut = out
+	return f.updateErr
+}
+func (f *fakeSchedule) Describe(_ context.Context) (*client.ScheduleDescription, error) {
+	return &client.ScheduleDescription{}, nil
+}
+func (f *fakeSchedule) Trigger(_ context.Context, _ client.ScheduleTriggerOptions) error  { return nil }
+func (f *fakeSchedule) Pause(_ context.Context, _ client.SchedulePauseOptions) error      { return nil }
+func (f *fakeSchedule) Unpause(_ context.Context, _ client.ScheduleUnpauseOptions) error  { return nil }
+
+type fakeScheduleClient struct {
+	createCalls int
+	createErr   error
+	handle      *fakeSchedule
+}
+
+func (f *fakeScheduleClient) Create(_ context.Context, opts client.ScheduleOptions) (client.ScheduleHandle, error) {
+	f.createCalls++
+	if f.createErr != nil {
+		return nil, f.createErr
+	}
+	f.handle = &fakeSchedule{id: opts.ID}
+	return f.handle, nil
+}
+
+func (f *fakeScheduleClient) GetHandle(_ context.Context, id string) client.ScheduleHandle {
+	if f.handle == nil {
+		f.handle = &fakeSchedule{id: id}
+	}
+	return f.handle
+}
+
+func newOpts() client.ScheduleOptions {
+	return client.ScheduleOptions{
+		ID: "billing-partition-rollover",
+		Spec: client.ScheduleSpec{
+			CronExpressions: []string{"0 12 24 * *"},
+		},
+		Action: &client.ScheduleWorkflowAction{
+			ID:        "billing-partition-rollover-test",
+			Workflow:  "PartitionRolloverWorkflow",
+			TaskQueue: QueueBillingMaintenance,
+		},
+	}
+}
+
+func TestEnsureSchedule_createPath(t *testing.T) {
+	sc := &fakeScheduleClient{}
+	h, err := EnsureSchedule(context.Background(), sc, newOpts())
+	if err != nil {
+		t.Fatalf("EnsureSchedule: %v", err)
+	}
+	if sc.createCalls != 1 {
+		t.Errorf("createCalls=%d want 1", sc.createCalls)
+	}
+	if h == nil {
+		t.Error("nil handle")
+	}
+	if sc.handle != nil && sc.handle.updateCalls != 0 {
+		t.Errorf("update should not be called on create path; updateCalls=%d", sc.handle.updateCalls)
+	}
+}
+
+func TestEnsureSchedule_alreadyExists_updates(t *testing.T) {
+	sc := &fakeScheduleClient{createErr: temporal.ErrScheduleAlreadyRunning}
+	h, err := EnsureSchedule(context.Background(), sc, newOpts())
+	if err != nil {
+		t.Fatalf("EnsureSchedule: %v", err)
+	}
+	if h == nil {
+		t.Error("nil handle")
+	}
+	if sc.handle.updateCalls != 1 {
+		t.Errorf("updateCalls=%d want 1", sc.handle.updateCalls)
+	}
+	if sc.handle.lastUpdateOut == nil || sc.handle.lastUpdateOut.Schedule == nil {
+		t.Fatal("update body returned no schedule")
+	}
+	got := sc.handle.lastUpdateOut.Schedule
+	if got.Spec == nil || len(got.Spec.CronExpressions) != 1 || got.Spec.CronExpressions[0] != "0 12 24 * *" {
+		t.Errorf("update did not propagate Spec.CronExpressions: %+v", got.Spec)
+	}
+	if got.Action == nil {
+		t.Error("update did not propagate Action")
+	}
+}
+
+func TestEnsureSchedule_emptyID(t *testing.T) {
+	sc := &fakeScheduleClient{}
+	if _, err := EnsureSchedule(context.Background(), sc, client.ScheduleOptions{}); err == nil {
+		t.Error("expected error for empty ID")
+	}
+	if sc.createCalls != 0 {
+		t.Errorf("Create should not be invoked with empty ID; createCalls=%d", sc.createCalls)
+	}
+}
+
+func TestEnsureSchedule_nonRetryableCreateError(t *testing.T) {
+	sentinel := errors.New("network error")
+	sc := &fakeScheduleClient{createErr: sentinel}
+	if _, err := EnsureSchedule(context.Background(), sc, newOpts()); !errors.Is(err, sentinel) {
+		t.Errorf("expected sentinel propagated, got %v", err)
+	}
+}
+


### PR DESCRIPTION
## Summary

Idempotent ``EnsureSchedule`` for registering Temporal Schedules. Create-then-Update on ``temporal.ErrScheduleAlreadyRunning``. Closes #61 and unblocks A2.2 #18-rollover.

- ``plane/workflow/schedule.go``: ``EnsureSchedule(ctx, ScheduleClient, ScheduleOptions)``. Takes a minimal ``ScheduleClient`` interface so unit tests inject a fake without a live Temporal server.
- ``plane/workflow/schedule_test.go``: 4 cases — create path, already-running update path, empty-ID guard, non-retryable Create error.

Update path overlays ``Action + Spec`` from opts onto the live ``client.Schedule`` and carries forward server-side ``Policy/State`` so re-issuing ``EnsureSchedule`` does not stomp operator-driven Pauses (incident response).

## ADR-impact

``conforming`` ADR-003 (Temporal as orchestration layer). No new ADR; the helper is a thin convenience over ``client.ScheduleClient``.

## Test plan

- [x] ``go build ./...`` exit 0
- [x] ``go vet ./...`` exit 0
- [x] ``go test -race ./plane/workflow/...`` — all 4 cases pass
- [x] ``make lint-determinism`` — clean (the helper is non-workflow code; no determinism constraint)
- [x] ``make lint-md`` — 0 errors

## References

- Spec: ``docs/superpowers/specs/2026-05-06-issue-33-workflow-bootstrap-design.md`` D6
- Origin: deferred from PR #58 (#33-B)

Closes #61.

🤖 Generated with [Claude Code](https://claude.com/claude-code)