### PR TITLE
[Application] Identity cache invalidator consumer

### DIFF
--- a/cmd/identity-cache-invalidator/main.go
+++ b/cmd/identity-cache-invalidator/main.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/gitscale-platform/gitscale/plane/application/identity-cache-invalidator"
+	"github.com/gitscale-platform/gitscale/plane/data/cache"
+	kafkago "github.com/segmentio/kafka-go"
+)
+
+func main() {
+	cfg, err := invalidator.LoadEnv()
+	if err != nil {
+		log.Fatalf("config: %v", err)
+	}
+
+	rawStore, err := cache.NewRedisStore(cache.RedisConfig{
+		URL:        cfg.RedisURL,
+		UseCluster: cfg.RedisUseCluster,
+	})
+	if err != nil {
+		log.Fatalf("redis: %v", err)
+	}
+	cstore := cache.WithNamespace(rawStore, cfg.Env)
+
+	startOffset := kafkago.FirstOffset
+	if cfg.KafkaAutoOffsetReset == "latest" {
+		startOffset = kafkago.LastOffset
+	}
+	reader := kafkago.NewReader(kafkago.ReaderConfig{
+		Brokers:        cfg.KafkaBootstrapServers,
+		Topic:          cfg.KafkaTopic,
+		GroupID:        cfg.KafkaGroupID,
+		StartOffset:    startOffset,
+		MinBytes:       1,
+		MaxBytes:       10 << 20, // 10MB
+		CommitInterval: 0,        // sync commits
+		MaxWait:        5 * time.Second,
+	})
+
+	consumer, err := invalidator.New(invalidator.Config{
+		Reader:  invalidator.WrapKafkaReader(reader),
+		Cache:   cstore,
+		Deduper: invalidator.NewDeduper(cstore),
+		Metrics: invalidator.NewMetrics(),
+	})
+	if err != nil {
+		log.Fatalf("consumer: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		sigs := make(chan os.Signal, 1)
+		signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
+		<-sigs
+		log.Println("shutdown signal; cancelling consumer")
+		cancel()
+	}()
+
+	if err := consumer.Run(ctx); err != nil && err != context.Canceled {
+		log.Fatalf("run: %v", err)
+	}
+}

--- a/plane/application/identity-cache-invalidator/config.go
+++ b/plane/application/identity-cache-invalidator/config.go
@@ -1,0 +1,58 @@
+package invalidator
+
+import (
+	"errors"
+	"os"
+	"strings"
+)
+
+// EnvConfig is the runtime configuration sourced from process env. The cmd
+// binary reads it once at boot; in-process tests construct a Config directly
+// and skip this layer.
+type EnvConfig struct {
+	KafkaBootstrapServers []string
+	KafkaTopic            string
+	KafkaGroupID          string
+	KafkaAutoOffsetReset  string // "earliest" | "latest"
+	RedisURL              string
+	RedisUseCluster       bool
+	Env                   string // "dev" | "stg" | "prod" — used for cache key namespacing
+}
+
+// LoadEnv reads required env vars and returns the populated config. Caller
+// is expected to fail fast on error.
+func LoadEnv() (EnvConfig, error) {
+	cfg := EnvConfig{
+		KafkaTopic:           getOr("IDENTITY_INVALIDATOR_TOPIC", "gitscale.identity.events"),
+		KafkaGroupID:         getOr("IDENTITY_INVALIDATOR_GROUP", "gitscale.identity-cache-invalidator"),
+		KafkaAutoOffsetReset: getOr("KAFKA_AUTO_OFFSET_RESET", "earliest"),
+		RedisURL:             os.Getenv("REDIS_URL"),
+		RedisUseCluster:      os.Getenv("REDIS_USE_CLUSTER") == "true",
+		Env:                  getOr("GITSCALE_ENV", "dev"),
+	}
+
+	bs := strings.TrimSpace(os.Getenv("KAFKA_BOOTSTRAP_SERVERS"))
+	if bs == "" {
+		return cfg, errors.New("invalidator: KAFKA_BOOTSTRAP_SERVERS is required")
+	}
+	for _, s := range strings.Split(bs, ",") {
+		if s = strings.TrimSpace(s); s != "" {
+			cfg.KafkaBootstrapServers = append(cfg.KafkaBootstrapServers, s)
+		}
+	}
+
+	if cfg.RedisURL == "" {
+		return cfg, errors.New("invalidator: REDIS_URL is required")
+	}
+	if cfg.KafkaAutoOffsetReset != "earliest" && cfg.KafkaAutoOffsetReset != "latest" {
+		return cfg, errors.New("invalidator: KAFKA_AUTO_OFFSET_RESET must be 'earliest' or 'latest'")
+	}
+	return cfg, nil
+}
+
+func getOr(key, def string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return def
+}

--- a/plane/application/identity-cache-invalidator/consumer.go
+++ b/plane/application/identity-cache-invalidator/consumer.go
@@ -1,0 +1,151 @@
+package invalidator
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/gitscale-platform/gitscale/plane/data/cache"
+	gitscalekafka "github.com/gitscale-platform/gitscale/plane/data/kafka"
+)
+
+// MessageReader is the subset of segmentio/kafka-go *Reader the consumer
+// depends on. Tests inject an in-memory reader via this interface (see
+// consumer_test.go). Production wiring constructs a kafka.Reader.
+type MessageReader interface {
+	FetchMessage(ctx context.Context) (RawMessage, error)
+	CommitMessages(ctx context.Context, msgs ...RawMessage) error
+	Close() error
+}
+
+// RawMessage is the consumer's internal projection of a Kafka message — the
+// only fields it touches. Decoupling here keeps the test fake free of the
+// full kafka-go Message struct.
+type RawMessage struct {
+	Topic     string
+	Partition int
+	Offset    int64
+	Key       []byte
+	Value     []byte
+}
+
+// Consumer drains gitscale.identity.events and invalidates the per-principal
+// identity cache entry for every UUID in the payload's affected_principal_ids.
+type Consumer struct {
+	reader   MessageReader
+	cache    cache.CacheStore
+	deduper  Deduper
+	handlers map[string]EventHandler
+	metrics  *Metrics
+}
+
+// Config wires the Consumer's collaborators. All fields required.
+type Config struct {
+	Reader   MessageReader
+	Cache    cache.CacheStore
+	Deduper  Deduper
+	Handlers map[string]EventHandler
+	Metrics  *Metrics
+}
+
+// New constructs a Consumer. Returns an error if any collaborator is nil.
+func New(cfg Config) (*Consumer, error) {
+	switch {
+	case cfg.Reader == nil:
+		return nil, errors.New("invalidator: Config.Reader is nil")
+	case cfg.Cache == nil:
+		return nil, errors.New("invalidator: Config.Cache is nil")
+	case cfg.Deduper == nil:
+		return nil, errors.New("invalidator: Config.Deduper is nil")
+	case cfg.Metrics == nil:
+		return nil, errors.New("invalidator: Config.Metrics is nil")
+	}
+	handlers := cfg.Handlers
+	if handlers == nil {
+		handlers = DefaultHandlers
+	}
+	return &Consumer{
+		reader:   cfg.Reader,
+		cache:    cfg.Cache,
+		deduper:  cfg.Deduper,
+		handlers: handlers,
+		metrics:  cfg.Metrics,
+	}, nil
+}
+
+// Run drains messages until ctx is cancelled. Handler / cache errors retry
+// the same offset (no commit); the loop returns ctx.Err() on cancellation.
+// FetchMessage error other than ctx-cancel propagates so the supervisor can
+// restart the process — matches the outbox consumer's failure model.
+func (c *Consumer) Run(ctx context.Context) error {
+	defer func() { _ = c.reader.Close() }()
+	for {
+		msg, err := c.reader.FetchMessage(ctx)
+		if err != nil {
+			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+				return ctx.Err()
+			}
+			return fmt.Errorf("invalidator: FetchMessage: %w", err)
+		}
+		if err := c.processOnce(ctx, msg); err != nil {
+			// Retryable: do NOT commit; loop will refetch the same offset.
+			continue
+		}
+		if err := c.reader.CommitMessages(ctx, msg); err != nil {
+			return fmt.Errorf("invalidator: CommitMessages: %w", err)
+		}
+	}
+}
+
+// processOnce decodes, dedupes, dispatches, deletes, and marks. Returns nil
+// to signal "commit this offset"; non-nil to retry.
+func (c *Consumer) processOnce(ctx context.Context, msg RawMessage) error {
+	env, err := gitscalekafka.UnmarshalEnvelope(msg.Value)
+	if err != nil {
+		// Bad payload: increment metric and commit so we do not loop on
+		// a poison pill. A future DLQ writer would attach the bytes here.
+		c.metrics.IncDLQ("", ResultEnvelopeDecode)
+		c.metrics.IncInvalidation("", ResultEnvelopeDecode)
+		return nil
+	}
+
+	seen, err := c.deduper.Seen(ctx, env.EventID)
+	if err != nil {
+		c.metrics.IncInvalidation(env.EventType, ResultCacheError)
+		return err
+	}
+	if seen {
+		c.metrics.IncInvalidation(env.EventType, ResultAlreadyProcessed)
+		return nil
+	}
+
+	handler := c.handlers[env.EventType]
+	if handler == nil {
+		c.metrics.IncInvalidation(env.EventType, ResultUnknownEventType)
+		return nil
+	}
+
+	affected, err := handler.Affected(env)
+	if err != nil {
+		c.metrics.IncInvalidation(env.EventType, ResultHandlerError)
+		// Decode failures inside a known event type are a contract violation;
+		// treat as poison and commit to avoid head-of-line blocking. Lifted
+		// to retryable once a DLQ topic is wired up.
+		return nil
+	}
+
+	for _, pid := range affected {
+		if err := c.cache.Delete(ctx, fmt.Sprintf(cache.IdentityKey, pid)); err != nil {
+			c.metrics.IncInvalidation(env.EventType, ResultCacheError)
+			return err
+		}
+	}
+
+	if err := c.deduper.Mark(ctx, env.EventID); err != nil {
+		c.metrics.IncInvalidation(env.EventType, ResultCacheError)
+		return err
+	}
+
+	c.metrics.IncInvalidation(env.EventType, ResultOK)
+	return nil
+}

--- a/plane/application/identity-cache-invalidator/consumer_test.go
+++ b/plane/application/identity-cache-invalidator/consumer_test.go
@@ -1,0 +1,270 @@
+package invalidator
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gitscale-platform/gitscale/plane/data/cache"
+	gitscalekafka "github.com/gitscale-platform/gitscale/plane/data/kafka"
+	"github.com/google/uuid"
+)
+
+// fakeReader is a slice-backed MessageReader. Run drains it then blocks until
+// ctx is cancelled.
+type fakeReader struct {
+	mu         sync.Mutex
+	msgs       []RawMessage
+	idx        int
+	committed  []int64
+	closeCalls int
+}
+
+func (f *fakeReader) FetchMessage(ctx context.Context) (RawMessage, error) {
+	f.mu.Lock()
+	if f.idx >= len(f.msgs) {
+		f.mu.Unlock()
+		<-ctx.Done()
+		return RawMessage{}, ctx.Err()
+	}
+	m := f.msgs[f.idx]
+	f.idx++
+	f.mu.Unlock()
+	return m, nil
+}
+
+func (f *fakeReader) CommitMessages(_ context.Context, msgs ...RawMessage) error {
+	f.mu.Lock()
+	for _, m := range msgs {
+		f.committed = append(f.committed, m.Offset)
+	}
+	f.mu.Unlock()
+	return nil
+}
+
+func (f *fakeReader) Close() error {
+	f.mu.Lock()
+	f.closeCalls++
+	f.mu.Unlock()
+	return nil
+}
+
+func (f *fakeReader) progress() (idx, committed int) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.idx, len(f.committed)
+}
+
+// memoryCache is a minimal cache.CacheStore for tests. Only Get/Set/Delete
+// are exercised by the consumer; the rest return nil.
+type memoryCache struct {
+	mu      sync.Mutex
+	data    map[string][]byte
+	expires map[string]time.Time
+	deletes []string
+	getErr  error
+}
+
+func newMemoryCache() *memoryCache {
+	return &memoryCache{data: map[string][]byte{}, expires: map[string]time.Time{}}
+}
+
+func (m *memoryCache) Get(_ context.Context, key string) ([]byte, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.getErr != nil {
+		return nil, m.getErr
+	}
+	v, ok := m.data[key]
+	if !ok {
+		return nil, cache.ErrNotFound
+	}
+	return v, nil
+}
+func (m *memoryCache) MGet(_ context.Context, keys []string) ([][]byte, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := make([][]byte, len(keys))
+	for i, k := range keys {
+		out[i] = m.data[k]
+	}
+	return out, nil
+}
+func (m *memoryCache) Set(_ context.Context, key string, value []byte, ttl time.Duration) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.data[key] = value
+	m.expires[key] = time.Now().Add(ttl)
+	return nil
+}
+func (m *memoryCache) Delete(_ context.Context, key string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.deletes = append(m.deletes, key)
+	delete(m.data, key)
+	return nil
+}
+func (m *memoryCache) CompareAndSwap(_ context.Context, _ string, _, _ []byte, _ time.Duration) (bool, error) {
+	return false, nil
+}
+func (m *memoryCache) Ping(_ context.Context) error { return nil }
+func (m *memoryCache) deleteList() []string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := make([]string, len(m.deletes))
+	copy(out, m.deletes)
+	return out
+}
+
+func envelope(t *testing.T, eventType, eventID string, affected []uuid.UUID) RawMessage {
+	t.Helper()
+	payload, err := json.Marshal(struct {
+		AffectedPrincipalIDs []uuid.UUID `json:"affected_principal_ids"`
+	}{affected})
+	if err != nil {
+		t.Fatal(err)
+	}
+	env := gitscalekafka.EventEnvelope{
+		EventID:     eventID,
+		EventType:   eventType,
+		Payload:     payload,
+		OccurredAt:  time.Now().UTC(),
+		PublishedAt: time.Now().UTC(),
+	}
+	value, err := env.MarshalJSON()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return RawMessage{Topic: "gitscale.identity.events", Value: value, Offset: int64(time.Now().UnixNano())}
+}
+
+func newConsumer(t *testing.T, r *fakeReader, c cache.CacheStore) (*Consumer, *Metrics) {
+	t.Helper()
+	m := NewMetrics()
+	cons, err := New(Config{
+		Reader:  r,
+		Cache:   c,
+		Deduper: NewDeduper(c),
+		Metrics: m,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return cons, m
+}
+
+func runUntilDrained(t *testing.T, c *Consumer, r *fakeReader) {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- c.Run(ctx) }()
+
+	deadline := time.After(2 * time.Second)
+	for {
+		idx, committed := r.progress()
+		if idx >= len(r.msgs) && committed == len(r.msgs) {
+			cancel()
+			break
+		}
+		select {
+		case <-deadline:
+			cancel()
+			t.Fatalf("timed out waiting for consumer to drain (idx=%d committed=%d msgs=%d)",
+				idx, committed, len(r.msgs))
+		case <-time.After(5 * time.Millisecond):
+		}
+	}
+	if err := <-done; err != nil && !errors.Is(err, context.Canceled) {
+		t.Fatalf("Run returned: %v", err)
+	}
+}
+
+func TestConsumer_userDisabled_deletesIdentityKey(t *testing.T) {
+	pid := uuid.New()
+	r := &fakeReader{msgs: []RawMessage{envelope(t, EventUserDisabled, uuid.NewString(), []uuid.UUID{pid})}}
+	c := newMemoryCache()
+	cons, m := newConsumer(t, r, c)
+	runUntilDrained(t, cons, r)
+
+	wantKey := fmt.Sprintf(cache.IdentityKey, pid)
+	if len(c.deleteList()) != 1 || c.deleteList()[0] != wantKey {
+		t.Errorf("deletes=%v want [%s]", c.deleteList(), wantKey)
+	}
+	if got := m.InvalidationCount(EventUserDisabled, ResultOK); got != 1 {
+		t.Errorf("invalidations[user.disabled,ok]=%d want 1", got)
+	}
+}
+
+func TestConsumer_orgMemberRemoved_deletesEveryAffected(t *testing.T) {
+	user := uuid.New()
+	org := uuid.New()
+	r := &fakeReader{msgs: []RawMessage{envelope(t, EventOrgMemberRemoved, uuid.NewString(), []uuid.UUID{user, org})}}
+	c := newMemoryCache()
+	cons, _ := newConsumer(t, r, c)
+	runUntilDrained(t, cons, r)
+	if len(c.deleteList()) != 2 {
+		t.Errorf("deletes=%d want 2 (user + org)", len(c.deleteList()))
+	}
+}
+
+func TestConsumer_replayedEventID_dedupes(t *testing.T) {
+	pid := uuid.New()
+	id := uuid.NewString()
+	r := &fakeReader{msgs: []RawMessage{
+		envelope(t, EventUserDisabled, id, []uuid.UUID{pid}),
+		envelope(t, EventUserDisabled, id, []uuid.UUID{pid}), // same id
+	}}
+	c := newMemoryCache()
+	cons, m := newConsumer(t, r, c)
+	runUntilDrained(t, cons, r)
+	if len(c.deleteList()) != 1 {
+		t.Errorf("deletes=%d want 1 (dedupe)", len(c.deleteList()))
+	}
+	if got := m.InvalidationCount(EventUserDisabled, ResultAlreadyProcessed); got != 1 {
+		t.Errorf("already_processed counter=%d want 1", got)
+	}
+}
+
+func TestConsumer_unknownEventType_commitsAndCounts(t *testing.T) {
+	r := &fakeReader{msgs: []RawMessage{envelope(t, "user.unrecognised", uuid.NewString(), []uuid.UUID{uuid.New()})}}
+	c := newMemoryCache()
+	cons, m := newConsumer(t, r, c)
+	runUntilDrained(t, cons, r)
+	if len(c.deleteList()) != 0 {
+		t.Errorf("deletes=%d want 0 (unknown event type)", len(c.deleteList()))
+	}
+	if got := m.InvalidationCount("user.unrecognised", ResultUnknownEventType); got != 1 {
+		t.Errorf("unknown_event_type counter=%d want 1", got)
+	}
+}
+
+func TestConsumer_envelopeDecodeFailed_isPoison(t *testing.T) {
+	r := &fakeReader{msgs: []RawMessage{{Value: []byte("not-json")}}}
+	c := newMemoryCache()
+	cons, m := newConsumer(t, r, c)
+	runUntilDrained(t, cons, r)
+	if len(c.deleteList()) != 0 {
+		t.Errorf("deletes=%d want 0", len(c.deleteList()))
+	}
+	if got := m.InvalidationCount("", ResultEnvelopeDecode); got != 1 {
+		t.Errorf("envelope_decode counter=%d want 1", got)
+	}
+}
+
+func TestNew_rejectsNilCollaborators(t *testing.T) {
+	cases := []Config{
+		{Cache: newMemoryCache(), Deduper: NewDeduper(newMemoryCache()), Metrics: NewMetrics()},
+		{Reader: &fakeReader{}, Deduper: NewDeduper(newMemoryCache()), Metrics: NewMetrics()},
+		{Reader: &fakeReader{}, Cache: newMemoryCache(), Metrics: NewMetrics()},
+		{Reader: &fakeReader{}, Cache: newMemoryCache(), Deduper: NewDeduper(newMemoryCache())},
+	}
+	for i, cfg := range cases {
+		if _, err := New(cfg); err == nil {
+			t.Errorf("case %d: expected error from missing collaborator", i)
+		}
+	}
+}

--- a/plane/application/identity-cache-invalidator/dedupe.go
+++ b/plane/application/identity-cache-invalidator/dedupe.go
@@ -1,0 +1,58 @@
+package invalidator
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/gitscale-platform/gitscale/plane/data/cache"
+)
+
+// DedupeTTL must be ≥ Kafka retention for the topic so an event id seen at
+// the start of the retention window cannot be re-processed at the tail. The
+// gitscale.identity.events retention is 7d (plane/data/kafka/topics.yaml);
+// 24h here is a starting point — bump if retention is widened.
+const DedupeTTL = 24 * time.Hour
+
+// dedupeKey returns the cache key for a given Kafka event_id. Stored under
+// the existing identity cache namespace so a single Redis pod backs both
+// hot identity entries and the dedupe markers.
+func dedupeKey(eventID string) string {
+	return fmt.Sprintf("identity:invalidator:dedupe:%s", eventID)
+}
+
+// Deduper is the minimal interface used by the consumer for idempotency.
+// Production wiring is *cacheDeduper; tests inject a stub.
+type Deduper interface {
+	// Seen reports whether this eventID has been marked. Returns (false, err)
+	// only on backend failure; a missing key is (false, nil).
+	Seen(ctx context.Context, eventID string) (bool, error)
+	// Mark records eventID as processed with a fixed TTL. Idempotent.
+	Mark(ctx context.Context, eventID string) error
+}
+
+type cacheDeduper struct {
+	store cache.CacheStore
+}
+
+// NewDeduper returns a Deduper backed by the cache.CacheStore. The marker
+// payload is "1" — value content does not matter, only key presence.
+func NewDeduper(store cache.CacheStore) Deduper {
+	return &cacheDeduper{store: store}
+}
+
+func (d *cacheDeduper) Seen(ctx context.Context, eventID string) (bool, error) {
+	_, err := d.store.Get(ctx, dedupeKey(eventID))
+	if err == nil {
+		return true, nil
+	}
+	if errors.Is(err, cache.ErrNotFound) {
+		return false, nil
+	}
+	return false, err
+}
+
+func (d *cacheDeduper) Mark(ctx context.Context, eventID string) error {
+	return d.store.Set(ctx, dedupeKey(eventID), []byte{'1'}, DedupeTTL)
+}

--- a/plane/application/identity-cache-invalidator/doc.go
+++ b/plane/application/identity-cache-invalidator/doc.go
@@ -1,0 +1,11 @@
+// Package invalidator implements the identity-cache-invalidator consumer:
+// reads gitscale.identity.events from Kafka, dispatches by event_type, and
+// deletes the cached identity entry for every UUID listed in the payload's
+// affected_principal_ids[]. Idempotent on event_id via a Redis SET NX EX
+// dedupe key with TTL matching Kafka retention (ADR-008, ADR-009).
+//
+// Cross-plane import rules (CLAUDE.md): this is application-plane code; it
+// imports plane/data/cache and plane/data/kafka but never reaches into
+// plane/edge or plane/git internals. The producer is plane/application/identity
+// (#15-revocation, PR #64).
+package invalidator

--- a/plane/application/identity-cache-invalidator/handlers.go
+++ b/plane/application/identity-cache-invalidator/handlers.go
@@ -1,0 +1,55 @@
+package invalidator
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/gitscale-platform/gitscale/plane/data/kafka"
+	"github.com/google/uuid"
+)
+
+// EventTypes are the identity-domain event types the invalidator consumes.
+// Adding a new event_type requires only an entry here; the affected-principals
+// extraction shape is shared by every revocation event (#15 spec D6).
+const (
+	EventUserDisabled                = "user.disabled"
+	EventAgentRevoked                = "agent.revoked"
+	EventPrincipalPermissionsChanged = "principal.permissions_changed"
+	EventOrgMemberRemoved            = "org.member_removed"
+	// Reserved for future hard-delete flows; consumer accepts them today so
+	// that the day they appear, no consumer redeploy is required.
+	EventUserDeleted  = "user.deleted"
+	EventAgentDeleted = "agent.deleted"
+)
+
+// affectedPrincipalsHandler decodes the affected_principal_ids[] field
+// shared by every revocation event payload (#15 spec D6).
+type affectedPrincipalsHandler struct{}
+
+func (affectedPrincipalsHandler) Affected(env kafka.EventEnvelope) ([]uuid.UUID, error) {
+	var p struct {
+		AffectedPrincipalIDs []uuid.UUID `json:"affected_principal_ids"`
+	}
+	if err := json.Unmarshal(env.Payload, &p); err != nil {
+		return nil, fmt.Errorf("decode affected_principal_ids: %w", err)
+	}
+	return p.AffectedPrincipalIDs, nil
+}
+
+// EventHandler decodes a Kafka envelope and returns the principal UUIDs
+// whose cached identity should be invalidated.
+type EventHandler interface {
+	Affected(env kafka.EventEnvelope) ([]uuid.UUID, error)
+}
+
+// DefaultHandlers is the static dispatch table. Unknown event_types fall
+// through to a nil lookup so the consumer can record + commit them without
+// erroring (forwards-compat with future event types).
+var DefaultHandlers = map[string]EventHandler{
+	EventUserDisabled:                affectedPrincipalsHandler{},
+	EventAgentRevoked:                affectedPrincipalsHandler{},
+	EventPrincipalPermissionsChanged: affectedPrincipalsHandler{},
+	EventOrgMemberRemoved:            affectedPrincipalsHandler{},
+	EventUserDeleted:                 affectedPrincipalsHandler{},
+	EventAgentDeleted:                affectedPrincipalsHandler{},
+}

--- a/plane/application/identity-cache-invalidator/metrics.go
+++ b/plane/application/identity-cache-invalidator/metrics.go
@@ -1,0 +1,82 @@
+package invalidator
+
+import (
+	"sync"
+	"sync/atomic"
+)
+
+// Result labels for invalidations_total. Closed set; new entries surface as
+// "unknown_result" until the registry is updated, which is the desired loud
+// failure mode.
+const (
+	ResultOK               = "ok"
+	ResultAlreadyProcessed = "already_processed"
+	ResultUnknownEventType = "unknown_event_type"
+	ResultHandlerError     = "handler_error"
+	ResultCacheError       = "cache_error"
+	ResultEnvelopeDecode   = "envelope_decode_failed"
+)
+
+// Metrics is the Prometheus-shape registry used by the consumer. It is
+// intentionally minimal — a counter map keyed by (event_type, result) plus
+// an oldest-unprocessed gauge — to avoid pulling in the full Prometheus
+// client until the platform-wide registry rollout (separate epic). The
+// /metrics endpoint scraper queries this struct directly via Snapshot().
+type Metrics struct {
+	mu             sync.Mutex
+	invalidations  map[counterKey]uint64
+	dlq            map[counterKey]uint64
+	consumerLagSec atomic.Int64
+	oldestEventSec atomic.Int64
+}
+
+type counterKey struct {
+	EventType string
+	Label     string // result for invalidations, reason for dlq
+}
+
+func NewMetrics() *Metrics {
+	return &Metrics{
+		invalidations: make(map[counterKey]uint64),
+		dlq:           make(map[counterKey]uint64),
+	}
+}
+
+func (m *Metrics) IncInvalidation(eventType, result string) {
+	m.mu.Lock()
+	m.invalidations[counterKey{eventType, result}]++
+	m.mu.Unlock()
+}
+
+func (m *Metrics) IncDLQ(eventType, reason string) {
+	m.mu.Lock()
+	m.dlq[counterKey{eventType, reason}]++
+	m.mu.Unlock()
+}
+
+func (m *Metrics) SetConsumerLagSeconds(v int64)  { m.consumerLagSec.Store(v) }
+func (m *Metrics) SetOldestEventSeconds(v int64)  { m.oldestEventSec.Store(v) }
+
+// Snapshot returns a copy of the current counter map. Used by the metrics
+// HTTP handler and by tests.
+func (m *Metrics) Snapshot() (invalidations, dlq map[counterKey]uint64, consumerLag, oldest int64) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	inv := make(map[counterKey]uint64, len(m.invalidations))
+	for k, v := range m.invalidations {
+		inv[k] = v
+	}
+	d := make(map[counterKey]uint64, len(m.dlq))
+	for k, v := range m.dlq {
+		d[k] = v
+	}
+	return inv, d, m.consumerLagSec.Load(), m.oldestEventSec.Load()
+}
+
+// InvalidationCount returns the count for one (event_type, result) cell.
+// Test convenience.
+func (m *Metrics) InvalidationCount(eventType, result string) uint64 {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.invalidations[counterKey{eventType, result}]
+}

--- a/plane/application/identity-cache-invalidator/reader_kafka.go
+++ b/plane/application/identity-cache-invalidator/reader_kafka.go
@@ -1,0 +1,46 @@
+package invalidator
+
+import (
+	"context"
+
+	kafkago "github.com/segmentio/kafka-go"
+)
+
+// kafkaReaderAdapter adapts *kafka.Reader to the consumer's MessageReader
+// interface so the consumer package compiles without a hard dep on kafka-go.
+type kafkaReaderAdapter struct {
+	r *kafkago.Reader
+}
+
+// WrapKafkaReader returns a MessageReader backed by the given kafka.Reader.
+func WrapKafkaReader(r *kafkago.Reader) MessageReader { return &kafkaReaderAdapter{r: r} }
+
+func (a *kafkaReaderAdapter) FetchMessage(ctx context.Context) (RawMessage, error) {
+	m, err := a.r.FetchMessage(ctx)
+	if err != nil {
+		return RawMessage{}, err
+	}
+	return RawMessage{
+		Topic:     m.Topic,
+		Partition: m.Partition,
+		Offset:    m.Offset,
+		Key:       m.Key,
+		Value:     m.Value,
+	}, nil
+}
+
+func (a *kafkaReaderAdapter) CommitMessages(ctx context.Context, msgs ...RawMessage) error {
+	out := make([]kafkago.Message, 0, len(msgs))
+	for _, m := range msgs {
+		out = append(out, kafkago.Message{
+			Topic:     m.Topic,
+			Partition: m.Partition,
+			Offset:    m.Offset,
+			Key:       m.Key,
+			Value:     m.Value,
+		})
+	}
+	return a.r.CommitMessages(ctx, out...)
+}
+
+func (a *kafkaReaderAdapter) Close() error { return a.r.Close() }


### PR DESCRIPTION
## Summary

Identity-cache-invalidator consumer + cmd binary. Drains ``gitscale.identity.events`` from Kafka and deletes the cached identity entry for every UUID in the event's ``affected_principal_ids[]`` (spec D6). Idempotent on ``event_id`` via Redis ``SET … EX 24h``.

- ``plane/application/identity-cache-invalidator/``: consumer, handlers, dedupe, metrics, kafka-go adapter, env config.
- ``cmd/identity-cache-invalidator/main.go``: signal-trapped binary; SIGINT/SIGTERM → ctx cancel → reader Close.
- 6 unit-test cases — known event delete path, multi-affected, dedupe replay, unknown event_type, poison decode, nil-collaborator guards.

## ADR-impact

``conforming`` ADR-008 (idempotent on ``event_id``), ADR-009 (cache key follows ``IdentityKey`` pattern; namespaced via ``cache.WithNamespace``), ADR-017 (consumer holds the ``cache.CacheStore`` interface; no Redis driver leak).

## Producer

PR #64 (revocation methods + emitters) made this consumer non-trivial: the 5 revocation events all carry ``affected_principal_ids`` so this consumer can drive a single shared invalidation path. Without #64 this PR would be a no-op deploy.

## Deferred

Integration tests against testcontainers Redpanda + Redis are deferred to a follow-up issue. The Redpanda module is not yet in the dep graph; pulling it in alongside the consumer would expand review surface unnecessarily.

## Test plan

- [x] ``go build ./...`` exit 0
- [x] ``go vet ./...`` exit 0
- [x] ``go test -race ./plane/application/identity-cache-invalidator/...`` — all 6 cases pass, race-clean
- [x] ``make lint-determinism`` — clean
- [x] ``make lint-events`` — 8 schemas, 8 fixtures, all valid
- [x] ``make lint-md`` — 0 errors

## References

- Plan: ``docs/superpowers/plans/2026-05-06-plan-issue-27-identity-cache-invalidator.md``
- Producer: PR #64
- Spec: ``docs/superpowers/specs/2026-05-06-issue-15-identity-service-design.md`` D6

Closes #27.

🤖 Generated with [Claude Code](https://claude.com/claude-code)