### PR TITLE
[ADR] ADR-019 status: Proposed → Accepted

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -668,8 +668,8 @@ Consequences: <positive, negative, follow-ups>
 
 ### ADR-019: Adopted application-plane RPC as the only state-mutation path from the workflow plane
 
-- **Status:** Proposed
-- **Date:** 2026-05-06
+- **Status:** Accepted
+- **Date:** 2026-05-06 (proposed); 2026-05-07 (accepted after #33 workflow bootstrap and #18-rollover billing partition rollover both shipped against `appclient`)
 - **Context:** Temporal workflows in `plane/workflow/` need to mutate metadata-layer state — partition rollover, agent-session lifecycle, CI pipeline state transitions, future automated remediation. Two architectural paths exist: (1) direct path — workflow activities receive `plane/data/store.MetadataStore` and call `Transact` + `WriteOutbox` themselves; (2) app-plane RPC path — workflow activities receive a thin gRPC client (`plane/workflow/appclient/`) into the application plane's per-domain service, which performs the Tx + outbox write. The direct path is technically permitted by the existing interfaces; ADR-008 is preserved either way. The choice is not about transactional integrity; it is about where domain invariants live.
 - **Decision:**
 


### PR DESCRIPTION
## Summary

- Flip ADR-019 (workflow→app-plane RPC as the only state-mutation path from the workflow plane) from `Proposed` to `Accepted`.
- Records both proposed (2026-05-06) and accepted (2026-05-07) dates.

## ADR-impact

`amending` — ADR-019 status field only. No decision text, context, or consequences change. Per supervisor prompt §11, this flip is gated on #33 (workflow plane bootstrap) and at least one workflow ship against the `appclient` surface; both have merged:

- #33 Phase A (#56) + Phase B (#58) — workflow bootstrap.
- #18-rollover (#68) — billing partition rollover, first production workflow on `appclient`.

## Test plan

- [x] `docs/architecture.md` ADR-019 Status reads `Accepted`.
- [x] Date line records proposal and acceptance dates.
- [x] `make lint-md` clean.
- [x] No code changes.

Refs:
- Spec: `docs/superpowers/specs/2026-05-06-adr-019-workflow-app-plane-boundary.md`
- Supervisor prompt: `docs/superpowers/prompts/2026-05-06-supervisor-implementation.md`

Closes #70.

🤖 Generated with [Claude Code](https://claude.com/claude-code)