### PR TITLE
[Meta] Commit superpowers specs+plans and scope PR-closes-issue rule

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -50,7 +50,9 @@
       "Bash(gh issue view *)",
       "Bash(gh issue list *)",
 
-      "mcp__plugin_context7_context7__*"
+      "mcp__plugin_context7_context7__*",
+
+      "Bash(*ralph-loop*/scripts/*)"
     ]
   },
   "enabledPlugins": {

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,7 +75,7 @@ Avoid committing to these until the spike is resolved:
 
 Valid plane names: `edge`, `git`, `application`, `workflow`, `data`. Cross-cutting tooling (hooks, CI config, repo-wide docs) uses `meta` — e.g. `chore/meta-pre-commit-lint-hook`.
 
-Every merged PR must close at least one issue.
+Every merged `feat/`, `fix/`, `spike/`, or `adr/` PR must close at least one issue. `chore/` and `docs/` PRs may skip — the branch prefix encodes intent. A change is a chore only if it has no behaviour visible to users or operators (e.g. dependency bumps, gitignore tweaks, CI config, hook installs, repo-wide doc commits). If it moves a metric, alters an API surface, or touches an ADR, it is not a chore.
 
 ## CI linter rule
 

--- a/docs/superpowers/plans/2026-05-06-plan-issue-14-metadatastore-interfaces.md
+++ b/docs/superpowers/plans/2026-05-06-plan-issue-14-metadatastore-interfaces.md
@@ -1,0 +1,142 @@
+# Plan: #14 — MetadataStore + Tx interfaces
+
+**Date:** 2026-05-06
+**Issue:** #14
+**Spec:** none (issue body + execution-plan §13.1 amendments)
+**Branch:** `feat/data-store-interfaces`
+**Closes:** none directly; unblocks #35 + #15-stub
+**Pre-merge of:** none required (compiles standalone; integration test against existing `identity_outbox` from #19)
+
+## Pre-flight
+
+- `git fetch && git checkout main && git pull`
+- `git checkout -b feat/data-store-interfaces`
+- Confirm `plane/data/migrations/001_identity.sql` exists and `identity_outbox` is part of it.
+- Confirm `plane/data/cache/` package shape — mirror it for layout.
+
+## Step sequence
+
+### Step 1 — Domain enum + topic helper
+
+File: `plane/data/store/domain.go`
+
+```go
+package store
+
+type Domain string
+
+const (
+    DomainIdentity      Domain = "identity"
+    DomainRepositories  Domain = "repositories"
+    DomainCollaboration Domain = "collaboration"
+    DomainCI            Domain = "ci"
+    DomainBilling       Domain = "billing"
+)
+
+func (d Domain) Valid() bool { /* allowlist check */ }
+func (d Domain) OutboxTable() string // returns "<domain>_outbox"
+```
+
+Verify: `go vet ./plane/data/store/...` clean.
+
+### Step 2 — Interfaces
+
+File: `plane/data/store/metadata.go`
+
+- `MetadataStore` interface (`Transact`, `Identity()`, `Repositories()`).
+- `Tx` interface (`Identity()`, `Repositories()`, `WriteOutbox(ctx, Domain, aggregateType string, aggregateID uuid.UUID, eventType string, payload any) error`).
+- `IdentityReader` / `IdentityWriter` / `RepositoryReader` / `RepositoryWriter` interfaces with method bodies for currently-merged schema (per execution-plan §13.1: fill in #14, do NOT punt to #15).
+
+Methods to fill on `IdentityReader`: `GetUserByID`, `GetUserByEmail`, `GetAgentByID`, `GetAgentsByParentUser`, `LookupIdentityForCache`.
+
+Methods to fill on `IdentityWriter`: `InsertHumanUser`, `InsertAgentIdentity`, `SetAgentReputationScore`, `DisableUser`, `RevokeAgent`, `UpdateAgentPermissions`, `AddOrgMember`, `RemoveOrgMember`. (Bodies stay `errNotImplemented` for the revocation set since #15-revocation owns wiring; signatures land here so #15-stub can compile against the interface.)
+
+Methods on `RepositoryReader` / `RepositoryWriter`: `GetByID`, `GetBySlug`, `Insert`, `UpdatePermissions` — bodies `errNotImplemented` until repository service work begins.
+
+### Step 3 — Retryable error helper
+
+File: `plane/data/store/retryable.go`
+
+```go
+func IsRetryable(err error) bool // checks pgconn SQLState == "40001"
+```
+
+Tested with both pgx-wrapped and bare errors.
+
+### Step 4 — Postgres impl
+
+File: `plane/data/store/postgres/metadata.go`
+
+- `Store` struct over `*pgxpool.Pool`.
+- `Transact(ctx, fn)` — opens `BEGIN ISOLATION LEVEL SERIALIZABLE`; calls fn(tx); commits on nil error; rolls back on non-nil; surfaces `40001` to caller.
+- `WriteOutbox` — validates `domain.Valid()`, dispatches to `<domain>_outbox` via prepared INSERT.
+- Reader/writer impls that have schema (per Step 2) execute real SQL; revocation + repository writers return sentinel.
+
+File: `plane/data/store/postgres/identity_reader.go`, `identity_writer.go` — split for review hygiene.
+
+### Step 5 — Stub impl
+
+File: `plane/data/store/stub/metadata.go`
+
+- In-memory `Store` recording all inserts + outbox writes.
+- `Transact` simulates serializable: commit applies recorded ops; rollback discards.
+- Records exposed via `Recorded()` for test assertions.
+
+### Step 6 — Compliance hooks
+
+File: `plane/data/store/postgres/compliance_test.go` — empty placeholder; #35 fills.
+File: `plane/data/store/stub/compliance_test.go` — empty placeholder; #35 fills.
+
+### Step 7 — UUIDv7 generator
+
+File: `plane/data/store/eventid.go`
+
+```go
+func NewEventID() uuid.UUID // monotonic UUIDv7
+```
+
+Used by `WriteOutbox` for outbox row's `event_id` if caller doesn't supply one. Avoids collision risk under concurrent inserts (architect review).
+
+### Step 8 — Refactor `wiring.DomainConfig`
+
+File: `plane/data/outbox/wiring/wiring.go`
+
+- Replace string-typed `Domain` field with `store.Domain`.
+- `AllDomains` becomes `[]store.Domain` populated from store constants.
+
+Verify: `go build ./plane/data/outbox/...` clean (no caller drift).
+
+## Validation gates
+
+| Gate | Command | Pass |
+|---|---|---|
+| Build | `go build ./plane/data/store/... && go build ./...` | exit 0 |
+| Vet | `go vet ./plane/data/store/...` | exit 0 |
+| Unit | `go test -race ./plane/data/store/...` | pass |
+| Integration | `go test -tags integration -race ./plane/data/store/postgres/...` | pass — testcontainers PG, exercises `WriteOutbox` against real `identity_outbox` |
+| 40001 race | manual + integration test in `postgres_test.go` | second tx gets `40001` |
+| Lint | `golangci-lint run ./plane/data/store/...` | clean |
+
+## Acceptance checklist
+
+- [ ] `plane/data/store/{domain.go, metadata.go, retryable.go, eventid.go}` compile.
+- [ ] `plane/data/store/postgres/` implements `MetadataStore` against `*pgxpool.Pool`.
+- [ ] `plane/data/store/stub/` provides in-memory test double with `Recorded()` accessor.
+- [ ] `WriteOutbox(DomainIdentity, …)` writes into `identity_outbox`; rollback removes it.
+- [ ] `IsRetryable(err)` returns true for `40001` and false for everything else.
+- [ ] `wiring.DomainConfig` refactored to use `store.Domain`.
+- [ ] No `EventQueue` interface introduced.
+- [ ] Branch closes #14 in PR description; spec/execution-plan cross-links present.
+
+## Rollback
+
+Pure additions in a new package + a single typed-refactor in `wiring.DomainConfig`. If post-merge regression in outbox consumer, revert PR — `wiring.DomainConfig` field rename is the only call-site touched.
+
+## Risks
+
+| Risk | Mitigation |
+|---|---|
+| `pgxpool.Pool` import in `plane/data/store/postgres/` accidentally re-exported | only the postgres subpackage imports pgx; package boundary enforced by `gitscale-plane-boundary` skill |
+| Stub diverges from postgres on rollback semantics | both run the #35 compliance suite |
+| Domain enum refactor leaks pgx | `store.Domain` is a plain string-typed alias; no pgx dep |
+| 40001 race test flaky in CI | use `sync.WaitGroup` + chan to interleave; document expected outcome |

--- a/docs/superpowers/plans/2026-05-06-plan-issue-15-postgres.md
+++ b/docs/superpowers/plans/2026-05-06-plan-issue-15-postgres.md
@@ -1,0 +1,145 @@
+# Plan: #15-postgres — Identity service postgres impl
+
+**Date:** 2026-05-06
+**Issue:** #15 (postgres PR — second of three)
+**Spec:** `2026-05-06-issue-15-identity-service-design.md`
+**Branch:** `feat/application-identity-service-postgres`
+**Pre-merge of:** #14, #35, #15-stub
+**Blocks:** #15-revocation; closes #5 Phase 1 epic together with #14, #35, #15-stub
+
+## Pre-flight
+
+- Confirm #14, #35, #15-stub all merged on main.
+- `git fetch && git checkout main && git pull`
+- `git checkout -b feat/application-identity-service-postgres`
+- Verify postgres `MetadataStore` impl from #14 passes #35's compliance suite.
+
+## Step sequence
+
+### Step 1 — Postgres service
+
+File: `plane/application/identity/postgres_service.go`
+
+`postgresService` wraps a `store.MetadataStore`. Each method:
+
+```go
+func (s *postgresService) CreateUser(ctx context.Context, email, plaintextCred string) (*HumanUser, error) {
+    hash, err := s.hasher.Hash(plaintextCred)
+    if err != nil { return nil, err }
+
+    user := &HumanUser{
+        ID:             uuid.Must(uuid.NewV7()),
+        Email:          normalizeEmail(email),
+        CredentialHash: hash,
+        RateBucket:     "human_default",
+        CreatedAt:      time.Now().UTC(),
+    }
+
+    err = WithSerializableRetry(ctx, func() error {
+        return s.store.Transact(ctx, func(tx store.Tx) error {
+            if err := tx.Identity().InsertHumanUser(ctx, user); err != nil {
+                return err
+            }
+            return tx.WriteOutbox(ctx, store.DomainIdentity, "human_user", user.ID, EventUserCreated, userCreatedPayload(user))
+        })
+    })
+    if err != nil { return nil, err }
+    return user, nil
+}
+```
+
+Same pattern for `CreateAgent` (writes `agent_identities` + outbox). `SetAgentReputationScore` reads-then-writes inside the same Tx (single round trip).
+
+### Step 2 — JSON schemas
+
+Files:
+
+- `plane/data/events/identity/user.created.schema.json`
+- `plane/data/events/identity/agent.created.schema.json`
+- `plane/data/events/identity/agent.reputation_updated.schema.json`
+
+Each declares all fields from spec D5; `additionalProperties: false`; `_envelope_version: const 1`.
+
+### Step 3 — `lint-events` validation
+
+Run `make lint-events`; resolve any failures (key field, partition key, schema completeness).
+
+### Step 4 — Postgres-specific service tests
+
+File: `plane/application/identity/postgres_service_test.go`
+
+Same suite as `stub_service_test.go` but configured with postgres factory. Reuse `compliance.MetadataStoreFactory` from #35 to spin testcontainers + apply migrations. Tag with `//go:build integration`.
+
+### Step 5 — Integration test
+
+File: `plane/application/identity/integration_test.go`
+
+```go
+//go:build integration
+
+func TestCreateUser_atomicity(t *testing.T) {
+    pgStore, cleanup := newPostgresStore(t)
+    defer cleanup()
+    s := newPostgresService(pgStore, defaultHasher())
+
+    user, err := s.CreateUser(ctx, "alice@example.com", "S3cret!1234")
+    require.NoError(t, err)
+
+    // Source row exists
+    var got HumanUser
+    require.NoError(t, queryUserByID(pgStore.Pool(), user.ID, &got))
+    require.Equal(t, user.Email, got.Email)
+
+    // Outbox row exists with same UUIDv7-ish event_id and matching payload
+    var outboxCount int
+    require.NoError(t, pgStore.Pool().QueryRow(ctx,
+        "SELECT count(*) FROM identity.identity_outbox WHERE aggregate_id=$1 AND event_type=$2",
+        user.ID, EventUserCreated,
+    ).Scan(&outboxCount))
+    require.Equal(t, 1, outboxCount)
+}
+
+func TestCreateUser_rollback_removes_both(t *testing.T) { ... }
+func TestSetAgentReputationScore_under_contention_retries(t *testing.T) { ... }
+```
+
+### Step 6 — Wiring example
+
+File: `plane/application/identity/example_test.go`
+
+Documentation-grade example showing how a future `cmd/identity-service` will wire the postgres service together. No binary in this PR.
+
+## Validation gates
+
+| Gate | Command | Pass |
+|---|---|---|
+| Build | `go build ./...` | exit 0 |
+| Unit | `go test -race ./plane/application/identity/...` | pass |
+| Integration | `go test -tags integration -race ./plane/application/identity/...` | pass |
+| Event lint | `make lint-events` | pass |
+| Markdown lint | `make lint-md` | pass |
+| Coverage | review | postgres_service.go ≥ 75% |
+
+## Acceptance checklist
+
+- [ ] `postgresService` implements all non-revocation `Service` methods.
+- [ ] Each create method writes source row + outbox row in same `Transact`.
+- [ ] Integration test proves atomicity (rollback removes both).
+- [ ] Integration test proves 40001 retry success within 3 attempts under simulated contention.
+- [ ] All three event schemas validate against `lint-events`.
+- [ ] No stub references in postgres_service.go.
+- [ ] Closes #5 (in PR description, alongside #14, #35, #15-stub references).
+
+## Risks
+
+| Risk | Mitigation |
+|---|---|
+| Email normalization changes break existing rows in tests | normalize on input only; existing rows unchanged |
+| 40001 retry mishandled when outbox payload changes mid-retry | retry boundary is per-Tx; payload is recomputed on each attempt — already correct |
+| `lint-events` schema drift | schemas land in same PR with payload structs; CI gate catches drift |
+| Migration overlay (PG-only partitioning from #21) interacts oddly with serializable | partitions are hash-by-`repo_id`; identity tables are not partitioned; no interaction |
+| Race in `SetAgentReputationScore` reads stale row under serializable | retry helper handles `40001`; if non-retryable, propagates |
+
+## Rollback
+
+Revert undoes service code + schemas; nothing else depends on them yet (#15-revocation hasn't shipped). One-PR revert is safe.

--- a/docs/superpowers/plans/2026-05-06-plan-issue-15-revocation.md
+++ b/docs/superpowers/plans/2026-05-06-plan-issue-15-revocation.md
@@ -1,0 +1,188 @@
+# Plan: #15-revocation — Identity revocation methods + emitters + gRPC service
+
+**Date:** 2026-05-06
+**Issue:** #15 (revocation PR — third of three) + new "identity revocation methods" issue (file before this PR opens)
+**Spec:** `2026-05-06-issue-15-identity-service-design.md` (D6, D2 revocation set)
+**Branch:** `feat/application-identity-service-revocation`
+**Pre-merge of:** #15-postgres, #33 (for `appclient.IdentityClient` interface)
+**Blocks:** #27 (cache invalidator)
+
+## Pre-flight
+
+- Confirm #15-postgres + #33 merged on main.
+- File the new "identity revocation methods" issue first if not yet filed (gates this PR per execution-plan §13.6).
+- `git fetch && git checkout main && git pull`
+- `git checkout -b feat/application-identity-service-revocation`
+- Verify `plane/workflow/appclient/identity.go` exports the `IdentityClient` interface.
+
+## Step sequence
+
+### Step 1 — Revocation method impls
+
+File: `plane/application/identity/revocation.go`
+
+Methods (all serializable Tx, all emit outbox):
+
+```go
+DisableUser(ctx, id, reason) error
+RevokeAgent(ctx, id, reason) error
+UpdateAgentPermissions(ctx, id, scope) error
+AddOrgMember(ctx, orgID, userID, role) error
+RemoveOrgMember(ctx, orgID, userID) error
+```
+
+Each:
+
+1. Validates input.
+2. `WithSerializableRetry` wraps `store.Transact`.
+3. Inside Tx: read current state (for `affected_principal_ids[]` and old/new diff payload).
+4. Update via writer.
+5. Emit outbox row with payload per spec D6.
+
+`RemoveOrgMember` payload includes the removed user UUID in `affected_principal_ids`. `UpdateAgentPermissions` payload includes the agent UUID in `affected_principal_ids`.
+
+### Step 2 — `IdentityWriter` body fills
+
+File: `plane/data/store/postgres/identity_writer.go`
+
+Replace `errNotImplemented` stubs (left from #14) with real impls for: `DisableUser`, `RevokeAgent`, `UpdateAgentPermissions`, `AddOrgMember`, `RemoveOrgMember`.
+
+`DisableUser` sets a `disabled_at` column — schema currently has none. **Schema gap to resolve before this PR**: file a sub-issue to add `disabled_at TIMESTAMPTZ` to `human_users` and `revoked_at TIMESTAMPTZ` + `revoke_reason TEXT` to `agent_identities`. Migration `006_identity_disabled_columns.sql` lands in this PR with the schema additions.
+
+### Step 3 — Migration
+
+File: `plane/data/migrations/006_identity_disabled_columns.sql`
+
+```sql
+ALTER TABLE identity.human_users
+    ADD COLUMN disabled_at TIMESTAMPTZ,
+    ADD COLUMN disable_reason TEXT;
+
+ALTER TABLE identity.agent_identities
+    ADD COLUMN revoked_at TIMESTAMPTZ,
+    ADD COLUMN revoke_reason TEXT;
+
+CREATE INDEX idx_human_users_disabled_at ON identity.human_users(disabled_at) WHERE disabled_at IS NOT NULL;
+CREATE INDEX idx_agent_identities_revoked_at ON identity.agent_identities(revoked_at) WHERE revoked_at IS NOT NULL;
+
+-- updated_at bump trigger
+CREATE TRIGGER trg_human_users_updated_at BEFORE UPDATE ON identity.human_users
+    FOR EACH ROW EXECUTE FUNCTION identity.set_updated_at();
+
+CREATE TRIGGER trg_agent_identities_updated_at BEFORE UPDATE ON identity.agent_identities
+    FOR EACH ROW EXECUTE FUNCTION identity.set_updated_at();
+```
+
+(Trigger function added if not yet present from the schema-gap follow-up issue.)
+
+### Step 4 — Event schemas
+
+Files in `plane/data/events/identity/`:
+
+- `user.disabled.schema.json`
+- `agent.revoked.schema.json`
+- `principal.permissions_changed.schema.json`
+- `org.member_added.schema.json`
+- `org.member_removed.schema.json`
+
+All include `affected_principal_ids: array of uuid`. Required fields per spec D6.
+
+Run `make lint-events`.
+
+### Step 5 — gRPC proto
+
+File: `internal/proto/identity/v1/identity.proto`
+
+Service definition with all `Service` methods exposed as RPCs. Generate Go code:
+
+```bash
+buf generate # or protoc, depending on project tooling
+```
+
+Output: `internal/proto/identity/v1/identity.pb.go` + `identity_grpc.pb.go`.
+
+### Step 6 — gRPC server
+
+File: `cmd/identity-service/main.go`
+
+```go
+func main() {
+    cfg := loadConfig()
+    pool := openPostgres(cfg.PostgresURL)
+    pgStore := postgres.NewStore(pool)
+    hasher := identity.NewArgon2idHasher()
+    svc := identity.NewPostgresService(pgStore, hasher)
+
+    grpcSrv := grpc.NewServer(/* mTLS via SPIFFE ADR-010 */)
+    identityv1.RegisterIdentityServiceServer(grpcSrv, &grpcAdapter{svc: svc})
+
+    // signal handling, listen, serve.
+}
+```
+
+`grpcAdapter` translates between proto types and `Service` types.
+
+### Step 7 — `appclient.IdentityClient` impl
+
+File: `plane/workflow/appclient/identity_grpc.go`
+
+Implements the interface from #33 by wrapping a generated gRPC client. Workflow activities receive this concrete via DI.
+
+### Step 8 — Integration tests
+
+File: `plane/application/identity/integration_revocation_test.go`
+
+Each method: assert source-row mutation + outbox row in same Tx; assert payload shape matches schema.
+
+File: `cmd/identity-service/integration_test.go`
+
+Boots the gRPC server against testcontainers PG; uses `appclient.NewIdentityGRPC(addr)` to round-trip `DisableUser` end-to-end.
+
+### Step 9 — README
+
+File: `plane/application/identity/README.md`
+
+Documents:
+- Service shape.
+- ADR-019 routing rule (workflows call this service via gRPC).
+- Argon2id parameters.
+- Revocation event semantics + `affected_principal_ids[]` contract.
+
+## Validation gates
+
+| Gate | Command | Pass |
+|---|---|---|
+| Build | `go build ./...` | exit 0 |
+| Migrate | apply 006 against testcontainers PG | clean |
+| Unit | `go test -race ./plane/application/identity/...` | pass |
+| Integration | `go test -tags integration ./plane/application/identity/... ./cmd/identity-service/...` | pass |
+| Event lint | `make lint-events` | pass |
+| Proto | `buf lint && buf breaking --against '.git#branch=main'` | pass |
+| `appclient.IdentityClient` | unit test in `plane/workflow/appclient/...` against in-memory gRPC server | pass |
+
+## Acceptance checklist
+
+- [ ] All revocation methods implemented and emit outbox events with correct payloads.
+- [ ] Migration 006 applies cleanly; `disabled_at` / `revoked_at` columns in place.
+- [ ] `updated_at` triggers in place on `human_users` + `agent_identities`.
+- [ ] All 5 revocation event schemas validate against `lint-events`.
+- [ ] gRPC service compiles; mTLS configured via SPIFFE per ADR-010.
+- [ ] `cmd/identity-service` boots against docker-compose.
+- [ ] `appclient.IdentityClient` gRPC impl round-trips end-to-end.
+- [ ] PR description references ADR-019 + #15 spec + new revocation issue.
+- [ ] #27 unblocked.
+
+## Risks
+
+| Risk | Mitigation |
+|---|---|
+| Schema migration 006 conflicts with parallel work | rebase before merge; CI runs migrations on fresh DB |
+| `affected_principal_ids[]` payload missing for org events | schema enforces required; integration test asserts content |
+| gRPC mTLS not yet wired (SPIRE deployment) | start with insecure local credentials; gate prod deploy on SPIRE rollout — flagged in PR |
+| `revoke_reason` text grows unbounded | column is TEXT but limit caller via gRPC field validation (max 1024 chars) |
+| Trigger conflict with future `auto-update` libraries | trigger is plain SQL `BEFORE UPDATE`; standard pattern |
+| `appclient.IdentityClient` interface from #33 changed | ADR-019 fixes the contract; `IdentityClient` is interface, not concrete — drift caught at compile |
+
+## Rollback
+
+Migration 006 is additive only (new columns + triggers + indexes); rollback via `006_down.sql`. gRPC service can be turned off via deployment flag without breaking #15-postgres.

--- a/docs/superpowers/plans/2026-05-06-plan-issue-15-stub.md
+++ b/docs/superpowers/plans/2026-05-06-plan-issue-15-stub.md
@@ -1,0 +1,143 @@
+# Plan: #15-stub — Identity service interface + stub impl
+
+**Date:** 2026-05-06
+**Issue:** #15 (stub PR — first of three)
+**Spec:** `2026-05-06-issue-15-identity-service-design.md`
+**Branch:** `feat/application-identity-service-stub`
+**Pre-merge of:** #14
+**Blocks:** #15-postgres
+**Parallel-safe with:** #35
+
+## Pre-flight
+
+- Confirm #14 merged.
+- `git fetch && git checkout main && git pull`
+- `git checkout -b feat/application-identity-service-stub`
+- Verify `plane/data/store.MetadataStore` + `plane/data/store/stub` exist.
+
+## Step sequence
+
+### Step 1 — Models
+
+File: `plane/application/identity/models.go`
+
+`HumanUser`, `AgentIdentity` structs per spec D2. Field set matches `001_identity.sql` columns.
+
+### Step 2 — Event constants + payloads
+
+File: `plane/application/identity/events.go`
+
+Event-type constants: `EventUserCreated`, `EventAgentCreated`, `EventAgentReputationUpdated`, plus revocation set (constants only; no emitters yet).
+
+Payload structs per spec D5 + D6 with `EnvelopeVersion = 1`.
+
+### Step 3 — `CredentialHasher` interface + Argon2id default
+
+File: `plane/application/identity/credential.go`
+
+```go
+type CredentialHasher interface {
+    Hash(plaintext string) (string, error)
+    Verify(plaintext, hashed string) (ok, needsRehash bool)
+}
+
+type Argon2idHasher struct {
+    memoryKB    uint32 // default 64MB → 65536
+    iterations  uint32 // default 3
+    parallelism uint8  // default 2
+    saltLen     uint32 // 16
+    keyLen      uint32 // 32
+}
+```
+
+Constants pinned in code with comment citing OWASP 2026 baseline. Test vectors (round-trip hash + verify) in `credential_test.go`.
+
+### Step 4 — Service interface
+
+File: `plane/application/identity/service.go`
+
+Full interface per spec D2. All methods declared; revocation set marked `// implemented in #15-revocation` (returns sentinel in stub for now).
+
+### Step 5 — Retry helper
+
+File: `plane/application/identity/retry.go`
+
+```go
+func WithSerializableRetry(ctx context.Context, fn func() error) error {
+    const maxAttempts = 3
+    delay := 10 * time.Millisecond
+    for attempt := 0; attempt < maxAttempts; attempt++ {
+        if err := fn(); err == nil {
+            return nil
+        } else if !store.IsRetryable(err) {
+            return err
+        }
+        // jittered sleep
+    }
+    return ErrRetryExhausted
+}
+```
+
+### Step 6 — Stub service impl
+
+File: `plane/application/identity/stub_service.go`
+
+`stubService` wraps a `*stub.Store` from #14. All read methods consult the in-memory map. `CreateUser` / `CreateAgent` call `store.Transact` + `tx.WriteOutbox`. `SetAgentReputationScore` clamps + reads-current + writes-new + outbox in one Tx. Revocation methods return `ErrNotImplemented`.
+
+### Step 7 — Service-level tests
+
+File: `plane/application/identity/stub_service_test.go`
+
+Subtests per service method (excluding revocation):
+
+- `TestCreateUser_emitsUserCreated_inSameTx`
+- `TestCreateUser_rollbackOnInvalidEmail_removesOutbox`
+- `TestCreateUser_payloadCarriesMeteringFields`
+- `TestCreateAgent_emitsAgentCreated_withMeteringFields`
+- `TestCreateAgent_clampsInitialReputation`
+- `TestSetAgentReputationScore_clampsToZeroOne`
+- `TestSetAgentReputationScore_emitsDeltaPayload`
+- `TestGetUserByEmail_caseInsensitive`
+- `TestGetAgentsByParentUser_returnsAll`
+- `TestLookupIdentityForCache_returnsCacheEntry`
+- `TestCredentialHasher_roundTrip`
+- `TestWithSerializableRetry_succeedsWithin3`
+- `TestWithSerializableRetry_failsAfter3`
+
+Use `stub.Store.Recorded()` to assert outbox writes.
+
+### Step 8 — PR description
+
+Cross-link spec + execution plan + ADR-019 (governing). Note: `cmd/identity-service` ships in #15-revocation; this PR is library-only.
+
+## Validation gates
+
+| Gate | Command | Pass |
+|---|---|---|
+| Build | `go build ./plane/application/identity/... && go build ./...` | exit 0 |
+| Vet | `go vet ./plane/application/identity/...` | exit 0 |
+| Unit | `go test -race ./plane/application/identity/...` | all pass |
+| Coverage | manual review | ≥ 80% line coverage on stub_service.go |
+| Lint | `golangci-lint run ./plane/application/identity/...` | clean |
+
+## Acceptance checklist
+
+- [ ] All non-revocation Service methods implemented in stub.
+- [ ] All test cases listed in Step 7 green.
+- [ ] `Argon2idHasher` round-trip works; parameters pinned.
+- [ ] `WithSerializableRetry` correctly classifies retryable errors.
+- [ ] Outbox payloads carry metering fields per spec D5.
+- [ ] No imports outside the allowlist (spec D9).
+- [ ] `cmd/identity-service` NOT added (deferred to #15-revocation).
+
+## Risks
+
+| Risk | Mitigation |
+|---|---|
+| Stub semantics drift from postgres (revealed in #15-postgres) | both run service-level tests; #35 compliance covers `MetadataStore` invariants |
+| Argon2id parameters too aggressive for CI test runtime | `_test.go` uses lower params via internal constructor; production constants only via the default constructor |
+| Revocation method placeholders confuse callers | sentinel error message includes "available in #15-revocation" |
+
+## Rollback
+
+Pure addition under new package; no caller exists yet. Revert is one PR drop.

--- a/docs/superpowers/plans/2026-05-06-plan-issue-18-archive.md
+++ b/docs/superpowers/plans/2026-05-06-plan-issue-18-archive.md
@@ -1,0 +1,174 @@
+# Plan: #18-archive — Billing partition detach + Parquet archive
+
+**Date:** 2026-05-06
+**Issue:** #18 (archive arm)
+**Spec:** `2026-05-06-issue-34-billing-archival-tier-spike.md` (full archival decisions)
+**Branch:** `feat/workflow-billing-partition-archive`
+**Pre-merge of:** #33, #18-rollover, #34 (ADR-018), #15-revocation (for `appclient.IdentityClient` pattern — provides reference for `appclient.BillingClient`)
+**Blocks:** none
+
+## Pre-flight
+
+- Confirm ADR-018 merged.
+- Confirm `cmd/workflow-worker` running #18-rollover successfully for at least one cycle.
+- File `appclient.BillingClient` interface (mirrors identity pattern) — gates this PR if billing app-plane service does not yet exist; if absent, this PR is blocked on a "billing app-plane service" issue (out of scope here).
+- `git fetch && git checkout main && git pull`
+- `git checkout -b feat/workflow-billing-partition-archive`
+
+## Step sequence
+
+### Step 1 — Provision analytics-lake S3 bucket
+
+Out-of-band ops task (Terraform module — not in this PR but documented as a hard prereq):
+
+- Bucket `gitscale-analytics-${env}` with lifecycle policy per ADR-018.
+- IAM policy: workflow worker SPIFFE identity has write; analyst role has read; nobody else.
+- Glue Data Catalog database `gitscale_analytics` (or Hive metastore).
+- Vault transit engine `billing-archive` with platform KEK.
+
+PR description must reference the Terraform PR or be gated on it.
+
+### Step 2 — Detach activity
+
+File: `plane/workflow/billing/detach_activity.go`
+
+```go
+type DetachPartitionActivity struct {
+    store store.MetadataStore
+}
+
+func (a *DetachPartitionActivity) Execute(ctx context.Context, in DetachInput) error {
+    // ALTER TABLE billing.usage_events DETACH PARTITION billing.usage_events_YYYY_MM CONCURRENTLY
+    return a.store.Transact(ctx, func(tx store.Tx) error {
+        return tx.Exec(ctx, fmt.Sprintf(
+            "ALTER TABLE billing.usage_events DETACH PARTITION billing.usage_events_%04d_%02d CONCURRENTLY",
+            in.Year, in.Month,
+        ))
+    })
+}
+```
+
+### Step 3 — Stream-to-Parquet activity
+
+File: `plane/workflow/billing/parquet_export_activity.go`
+
+```go
+import "github.com/parquet-go/parquet-go"
+import vault "github.com/hashicorp/vault/api"
+import s3 "github.com/aws/aws-sdk-go-v2/service/s3"
+
+type ParquetExportActivity struct {
+    store     store.MetadataStore
+    s3Client  *s3.Client
+    vault     *vault.Client
+    kekName   string
+    bucket    string
+}
+
+func (a *ParquetExportActivity) Execute(ctx context.Context, in ExportInput) (ExportOutput, error) {
+    // 1. Derive DEK from Vault: HKDF(platform_master, year-month)
+    // 2. Open detached partition for read.
+    // 3. Stream rows in batches of 10k → Parquet writer (zstd) → encrypt with DEK → S3 multipart upload.
+    // 4. Compute SHA-256 hash during stream.
+    // 5. Upload .checksum.sha256 + .manifest.json siblings.
+    // 6. Return row count + bytes written for outbox event.
+}
+```
+
+Path: `s3://gitscale-analytics-${env}/billing/usage_events/year=YYYY/month=MM/usage_events_YYYY_MM.parquet`.
+
+### Step 4 — Glue catalog register activity
+
+File: `plane/workflow/billing/glue_register_activity.go`
+
+Calls Glue API to add the partition pointer to the `gitscale_analytics.usage_events` table. Idempotent.
+
+### Step 5 — Drop detached partition activity
+
+File: `plane/workflow/billing/drop_detached_activity.go`
+
+```go
+DROP TABLE billing.usage_events_YYYY_MM
+```
+
+Only runs if upload + manifest + catalog register all succeeded.
+
+### Step 6 — Emit `billing.partition_archived` event
+
+Per ADR-019: route via `appclient.BillingClient.RecordPartitionArchived(...)`. The billing app-plane service writes the outbox row.
+
+### Step 7 — Archive workflow
+
+File: `plane/workflow/billing/archive_workflow.go`
+
+```go
+func PartitionArchiveWorkflow(ctx workflow.Context, in ArchiveInput) error {
+    // Activity 1: Detach
+    // Activity 2: Stream to Parquet (long-running; heartbeat)
+    // Activity 3: Register in Glue
+    // Activity 4: Emit outbox via appclient.BillingClient
+    // Activity 5: Drop detached PG partition
+    // Compensation: if step 5 fails after steps 1-4 succeeded → log + page; data exists in both places, no loss.
+}
+```
+
+### Step 8 — Schedule
+
+Monthly schedule: identifies the partition older than 18 months from `RunTime`; runs the archive workflow for it.
+
+### Step 9 — Tests
+
+- Unit tests for each activity using mocks (S3, Vault, MetadataStore stubs).
+- Integration test using `localstack` for S3 + testcontainers PG. Verifies:
+  - Partition detached.
+  - Parquet file uploaded with correct schema, encrypted.
+  - Manifest + checksum present.
+  - Glue register succeeded (against `localstack` Glue).
+  - Outbox event emitted.
+  - PG partition dropped.
+
+### Step 10 — Restore stub
+
+File: `plane/workflow/billing/restore_partition_workflow.go`
+
+Out-of-scope for this PR per ADR-018. Add a TODO doc.go comment + open a follow-up issue.
+
+## Validation gates
+
+| Gate | Command | Pass |
+|---|---|---|
+| Build | `go build ./...` | exit 0 |
+| Lint determinism | `make lint-determinism` | clean |
+| Unit | `go test -race ./plane/workflow/billing/...` | pass |
+| Integration | `go test -tags integration -race ./plane/workflow/billing/...` | pass against localstack |
+| Manual e2e | run against staging analytics-lake bucket | partition archived, Glue catalog updated, outbox event observed |
+
+## Acceptance checklist
+
+- [ ] All 5 activities implemented and idempotent.
+- [ ] Parquet file uses zstd + encrypted with month-keyed DEK.
+- [ ] `.manifest.json` records row count, schema version, KEK version, source partition name.
+- [ ] `.checksum.sha256` written and verifiable.
+- [ ] Glue catalog updated atomically with archive.
+- [ ] Outbox event `billing.partition_archived` emitted via `appclient.BillingClient` (ADR-019 routing).
+- [ ] PG partition dropped only after all upstream success.
+- [ ] Workflow heartbeats during long Parquet write (>5min).
+- [ ] PR cross-links ADR-018 + ADR-019 + spec.
+- [ ] `RestorePartition` follow-up issue filed.
+
+## Risks
+
+| Risk | Mitigation |
+|---|---|
+| Parquet writer exhausts memory on 200GB partitions | streaming row batches; never load full partition into memory |
+| KEK rotation mid-archive | manifest captures `kek_version`; restore uses recorded version |
+| S3 multipart upload partial failure | parquet-go writer + S3 SDK handle retries; manifest is final step |
+| Glue catalog write fails after Parquet upload | activity is idempotent on rerun; "dark" partition state is recoverable |
+| Drop detached partition fails after archive | logs + page; data redundant, not lost |
+| Vault unavailability blocks DEK derivation | activity retries with backoff; workflow surface this as a paging-grade alert after N attempts |
+| Localstack-Glue divergence from real AWS | manual e2e against staging is mandatory; localstack test catches code paths only |
+| Per-month DEK destruction post-7y not yet implemented | track as separate retention-enforcer follow-up workflow |
+
+## Rollback
+
+If a Parquet upload corrupts data, the PG partition is still detached but present (drop activity is gated on success). Manual remediation = re-attach the partition (`ALTER TABLE … ATTACH PARTITION`) — no data loss. Document this runbook in PR.

--- a/docs/superpowers/plans/2026-05-06-plan-issue-18-rollover.md
+++ b/docs/superpowers/plans/2026-05-06-plan-issue-18-rollover.md
@@ -1,0 +1,188 @@
+# Plan: #18-rollover — Billing partition rollover (rollover arm only)
+
+**Date:** 2026-05-06
+**Issue:** #18 (split — rollover arm; archive arm tracked under #18-archive)
+**Spec:** `2026-05-06-issue-34-billing-archival-tier-spike.md` (archive context only); `2026-05-06-issue-33-workflow-bootstrap-design.md` D6 (Schedule API)
+**Branch:** `feat/workflow-billing-partition-rollover`
+**Pre-merge of:** #33
+**Blocks:** none directly; addresses calendar bomb at 2027-05 partition gap
+
+## Pre-flight
+
+- Confirm #33 merged on main.
+- `git fetch && git checkout main && git pull`
+- `git checkout -b feat/workflow-billing-partition-rollover`
+- Verify `005_billing.sql` exists and `usage_events` is `PARTITION BY RANGE(ts)` with 12 monthly partitions.
+
+## Step sequence
+
+### Step 1 — Workflow definition
+
+File: `plane/workflow/billing/partition_rollover_workflow.go`
+
+```go
+func PartitionRolloverWorkflow(ctx workflow.Context, input PartitionRolloverInput) error {
+    ao := workflow.ActivityOptions{
+        StartToCloseTimeout: 5 * time.Minute,
+        RetryPolicy:         workflow.DefaultRetryPolicy(),
+    }
+    ctx = workflow.WithActivityOptions(ctx, ao)
+
+    target := nextMonthFrom(input.RunTime) // computed deterministically
+    return workflow.ExecuteActivity(ctx, CreatePartitionActivity, CreatePartitionInput{
+        Year:  target.Year,
+        Month: target.Month,
+    }).Get(ctx, nil)
+}
+```
+
+`nextMonthFrom` is a pure function; deterministic. `input.RunTime` comes from the schedule firing.
+
+### Step 2 — `CreatePartition` activity
+
+File: `plane/workflow/billing/create_partition_activity.go`
+
+```go
+type CreatePartitionInput struct {
+    Year  int
+    Month int
+}
+
+type CreatePartitionActivity struct {
+    store store.MetadataStore // direct import permitted (read-only/DDL exception per ADR-019)
+}
+
+func (a *CreatePartitionActivity) Execute(ctx context.Context, in CreatePartitionInput) error {
+    return a.store.Transact(ctx, func(tx store.Tx) error {
+        // Advisory lock keyed on (table, year, month) to serialize concurrent retries.
+        if err := tx.AdvisoryLock(ctx, partitionLockKey(in.Year, in.Month)); err != nil {
+            return err
+        }
+
+        startDate := fmt.Sprintf("%04d-%02d-01", in.Year, in.Month)
+        endDate := nextMonth(startDate)
+        tableName := fmt.Sprintf("billing.usage_events_%04d_%02d", in.Year, in.Month)
+
+        ddl := fmt.Sprintf(`
+            CREATE TABLE IF NOT EXISTS %s
+            PARTITION OF billing.usage_events
+            FOR VALUES FROM ('%s') TO ('%s')
+        `, tableName, startDate, endDate)
+
+        return tx.Exec(ctx, ddl)
+    })
+}
+```
+
+`store.Tx.AdvisoryLock` and `store.Tx.Exec` need to be added to the `Tx` interface in #14 — file as a small follow-up issue if not already present.
+
+### Step 3 — Bundle
+
+File: `plane/workflow/billing/bundle.go`
+
+```go
+func Bundle(activity *CreatePartitionActivity) workflow.Bundle {
+    return workflow.Bundle{
+        TaskQueue: workflow.QueueBillingMaintenance,
+        Workflows: []any{PartitionRolloverWorkflow},
+        Activities: []any{activity.Execute},
+    }
+}
+```
+
+### Step 4 — Wire into worker
+
+File: `cmd/workflow-worker/main.go`
+
+- Construct `CreatePartitionActivity` with the `MetadataStore`.
+- Apply `billing.Bundle(...)` on the billing-maintenance worker.
+
+### Step 5 — Temporal Schedule
+
+File: `cmd/workflow-worker/schedules.go` (new)
+
+On worker start (or in a separate `cmd/workflow-scheduler` if reviewer prefers), call:
+
+```go
+workflow.EnsureSchedule(ctx, client, workflow.ScheduleSpec{
+    ID:           "billing-partition-rollover",
+    CronSchedule: "0 12 24 * *", // 12:00 UTC on the 24th of each month — 7 days before EoM
+    WorkflowID:   "billing-partition-rollover-{year}-{month}",
+    Workflow:     PartitionRolloverWorkflow,
+})
+```
+
+`EnsureSchedule` is idempotent; safe across worker restarts.
+
+### Step 6 — Tests
+
+File: `plane/workflow/billing/partition_rollover_workflow_test.go`
+
+Uses `testsuite.WorkflowTestSuite` (time-skipping). Verifies:
+
+- Workflow calls `CreatePartitionActivity` with correct year/month.
+- `nextMonthFrom` boundary correctness (December → next January, year boundary).
+
+File: `plane/workflow/billing/create_partition_activity_test.go`
+
+Unit test against stub `MetadataStore` — asserts DDL string.
+
+File: `plane/workflow/billing/integration_test.go`
+
+```go
+//go:build integration
+
+func TestCreatePartition_idempotent(t *testing.T) {
+    // run activity twice with same input → no error, single partition exists
+}
+
+func TestCreatePartition_advisory_lock_serializes_retries(t *testing.T) {
+    // two goroutines, same year/month → one creates, one is no-op; no error
+}
+
+func TestRollover_endToEnd(t *testing.T) {
+    // execute workflow with input.RunTime = 2027-04-24
+    // assert partition usage_events_2027_05 exists after run
+}
+```
+
+### Step 7 — Determinism lint check
+
+Verify the workflow file passes `make lint-determinism`. `nextMonthFrom` uses no `time.Now()`; takes `RunTime` from input (deterministic).
+
+## Validation gates
+
+| Gate | Command | Pass |
+|---|---|---|
+| Build | `go build ./...` | exit 0 |
+| Determinism | `make lint-determinism` | clean |
+| Unit | `go test -race ./plane/workflow/billing/...` | pass |
+| Integration | `go test -tags integration -race ./plane/workflow/billing/...` | all 3 cases pass |
+| Schedule register | manual: start worker, run `tctl schedule list -n gitscale-dev` | shows `billing-partition-rollover` |
+| Workflow execution | manual: trigger via tctl with `RunTime=2027-04-24` | partition `usage_events_2027_05` created |
+
+## Acceptance checklist
+
+- [ ] `PartitionRolloverWorkflow` deterministic; passes lint.
+- [ ] `CreatePartitionActivity` idempotent under retry (advisory lock + IF NOT EXISTS).
+- [ ] Bundle registered on `billing-maintenance` queue.
+- [ ] Schedule registered with monthly cadence (24th 12:00 UTC).
+- [ ] All test cases green.
+- [ ] PR description cross-links spec + ADR-019 (DDL exception clause) + execution plan.
+- [ ] PR closes "rollover arm" of #18; #18-archive remains open against #34 ADR.
+- [ ] 2027-05 partition gap closed before May 2027.
+
+## Risks
+
+| Risk | Mitigation |
+|---|---|
+| Schedule fires twice (Temporal restart bug) | activity is idempotent (advisory lock + IF NOT EXISTS); retries are no-op |
+| `nextMonthFrom` off-by-one at year boundary | unit test covers Dec→Jan, leap-year Feb |
+| `tx.Exec` and `tx.AdvisoryLock` not in `Tx` interface | file follow-up issue against #14; if blocking, add minimal extension here |
+| DDL inside Tx blocks concurrent OLTP | `CREATE TABLE … PARTITION OF` takes a brief lock on the parent; runs in seconds for an empty partition; schedule fires at low-traffic 12:00 UTC on the 24th |
+| Schedule API not stable in chosen SDK version | tested in #33; version pinned |
+| Operator forgets to set `TEMPORAL_NAMESPACE=gitscale-prod` in prod | worker fails fast per #33 D1 |
+
+## Rollback
+
+DDL is purely additive (new partition tables). Drop the partition manually if rolled back; no data loss because workflow runs ahead-of-time, not against existing data.

--- a/docs/superpowers/plans/2026-05-06-plan-issue-27-identity-cache-invalidator.md
+++ b/docs/superpowers/plans/2026-05-06-plan-issue-27-identity-cache-invalidator.md
@@ -1,0 +1,192 @@
+# Plan: #27 — Identity cache invalidator consumer
+
+**Date:** 2026-05-06
+**Issue:** #27
+**Spec:** none (issue body + execution-plan §13.2 + #15 spec D6)
+**Branch:** `feat/application-identity-cache-invalidator`
+**Pre-merge of:** #15-revocation (without it, no producer for the invalidating events; consumer would be a no-op)
+**Blocks:** none
+
+## Pre-flight
+
+- Confirm #15-revocation merged AND emitting at least one revocation event in staging.
+- `git fetch && git checkout main && git pull`
+- `git checkout -b feat/application-identity-cache-invalidator`
+- Verify `plane/data/cache/identity.go::IdentityKey` exists and `gitscale.identity.events` topic is configured.
+
+## Step sequence
+
+### Step 1 — Consumer service structure
+
+File: `plane/application/identity-cache-invalidator/main.go`
+
+```go
+package main
+
+func main() {
+    cfg := loadConfig()
+    redisClient := openRedis(cfg.RedisURL, cfg.RedisUseCluster)
+    cacheStore := cache.NewRedisStore(redisClient).WithNamespace(cfg.Env)
+    consumer := newConsumer(cacheStore, cfg.KafkaBootstrap)
+    consumer.Run(signalContext())
+}
+```
+
+### Step 2 — Consumer impl
+
+File: `plane/application/identity-cache-invalidator/consumer.go`
+
+```go
+type consumer struct {
+    cache    cache.Store
+    kafka    *kgo.Client // franz-go (matches outbox consumer's Kafka client)
+    deduper  *redisDedupe
+    metrics  *metricRegistry
+}
+
+func (c *consumer) processMessage(ctx context.Context, msg *kgo.Record) error {
+    var env kafka.EventEnvelope
+    if err := json.Unmarshal(msg.Value, &env); err != nil {
+        return c.routeToDLQ(msg, "envelope_decode_failed")
+    }
+
+    // Idempotency check
+    if seen, _ := c.deduper.Seen(ctx, env.EventID); seen {
+        c.metrics.invalidations.WithLabelValues(env.EventType, "already_processed").Inc()
+        return nil
+    }
+
+    handler := c.eventHandlers[env.EventType]
+    if handler == nil {
+        c.metrics.invalidations.WithLabelValues(env.EventType, "unknown_event_type").Inc()
+        return nil // not for us; commit
+    }
+
+    affected, err := handler(env)
+    if err != nil {
+        c.metrics.invalidations.WithLabelValues(env.EventType, "handler_error").Inc()
+        return err
+    }
+
+    for _, principalID := range affected {
+        if err := c.cache.Delete(ctx, fmt.Sprintf(cache.IdentityKey, principalID)); err != nil {
+            c.metrics.invalidations.WithLabelValues(env.EventType, "cache_error").Inc()
+            return err
+        }
+    }
+
+    c.metrics.invalidations.WithLabelValues(env.EventType, "ok").Inc()
+    return c.deduper.Mark(ctx, env.EventID)
+}
+```
+
+### Step 3 — Event handlers
+
+File: `plane/application/identity-cache-invalidator/handlers.go`
+
+Registry mapping event types to extractors of `affected_principal_ids[]`:
+
+```go
+var eventHandlers = map[string]handler{
+    "user.disabled":                payloadAffectedPrincipals,
+    "user.deleted":                 payloadAffectedPrincipals,
+    "agent.revoked":                payloadAffectedPrincipals,
+    "agent.deleted":                payloadAffectedPrincipals,
+    "org.member_removed":           payloadAffectedPrincipals,
+    "principal.permissions_changed": payloadAffectedPrincipals,
+}
+
+func payloadAffectedPrincipals(env kafka.EventEnvelope) ([]uuid.UUID, error) {
+    var p struct {
+        AffectedPrincipalIDs []uuid.UUID `json:"affected_principal_ids"`
+    }
+    if err := json.Unmarshal(env.Payload, &p); err != nil {
+        return nil, err
+    }
+    return p.AffectedPrincipalIDs, nil
+}
+```
+
+### Step 4 — Dedupe via Redis SET
+
+File: `plane/application/identity-cache-invalidator/dedupe.go`
+
+`SET event_id 1 NX EX 86400` — TTL 24h matches Kafka retention.
+
+### Step 5 — Metrics
+
+File: `plane/application/identity-cache-invalidator/metrics.go`
+
+Per execution-plan §13.2 + outbox `metrics.go` convention:
+
+```
+identity_invalidations_total{event_type, result}
+identity_invalidator_dlq_total{event_type, reason}
+identity_invalidator_consumer_lag_seconds
+identity_invalidator_oldest_unprocessed_seconds
+```
+
+### Step 6 — Kafka consumer config
+
+File: `plane/application/identity-cache-invalidator/config.go`
+
+| Env | Default | Purpose |
+|---|---|---|
+| `KAFKA_BOOTSTRAP_SERVERS` | (required) | |
+| `REDIS_URL` | (required) | rediss:// in prod |
+| `REDIS_USE_CLUSTER` | `true` (prod) / `false` (dev) | |
+| `IDENTITY_INVALIDATOR_GROUP` | `gitscale.identity-cache-invalidator` | |
+| `KAFKA_AUTO_OFFSET_RESET` | `earliest` (per #12 spec D7) | |
+
+### Step 7 — Tests
+
+Files:
+
+- `plane/application/identity-cache-invalidator/consumer_test.go` — unit tests with stub `cache.Store` and mock Kafka producer.
+  - Sends `user.disabled` → assert `cache.Delete(IdentityKey<user_id>)` called.
+  - Sends `org.member_removed` with multiple `affected_principal_ids[]` → assert all deleted.
+  - Replays same `event_id` → assert delete called once (dedupe).
+  - Sends unknown event type → assert no delete + counter incremented.
+- `plane/application/identity-cache-invalidator/integration_test.go` — testcontainers Redpanda + Redis.
+  - Produces `user.disabled` event → asserts cache key deleted.
+
+### Step 8 — Dockerfile + helm chart entry (optional, scope decision)
+
+If project ships per-service Dockerfiles, add `cmd/identity-cache-invalidator/Dockerfile`. Otherwise leave to deployment PR.
+
+## Validation gates
+
+| Gate | Command | Pass |
+|---|---|---|
+| Build | `go build ./...` | exit 0 |
+| Unit | `go test -race ./plane/application/identity-cache-invalidator/...` | pass |
+| Integration | `go test -tags integration -race ./plane/application/identity-cache-invalidator/...` | pass |
+| Manual e2e | trigger `RevokeAgent` via `cmd/identity-service`; `redis-cli GET identity:<uuid>` | returns nil after event consumed |
+| Lag metric | observe metric during integration test | drops to 0 after consumer catches up |
+
+## Acceptance checklist
+
+- [ ] Consumer subscribes to `gitscale.identity.events` with group `gitscale.identity-cache-invalidator`.
+- [ ] Handles all 6 event types listed in Step 3.
+- [ ] Iterates `affected_principal_ids[]` (not `aggregate_id`) — per #15 spec D6.
+- [ ] Idempotent on `event_id` via Redis dedupe SET.
+- [ ] All 4 metrics emitted with `result` label set.
+- [ ] `auto.offset.reset=earliest`.
+- [ ] PR description cross-links #15-revocation as the producer.
+- [ ] Integration test demonstrates real round-trip (Redpanda + Redis).
+- [ ] PR closes #27.
+
+## Risks
+
+| Risk | Mitigation |
+|---|---|
+| Consumer lags behind during cold start | `auto.offset.reset=earliest` + bounded backlog in metrics; alert if lag > 60s |
+| `affected_principal_ids[]` missing from old payloads | schema is mandatory in #15; integration test produces real envelope from #15 emitter |
+| Dedupe collisions across event types | `event_id` is UUIDv7 globally unique per #14 |
+| Redis cluster split-brain causes double-delete | delete is idempotent; no harm |
+| Consumer crashes after DEL but before dedupe-mark | delete + mark are independent; replay re-deletes (idempotent), then re-marks |
+| Revocation events flood the topic during mass cleanup | consumer batches 100; per-message handler is O(deletes); metrics track throughput |
+
+## Rollback
+
+Stand-alone consumer; no other code path depends on it. Revert is a single PR drop; cached identities continue to expire by TTL (60s) without it — same behaviour as before #27 shipped.

--- a/docs/superpowers/plans/2026-05-06-plan-issue-33-workflow-bootstrap.md
+++ b/docs/superpowers/plans/2026-05-06-plan-issue-33-workflow-bootstrap.md
@@ -1,0 +1,184 @@
+# Plan: #33 — Workflow plane bootstrap
+
+**Date:** 2026-05-06
+**Issue:** #33
+**Spec:** `2026-05-06-issue-33-workflow-bootstrap-design.md`
+**Branch:** `feat/workflow-plane-bootstrap`
+**Pre-merge of:** ADR-019 (`adr/workflow-app-plane-boundary`)
+**Blocks:** #18 (rollover + archive), all future workflow PRs
+
+## Pre-flight
+
+- Confirm ADR-019 merged in `docs/architecture.md §8`.
+- `git fetch && git checkout main && git pull`
+- `git checkout -b feat/workflow-plane-bootstrap`
+- Add Temporal dev server to `docker-compose.yml` (port 7233).
+
+## Step sequence — Phase A (no Temporal deps)
+
+### Step A1 — Queue constants
+
+File: `plane/workflow/queues.go` per spec D2.
+
+### Step A2 — Bundle registry
+
+File: `plane/workflow/registry.go` per spec D4.
+
+### Step A3 — Retry policy helper
+
+File: `plane/workflow/retrypolicy.go` per spec D9.
+
+### Step A4 — Continue-as-new helper
+
+File: `plane/workflow/continueasnew.go` per spec D11.
+
+### Step A5 — Determinism rules + lint script
+
+Files:
+
+- `plane/workflow/lint/determinism-rules.txt` (regex per line, # for comments)
+- `plane/workflow/lint/lint-determinism.sh` (reads rules, greps `plane/workflow/**/workflow*.go` excluding activity files)
+- `plane/workflow/lint/testdata/bad/forbidden_time_now.go`
+- `plane/workflow/lint/testdata/bad/forbidden_uuid_new.go`
+- `plane/workflow/lint/testdata/bad/forbidden_go_routine.go`
+- `plane/workflow/lint/testdata/good/clean_workflow.go`
+
+Initial rules per spec D5.
+
+### Step A6 — Makefile + CI
+
+File edits:
+
+- `Makefile` — add `lint-determinism` target.
+- `.github/workflows/go.yml` — add `make lint-determinism` step.
+
+Verify: `make lint-determinism` exits 1 on bad fixtures, 0 on good.
+
+## Step sequence — Phase B (Temporal worker)
+
+### Step B1 — Module deps
+
+```bash
+go get go.temporal.io/sdk@latest
+go get go.temporal.io/sdk/contrib/opentelemetry@latest
+```
+
+### Step B2 — Worker entrypoint
+
+File: `cmd/workflow-worker/main.go`
+
+- Loads `TEMPORAL_NAMESPACE`, `TEMPORAL_HOST`, `OTEL_EXPORTER_OTLP_ENDPOINT`, worker tunables.
+- Builds Temporal client with OTel interceptor (per spec D7).
+- Constructs worker on `QueueBillingMaintenance` initially.
+- Applies `canary.Bundle()` (Phase D) once it exists.
+- SIGTERM trap → `worker.Stop()` with `WORKER_STOP_TIMEOUT`.
+
+### Step B3 — Schedule helper
+
+File: `plane/workflow/schedule.go` per spec D6 — `EnsureSchedule` idempotent.
+
+### Step B4 — Env + compose
+
+Files:
+
+- `.env.example` — add `TEMPORAL_NAMESPACE=gitscale-dev`, `TEMPORAL_HOST=localhost:7233`, etc.
+- `docker-compose.yml` — add Temporal dev server service.
+
+## Step sequence — Phase C (appclient interface)
+
+### Step C1 — IdentityClient interface
+
+File: `plane/workflow/appclient/identity.go`
+
+```go
+package appclient
+
+type IdentityClient interface {
+    DisableUser(ctx context.Context, id uuid.UUID, reason string) error
+    RevokeAgent(ctx context.Context, id uuid.UUID, reason string) error
+    GetUser(ctx context.Context, id uuid.UUID) (*identity.HumanUser, error)
+    // ... other methods needed by initial workflows
+}
+```
+
+Stub impl: returns `errNotImplemented`. gRPC impl lands in #15-revocation.
+
+File: `plane/workflow/appclient/doc.go` documents ADR-019 routing rule.
+
+## Step sequence — Phase D (canary)
+
+### Step D1 — Canary workflow + activity
+
+Files:
+
+- `plane/workflow/canary/workflow.go`
+- `plane/workflow/canary/activity.go`
+- `plane/workflow/canary/bundle.go`
+
+Canary reads `gitscale:dev:workflow:health` from `cache.Store` via a single read-only activity.
+
+### Step D2 — Integration test
+
+File: `plane/workflow/canary/integration_test.go`
+
+- Spins Temporal dev server (testcontainers `temporalio/auto-setup` image OR `go.temporal.io/sdk/testsuite` time-skipping env).
+- Spins Redis testcontainer.
+- Sets the health key directly.
+- Calls `client.ExecuteWorkflow(...)`; awaits result; asserts payload.
+
+### Step D3 — Determinism lint negative test
+
+File: `plane/workflow/lint/lint_test.go`
+
+Runs `lint-determinism.sh` against `testdata/bad/`; asserts non-zero exit.
+
+## Phase E — docs
+
+### Step E1 — README
+
+File: `plane/workflow/README.md`
+
+Documents D1–D12 from spec, ADR-019 cross-link, plane-boundary rule, registry conventions, lint canon, retry-policy defaults, single-domain rule.
+
+## Validation gates
+
+| Gate | Command | Pass |
+|---|---|---|
+| Build | `go build ./...` | exit 0 |
+| Vet | `go vet ./plane/workflow/...` | exit 0 |
+| Lint determinism | `make lint-determinism` | exit 0 on real code; exit 1 on `testdata/bad/` |
+| Unit | `go test -race ./plane/workflow/...` (excludes integration tag) | pass |
+| Canary integration | `go test -tags integration -race ./plane/workflow/canary/...` | pass |
+| Worker boot | `docker-compose up -d temporal redis postgres && go run ./cmd/workflow-worker` | starts; canary workflow registered |
+| Markdown | `make lint-md` | clean |
+
+## Acceptance checklist
+
+- [ ] `cmd/workflow-worker` builds; binary boots against docker-compose Temporal.
+- [ ] Worker reads `TEMPORAL_NAMESPACE` from env, fails fast if unset.
+- [ ] `Bundle` registry compiles; `canary.Bundle()` registers cleanly.
+- [ ] OTel interceptor wired; canary spans show parent-child linkage.
+- [ ] Worker options pinned per spec D8; env override works.
+- [ ] `DefaultRetryPolicy` and `ShouldContinueAsNew` exported.
+- [ ] Determinism lint fires on bad fixtures + clean on good.
+- [ ] Canary integration test passes against real Redis + Temporal dev.
+- [ ] `appclient.IdentityClient` interface exported; stub impl returns sentinel.
+- [ ] No `plane/workflow/adapters/data/` package created.
+- [ ] `plane/workflow/README.md` documents D1–D12.
+- [ ] SIGTERM gracefully stops worker within `WORKER_STOP_TIMEOUT`.
+- [ ] PR description cross-links ADR-019 + spec + execution plan.
+
+## Risks
+
+| Risk | Mitigation |
+|---|---|
+| Temporal dev server flaky in CI | restrict integration test to canary; unit tests use `testsuite.WorkflowTestSuite` time-skipping |
+| Determinism rules too aggressive (false-positives in activity files) | activity files exempt by name pattern; `*_test.go` exempt |
+| OTel collector misconfigured silently | worker logs OTLP target at startup; canary asserts span count > 0 |
+| Adapter sprawl post-merge (engineers reach for `adapters/data/`) | README + skill hook + ADR-019 reference |
+| `appclient.IdentityClient` stub merged but no impl follow-up | PR description explicitly cross-links #15-revocation as the impl source |
+| Schedule API not yet supported in Temporal SDK version chosen | SDK ≥ v1.25.0 has Schedule support; pin version in go.mod |
+
+## Rollback
+
+`cmd/workflow-worker` not in any deployment yet; binary can be reverted independently. Determinism CI step can be disabled via `.github/workflows/go.yml` revert without breaking other gates.

--- a/docs/superpowers/plans/2026-05-06-plan-issue-35-metadatastore-compliance.md
+++ b/docs/superpowers/plans/2026-05-06-plan-issue-35-metadatastore-compliance.md
@@ -1,0 +1,116 @@
+# Plan: #35 — MetadataStore compliance suite
+
+**Date:** 2026-05-06
+**Issue:** #35
+**Spec:** none (issue body + execution-plan §13.1 UUIDv7 assertion)
+**Branch:** `feat/data-metadatastore-compliance-suite`
+**Pre-merge of:** #14 (`MetadataStore`, `Tx`, stub + postgres impls)
+**Blocks:** #15-postgres
+
+## Pre-flight
+
+- Confirm #14 merged on main.
+- `git fetch && git checkout main && git pull`
+- `git checkout -b feat/data-metadatastore-compliance-suite`
+- Confirm `plane/data/compliance/{cachestore,eventqueue,ratelimiter}.go` already exist (template to mirror).
+
+## Step sequence
+
+### Step 1 — Factory type
+
+File: `plane/data/compliance/metadatastore.go`
+
+```go
+type MetadataStoreFactory func(t *testing.T) (s store.MetadataStore, cleanup func())
+
+func RunMetadataStoreCompliance(t *testing.T, factory MetadataStoreFactory) {
+    t.Run("Transact_commit_on_nil_error", func(t *testing.T) { ... })
+    t.Run("Transact_rollback_on_non_nil_error", func(t *testing.T) { ... })
+    t.Run("WriteOutbox_transactional_invariant", func(t *testing.T) { ... })
+    t.Run("WriteOutbox_domain_allowlist", func(t *testing.T) { ... })
+    t.Run("WriteOutbox_table_dispatch", func(t *testing.T) { ... })
+    t.Run("Serializable_retry_contract_40001", func(t *testing.T) { ... })
+    t.Run("EventID_monotonic_uuidv7", func(t *testing.T) { ... })
+    t.Run("Domain_reader_stubs_return_sentinel", func(t *testing.T) { ... })
+}
+```
+
+### Step 2 — Per-case implementations
+
+For each subtest:
+
+| Case | Asserts |
+|---|---|
+| Transact basics | commit on nil; rollback on non-nil; no partial writes after rollback |
+| Transactional invariant | source row + outbox row commit atomically; rollback removes both (query each table) |
+| Domain allowlist | `WriteOutbox(Domain("unknown"), …)` errors before any DB write; all 5 domains succeed |
+| Table dispatch | `domain=DomainIdentity` writes to `identity_outbox`; assert via `SELECT FROM <table>` after each |
+| 40001 race | two goroutines, both serializable, both `SELECT … FOR UPDATE` on `agent_identities.reputation_score`, both UPDATE; loser gets `40001`; `IsRetryable(err)==true` |
+| EventID UUIDv7 | sample N=100 outbox writes; assert each `event_id` is UUIDv7; assert monotonic across single-thread inserts |
+| Stub sentinel | calling un-filled reader (e.g. `RepositoryReader.GetBySlug`) returns sentinel error, never panics |
+
+### Step 3 — Postgres wiring
+
+File: `plane/data/store/postgres/compliance_test.go`
+
+```go
+func TestPostgresCompliance(t *testing.T) {
+    factory := func(t *testing.T) (store.MetadataStore, func()) {
+        // testcontainers PG; apply migrations 000-005; return store + cleanup
+    }
+    compliance.RunMetadataStoreCompliance(t, factory)
+}
+```
+
+Reuse `plane/data/outbox/integration_test.go::testDB` helper (already does container + migration apply).
+
+### Step 4 — Stub wiring
+
+File: `plane/data/store/stub/compliance_test.go`
+
+```go
+func TestStubCompliance(t *testing.T) {
+    factory := func(t *testing.T) (store.MetadataStore, func()) {
+        return stub.New(), func() {}
+    }
+    compliance.RunMetadataStoreCompliance(t, factory)
+}
+```
+
+Stub explicitly skips `Serializable_retry_contract_40001` with `t.Skip("40001 race covered by postgres compliance")`. Document in `plane/data/compliance/metadatastore.go` doc comment.
+
+### Step 5 — Update postgres impl gaps surfaced by compliance
+
+If 40001 case fails (e.g. `Transact` not actually serializable), fix in `plane/data/store/postgres/metadata.go`. Compliance is the gate.
+
+## Validation gates
+
+| Gate | Command | Pass |
+|---|---|---|
+| Build | `go build ./plane/data/compliance/... && go build ./...` | exit 0 |
+| Postgres compliance | `go test -tags integration -race -run TestPostgresCompliance ./plane/data/store/postgres/...` | all 8 subtests pass |
+| Stub compliance | `go test -race -run TestStubCompliance ./plane/data/store/stub/...` | 7 pass + 1 skip |
+| 40001 case timing | run 5 times | no flakes |
+
+## Acceptance checklist
+
+- [ ] `plane/data/compliance/metadatastore.go` exports `RunMetadataStoreCompliance` + `MetadataStoreFactory`.
+- [ ] All 8 cases listed above implemented.
+- [ ] Postgres compliance test passes against testcontainers PG.
+- [ ] Stub compliance passes; 40001 skip is explicit.
+- [ ] Each domain (`identity`, `repositories`, `collaboration`, `ci`, `billing`) is exercised at least once in dispatch test.
+- [ ] EventID test asserts UUIDv7 (not just any UUID).
+- [ ] PR description cross-links #14 + #35; closes #35.
+
+## Risks
+
+| Risk | Mitigation |
+|---|---|
+| `parent_user_id` FK in agent_identities forces test users to exist before agents | factory seeds a baseline user during cleanup setup |
+| testcontainers slow in CI | reuse the existing helper; cache image |
+| 40001 race flake | bound retry attempts; if no `40001` after 5 attempts, fail with explicit message |
+| Compliance suite imports postgres impl directly | suite imports only `plane/data/store` interface; postgres binding is in caller's `_test.go` only |
+
+## Rollback
+
+Test-only PR; pure addition. Revert if compliance surfaces a #14 bug — fix it as a separate PR rather than reverting the suite.

--- a/docs/superpowers/specs/2026-05-06-adr-019-workflow-app-plane-boundary.md
+++ b/docs/superpowers/specs/2026-05-06-adr-019-workflow-app-plane-boundary.md
@@ -1,0 +1,153 @@
+# Spec: ADR-019 — Workflow plane state mutations route via application-plane RPC
+
+**Date:** 2026-05-06
+**Status:** Proposed (ready to file as ADR-019 in `docs/architecture.md §8`)
+**Branch:** `adr/workflow-app-plane-boundary`
+**Blocks:** #33 (workflow bootstrap) — #33 cannot merge until this ADR lands.
+
+## 1. Why this is an ADR, not a PR-description gap-fill
+
+Per CLAUDE.md: *"If a proposal fills in an implementation detail not covered by any ADR, no new ADR is required — a PR description is sufficient."*
+
+This rule is **not** a gap-fill. It is a load-bearing plane-boundary contract that:
+
+1. Will affect every workflow PR henceforth (#18, future agent-session, future CI pipeline workflows).
+2. Constrains imports across two planes (`plane/workflow/` and `plane/application/`) for the project lifetime.
+3. Has a defensible alternative (workflow plane writes directly via `MetadataStore.Transact`) that ADRs must explicitly reject so the rejected path doesn't sneak back in.
+4. Architect review and adr-historian review both flagged it as needing ADR-level governance.
+
+CLAUDE.md two principles affected: (2) loose coupling at every seam — formal boundary contract; (3) metering is infrastructure — the boundary is what lets metering attach to write paths uniformly.
+
+## 2. Proposed ADR text
+
+The text below drops verbatim into `docs/architecture.md §8` as ADR-019.
+
+---
+
+### ADR-019: Adopted application-plane RPC as the only state-mutation path from the workflow plane
+
+- **Status:** Proposed
+- **Date:** 2026-05-06
+- **Context:** Temporal workflows in `plane/workflow/` need to mutate metadata-layer state — partition rollover, agent-session lifecycle, CI pipeline state transitions, future automated remediation. Two architectural paths exist:
+  1. **Direct path.** Workflow activities receive `plane/data/store.MetadataStore` and call `Transact` + `WriteOutbox` themselves.
+  2. **App-plane RPC path.** Workflow activities receive a thin gRPC client (`plane/workflow/appclient/`) into the application plane's per-domain service; the service performs the Tx + outbox write.
+
+  The direct path is technically permitted by the existing interfaces. ADR-008 (outbox) is preserved either way, because both paths converge on `MetadataStore.Transact` + `WriteOutbox` in the same Tx. The choice is **not** about transactional integrity; it is about where domain invariants live.
+
+- **Decision:**
+
+  Workflow plane state mutations route exclusively via per-domain gRPC services in `plane/workflow/appclient/` → `plane/application/<domain>/`. The direct path (workflow activities calling `MetadataStore.Transact` for writes) is forbidden.
+
+  Workflow plane reads MAY use `plane/data/store` interfaces directly via the activity adapter. Pure-DDL maintenance activities (e.g. partition rollover) MAY use `MetadataStore` directly, because the operation has no outbox row and no domain invariant.
+
+  No workflow activity writes more than one domain's outbox row in a single execution. Cross-domain workflows compose per-domain saga steps with explicit compensation activities.
+
+- **Consequences:**
+
+  **Domain invariants live in the application plane only.** `CreateUser` validation (uniqueness, email shape), reputation clamping, event-type selection, payload assembly are not duplicated across `plane/application/identity/` and `plane/workflow/<domain>/activities/`. A domain rule change ripples through one codebase, not two.
+
+  **Auth / audit context is uniform.** The application plane stamps `actor_id`, `principal_kind`, `rate_bucket` on every outbox payload from JWT-SVID claims (ADR-010). A workflow activity has no human principal; routing through the app plane gives the workflow's *system* SPIFFE identity a clear audit trail (`actor_kind=service`, `actor_id=<workflow-worker-spiffe>`).
+
+  **Single-writer per aggregate keeps schema migrations sane.** Adding a column to `agent_identities` requires updating one writer, not two.
+
+  **Workflow tests gain a clean stub surface.** `appclient.IdentityClient` is mockable; activities test against the interface, not against a postgres testcontainer.
+
+  **Latency cost: one network hop per write activity.** Acceptable. Temporal activities are async and retry-tolerant; this is not the latency-sensitive path.
+
+  **Operational cost: each app-plane domain ships a gRPC server.** Identity (#15-revocation) is the first; future PR-engine, CI-state, billing-aggregator services follow the same pattern. The cost is amortised across human-facing API traffic that needs gRPC anyway.
+
+  **Read-only fast path preserved.** Read activities skip the gRPC hop and call `MetadataStore` directly through the adapter — the rule does not penalise read-mostly workflows.
+
+  **Pure-DDL exception is narrow.** `CreatePartition` (#18) writes no row, emits no outbox, has no invariant. The single-domain rule still applies: a DDL activity touches one schema only.
+
+  **Cross-domain saga rule prevents distributed-Tx daydreams.** Two-phase commit across `identity_outbox` + `billing_outbox` is forbidden. A "create agent + provision billing account" workflow becomes two activities (`identityClient.CreateAgent` then `billingClient.ProvisionAccount`) with a compensation activity on failure.
+
+---
+
+## 3. Enforcement
+
+| Mechanism | Location | What it catches |
+|---|---|---|
+| Code review | every workflow PR | direct `MetadataStore` write from activity |
+| `gitscale-plane-boundary` skill | hook on edits to `plane/workflow/**/*.go` | `MetadataStore.Transact` import in activity files (`activity*.go`) |
+| `gitscale-outbox-check` skill | hook on outbox writes | dual-write paths |
+| Lint (future) | `plane/workflow/lint/` | `grep` for `Transact(` in activity files outside `*_readonly_*.go` allowlist |
+
+The lint script can ship in a follow-up PR after #33; for the bootstrap PR, code review + the skill hook are sufficient.
+
+## 4. Rejected alternatives
+
+### Alt 1 — Direct path (workflow plane writes via `MetadataStore.Transact`)
+
+**Pros:** Simpler, one fewer service to deploy, no gRPC layer, lower latency.
+
+**Rejected because:**
+
+- Domain invariant duplication is the root cause of "two implementations of `CreateUser` drift in 6 months" anti-pattern.
+- Auth / audit context becomes ad-hoc — workflow has to manually stamp fields the app plane fills automatically.
+- Schema migrations now have two writers to update.
+- The latency win is illusory — Temporal activities have heartbeat overhead measured in tens of milliseconds; one local gRPC hop adds <1ms in a co-located cluster.
+- The "simpler" claim is wrong: the simpler architecture is the one with one writer per aggregate, not the one with fewer service binaries.
+
+### Alt 2 — Hybrid (some domains direct, some via RPC)
+
+**Rejected because:** rule complexity. Engineers must remember which domains are direct-writable; mistakes are hard to catch in review. A uniform rule with one narrow DDL exception is easier to enforce.
+
+### Alt 3 — Workflow plane has its own outbox tables, separate from app plane
+
+**Rejected because:** doubles the polling-consumer surface (two outbox tables per domain), invents a new aggregate type for "workflow-initiated change," and breaks ADR-008's "single source of truth per aggregate" principle.
+
+## 5. Out-of-scope clarifications
+
+- **Read-only activities** are NOT covered by this ADR. They MAY import `plane/data/store` interfaces directly. Distinction: a method that does not call `Transact` or `WriteOutbox` is read-only.
+- **Activity-to-activity orchestration** within the workflow plane is unaffected. Activities can call other activities through the workflow context; the rule governs *external state mutations*.
+- **`cache.Set`** from a workflow activity is permitted — cache writes are not authoritative state and have no outbox.
+- **Metering counters** (Phase-2) — the rule applies. Workflow-initiated metering events go through the metering app-plane service, not directly into ClickHouse / Redis enforcement counters.
+
+## 6. Migration guidance
+
+This ADR is filed before any workflow code exists, so there is no migration. Future workflow PRs that try the direct path are caught at code review or by the boundary skill.
+
+If a future workflow needs an aggregate-level invariant (rare), the resolution is to add a method to the app-plane domain service, not to bypass the rule.
+
+## 7. Implementation plan
+
+This ADR ships as a documentation-only PR.
+
+### Files to modify
+
+- `docs/architecture.md` — append ADR-019 text (§ 2 above) after ADR-017 in §8.
+- `docs/architecture.md` §8 ADR-008 — add a one-line cross-reference: *"See ADR-019 for the workflow-plane variant of this invariant."*
+- `docs/architecture.md` §8 ADR-017 — add a one-line cross-reference: *"Workflow-plane consumers of these interfaces follow ADR-019 routing."*
+- `.claude/skills/gitscale-plane-boundary/SKILL.md` (if the skill has a doc — verify) — add ADR-019 to the reference list so the skill cites it on workflow-plane edits.
+- `.claude/skills/gitscale-outbox-check/SKILL.md` — add ADR-019 to the reference list.
+
+### Acceptance criteria
+
+- [ ] ADR-019 appears in `docs/architecture.md §8` with `Status: Proposed`.
+- [ ] `make lint-md` introduces zero NEW errors in the modified range.
+- [ ] ADR-008 and ADR-017 carry the cross-reference line.
+- [ ] Skill references updated.
+
+### Promotion to `Accepted`
+
+After #33 merges and at least one workflow (`#18-rollover`) ships against the rule, the ADR status flips from `Proposed` to `Accepted` in a follow-up doc PR.
+
+## 8. Risk mitigations
+
+| Risk | Mitigation |
+|---|---|
+| ADR text drifts from #33's actual implementation | #33 PR description cross-links ADR-019; reviewer compares wording |
+| Future engineer reads ADR-019 and decides "my case is the exception" | "Pure-DDL exception is narrow" wording is explicit; `CreatePartition` is the only example. Adding a new exception requires an ADR amendment. |
+| Single-domain rule blocks a legitimate cross-domain need | Saga pattern is the documented escape hatch; ADR-019 §Consequences names it |
+| ADR-019 conflicts with future ADR-007 (MCP) when MCP server proxies workflow tools | MCP server is in the application plane; tool calls go through it the same way. No conflict. |
+
+## 9. Cross-references
+
+- ADR-003 (Temporal) — establishes activities as the I/O boundary; ADR-019 specifies *which* I/O.
+- ADR-008 (outbox) — preserved by both paths; ADR-019 picks the path that keeps domain invariants single-sourced.
+- ADR-010 (SPIFFE/JWT-SVID) — the auth context that flows through the app-plane gRPC hop.
+- ADR-015 (plan approval) — `ApprovalActivity` slot in #33 registry uses the app-plane RPC pattern.
+- ADR-017 (interface swap surface) — `MetadataStore` and `CacheStore` remain the underlying swap surfaces; ADR-019 governs *who calls them from where*.
+- CLAUDE.md core principles 2 (loose coupling) and 3 (metering as infrastructure).
+- `gitscale-plane-boundary` skill, `gitscale-outbox-check` skill — enforcement.

--- a/docs/superpowers/specs/2026-05-06-execution-plan-post-phase1.md
+++ b/docs/superpowers/specs/2026-05-06-execution-plan-post-phase1.md
@@ -1,0 +1,377 @@
+# GitScale Execution Plan — 2026-05-06
+
+Post-Phase-1 closeout + workflow plane bootstrap + Phase-2 launch ramp.
+
+## 1. Current state (snapshot)
+
+**Merged & green** (Phase 1 epic #5, partial):
+
+- All 5 PostgreSQL domain schemas: identity, repositories, collaboration, ci, billing (#19–#23)
+- Polling outbox consumer with advisory-lock drain + Kafka publish (#32 / closes #11)
+- Kafka topology (10 topics, 5 main + 5 DLQ) + EventEnvelope + `lint-events` (#31 / closes #12)
+- Redis `CacheStore`, `RateLimiter`, namespace wrapper, typed helpers, compliance harnesses for cache + ratelimiter + eventqueue (#30 / closes #13)
+- ADR-004 amended: partition key = `aggregate_id` (#29 / closes #26)
+- ADR-009 amended: repo-location cache contract pinned (#36 / closes #17)
+- Project scaffolding, Makefile, pre-commit lint hook, Go module, plane skeletons (#2, #16)
+
+**Plane occupancy**:
+
+- `plane/data/` — populated (cache, ratelimit, kafka, outbox, compliance, migrations).
+- `plane/application/`, `plane/edge/`, `plane/git/`, `plane/workflow/` — `doc.go` only.
+
+## 2. Open issues — full inventory
+
+| # | Title | Plane | Pri | Type | Direct deps |
+|---|---|---|---|---|---|
+| #5 | Phase 1 epic | core | P1 | feature | closes when #14, #15, #35 merge |
+| #14 | MetadataStore + Tx interfaces (`plane/data/store/`) | data | P1 | feature | none (compiles standalone; integration tests need #6, merged) |
+| #15 | Identity domain service: HumanUser + AgentIdentity CRUD | application | P1 | feature | #14, #35, #6 (merged) |
+| #18 | Temporal cron: `usage_events` partition rollover + retention | workflow | P2 | feature | #33; archive arm needs #34 |
+| #27 | Identity cache invalidator consumer | application | P2 | feature | #11/#12/#13 (all merged) — **unblocked now** |
+| #33 | Workflow plane bootstrap (Temporal worker, registry, determinism lint) | workflow | P1 | feature | none |
+| #34 | ADR: billing `usage_events` archival tier + format | data | P2 | adr/decision-pending | none |
+| #35 | MetadataStore compliance suite (`plane/data/compliance/metadatastore.go`) | data | P1 | feature | #14 |
+
+No PRs currently open. Last merge: #36 on 2026-05-05.
+
+## 3. Dependency graph
+
+```
+                 (merged: #6, #11, #12, #13)
+                          │
+                          ▼
+                   ┌────────────┐
+                   │    #14     │  MetadataStore + Tx
+                   │   (Data)   │  *unblocker for #15, #35*
+                   └─────┬──────┘
+                         │
+                         ▼
+                   ┌────────────┐
+                   │    #35     │  MetadataStore compliance suite
+                   │   (Data)   │  ADR-017 obligation
+                   └─────┬──────┘
+                         │
+                         ▼
+                   ┌────────────┐
+                   │    #15     │  Identity domain service
+                   │ (Appl.)    │  closes #5 along with #14, #35
+                   └────────────┘
+
+   ┌────────────┐                   ┌────────────┐
+   │    #33     │                   │    #34     │  ADR billing archival
+   │ (Workflow) │  bootstrap        │ (decision) │  tier+format
+   └─────┬──────┘                   └─────┬──────┘
+         │                                │
+         └──────────┬─────────────────────┘
+                    ▼
+             ┌────────────┐
+             │    #18     │  Billing partition rollover
+             │ (Workflow) │  archive arm needs #34
+             └────────────┘
+
+   ┌────────────┐
+   │    #27     │  Identity cache invalidator — independent, fully unblocked
+   │ (Appl.)    │
+   └────────────┘
+```
+
+## 4. Wave-ordered execution plan
+
+### Wave 0 — kicks off in parallel, no cross-deps
+
+| Slot | Issue | Branch | Plane | Why parallel-safe |
+|---|---|---|---|---|
+| 0a | #14 | `feat/data-store-interfaces` | data | New package `plane/data/store/`; touches no existing files |
+| 0b | #33 | `feat/workflow-plane-bootstrap` | workflow | New `cmd/workflow-worker/` + `plane/workflow/` (currently empty except `doc.go`) |
+| 0c | #34 | `adr/data-billing-archival-tier` | data (docs) | Doc-only ADR; touches `docs/architecture.md §8` |
+| 0d | #27 | `feat/application-identity-cache-invalidator` | application | New package; consumes existing `plane/data/kafka` + `plane/data/cache` interfaces |
+
+**Wave 0 critical-path = max(0a, 0b)** — both are P1 and the longest tickets in this wave.
+
+#34 is decision-only and short. #27 is small (one consumer + one integration test).
+
+### Wave 1 — gated on Wave 0a (#14)
+
+| Slot | Issue | Branch | Plane | Gating |
+|---|---|---|---|---|
+| 1a | #35 | `feat/data-metadatastore-compliance-suite` | data | needs `MetadataStore` symbols from #14 |
+
+### Wave 2 — gated on Wave 1a (#35)
+
+| Slot | Issue | Branch | Plane | Gating |
+|---|---|---|---|---|
+| 2a | #15 | `feat/application-identity-domain-service` | application | postgres impl must pass compliance suite before it ships per ADR-017 |
+
+Once #15 merges, `#5` Phase-1 acceptance criteria are met → close epic.
+
+### Wave 3 — gated on Wave 0b (#33) and Wave 0c (#34)
+
+| Slot | Issue | Branch | Plane | Gating |
+|---|---|---|---|---|
+| 3a | #18 | `feat/workflow-billing-partition-rollover` | workflow | rollover arm needs #33; archive arm needs #34 ADR target |
+
+#18 may ship in two parts:
+
+- **#18-rollover** — only `CreatePartition` activity, depends on #33 only.
+- **#18-archive** — adds `DetachAndArchivePartition`; depends on #34.
+
+Recommend split if #34 ADR slips.
+
+## 5. Critical path
+
+`#14 → #35 → #15 → close #5`
+
+Three sequential merges. Everything else is parallel cover.
+
+## 6. Per-issue scope confirmation
+
+### #14 — MetadataStore + Tx (P1, Data)
+
+- `plane/data/store/{metadata.go, identity_reader.go, identity_writer.go, repository_reader.go, repository_writer.go}`
+- `plane/data/store/postgres/metadata.go` — `*pgxpool.Pool` impl; `Transact` (serializable, surfaces `40001` to caller per ADR-006); `WriteOutbox` (5-domain allowlist, dispatches to `<domain>_outbox`).
+- `plane/data/store/stub/metadata.go` — in-mem test double.
+- **Drop** `EventQueue`. Issue body explicitly removes it; outbox consumer keeps using `plane/data/outbox.KafkaProducer` per ADR-008.
+- Domain reader/writer bodies: `errNotImplemented` stubs except what #15 needs.
+- Acceptance: `go build ./plane/data/store/...` clean; integration test against `identity_outbox` proves transactional WriteOutbox.
+
+### #35 — MetadataStore compliance suite (P1, Data)
+
+- `plane/data/compliance/metadatastore.go` exports `RunMetadataStoreCompliance(t, factory)` + `MetadataStoreFactory`.
+- 7 test cases per issue body: Transact basics, WriteOutbox transactional invariant, domain allowlist, table dispatch, serializable retry contract (`40001` race), `event_id` uniqueness, domain reader stubs return sentinel.
+- Wiring: `plane/data/store/postgres/compliance_test.go` (testcontainers) + `plane/data/store/stub/compliance_test.go` (skip 40001 race with explicit comment).
+- Lands **before** #15 merges so the postgres impl is enforced from day one.
+
+### #15 — Identity domain service (P1, Application)
+
+- `plane/application/identity/{models.go, service.go, postgres_service.go}`.
+- Fills `IdentityReader`/`IdentityWriter` bodies in `plane/data/store/postgres/`.
+- `CreateUser` and `CreateAgent` MUST call `Transact` and `WriteOutbox` in the same Tx — emits `user.created` / `agent.created`.
+- `UpdateAgentReputationScore` clamps to `[0.0, 1.0]`, emits `agent.reputation_updated`.
+- Integration test: testcontainers PG; assert source row + outbox row in same Tx; rollback removes both.
+- Closes Phase 1 epic.
+
+### #33 — Workflow plane bootstrap (P1, Workflow)
+
+- `cmd/workflow-worker/main.go` — Temporal worker, signal handling, structured logging, OTel.
+- `plane/workflow/registry.go` — pluggable workflow + activity registration per task queue.
+- Task queues: `billing-maintenance`, `agent-sessions` (placeholder), `ci-pipelines` (placeholder). Namespace: `gitscale`.
+- `plane/workflow/adapters/data/` — interfaces wrapping `plane/data/store.MetadataStore` + `plane/data/cache.CacheStore`. Activities receive interfaces, never concretes. Plane boundary contract.
+- **State-mutating activities** call `plane/application/<domain>` over HTTP/gRPC (so outbox transaction hits app plane). Read-only activities MAY use `plane/data/store` directly via the adapter.
+- `plane/workflow/lint-determinism.sh` — greps for `time.Now()`, `rand.X`, `os.Getenv`, `range` over `map` in workflow files. Config + script in same commit (CLAUDE.md CI rule).
+- One canary workflow + integration test against Temporal dev server.
+
+### #18 — Billing partition rollover (P2, Workflow)
+
+- `plane/workflow/billing/partition_rollover_workflow.go` — Temporal scheduled workflow, monthly cadence.
+- Activities: `CreatePartition(year, month)` (idempotent), `DetachAndArchivePartition(year, month)` (target = #34 outcome).
+- Roll forward: 7 days before EoM, create next month's partition. Retention: detach+archive partitions older than retention horizon (TBD — set by #34).
+- Idempotent + portable across PG and CRDB (dialect SQL in adapter, not workflow).
+- Recommend split: `#18-rollover` lands first (#33 only); `#18-archive` follows (#34).
+
+### #27 — Identity cache invalidator (P2, Application)
+
+- `plane/application/identity-cache-invalidator/` — small consumer service.
+- Subscribes `gitscale.identity.events`, group `gitscale.identity-cache-invalidator`.
+- Acts on: `user.disabled`, `user.deleted`, `agent.revoked`, `agent.deleted`, `org.member_removed`, `principal.permissions_changed` → `cache.Delete(IdentityKey<aggregate_id>)`.
+- Idempotent on `event_id`. `auto.offset.reset=earliest`. Metrics: `identity_invalidations_total{event_type}`, `identity_invalidator_consumer_lag_seconds`.
+- **Note**: #15 is what *emits* `user.created` / `agent.created`, but **revocation** events come later (no current emitter for `user.disabled` / `agent.revoked`). Recommend coordinating with the issue author whether to ship #27 now (correct contract, idle until emitters exist) or defer.
+
+### #34 — Billing archival tier ADR (P2, decision-pending)
+
+Seven open questions per issue body:
+
+1. Storage target (Git cold-tier bucket vs separate analytics-lake bucket)
+2. Erasure-coding (10,4) vs 3× replication (small dataset, infrequent reads)
+3. Format: Parquet (recommend) vs JSONL
+4. Query path: Athena/Trino vs write-and-forget
+5. Retention horizon (initial 13 months in PG; legal floor ≥ 7 years for invoices)
+6. Restore path (manual workflow vs read-only FDW attach)
+7. Encryption scope (ADR-011 inheritance vs separate KMS)
+
+Decision-only PR. No code. Suggested ADR number: ADR-018.
+
+## 7. Open architecture questions reminder
+
+Per `CLAUDE.md`, do not commit to these without a spike:
+
+- Erasure coding library (June 2026)
+- MCP server protocol version (July 2026)
+- PR reputation model (July 2026)
+- AGENTS.md schema versioning (July 2026)
+- Cross-org dedup feature-flag default (August 2026)
+
+#34 (billing archival tier) is **adjacent** to "erasure coding library" but distinct: #34 picks a tier shape for a different data class (operational analytics, not Git objects). #34 may *defer* the EC library question or anchor on the Git plane outcome.
+
+## 8. Risks & ordering hazards
+
+| Hazard | Mitigation |
+|---|---|
+| #14 ships `EventQueue` interface by reflex, contradicting issue body + ADR-008 | Issue #14 explicitly drops it. Reviewer must check no `EventQueue` interface added. |
+| #15 starts before #35 merges → postgres impl never validated | Hard-gate: #35 must merge before #15 PR opens. |
+| #18 archive arm pulls in #34 prematurely → blocked on ADR | Split into #18-rollover + #18-archive (recommended above). |
+| #33 worker imports `plane/data/store/postgres` directly → plane boundary breach | `plane/workflow/adapters/data/` MUST take interfaces only. State mutations MUST go via app-plane HTTP/gRPC, not direct outbox writes. |
+| #27 ships before #15 emits `user.created` events → harmless but consumer sees no traffic | Document explicitly. Or defer #27 until at least one identity event type is emitted in production. |
+| Determinism violations in #18 workflow code | #33 lint-determinism step + `gitscale-temporal-determinism` skill — run both. |
+| Redpanda integration tests in #14/#35 race outbox-consumer integration tests on shared docker-compose | Use distinct testcontainers per test package; avoid global state. |
+
+## 9. Phase-1 completion definition
+
+`#5` closes when:
+
+- ✅ All migrations apply on a fresh DB (already true)
+- ✅ All outbox tables co-located with source domain (already true)
+- ✅ Polling consumer drains and publishes < 1s (already true via #32)
+- ⏳ `MetadataStore`, `CacheStore`, `EventQueue` interfaces compile + stub impls — `CacheStore` ✅, `EventQueue` (= `KafkaProducer`) ✅, `MetadataStore` pending #14
+- ⏳ Identity domain integration tests against real PG — pending #15
+
+So #5 closure = #14 + #35 + #15 = 3 sequential merges.
+
+## 10. Suggested commit / PR sequence
+
+```
+1. PR #14 → main          (Data — MetadataStore interfaces)
+2. PR #35 → main          (Data — compliance suite, depends on #14)
+3. PR #15 → main          (Application — identity service, closes #5)
+
+In parallel:
+4. PR #33 → main          (Workflow — bootstrap)
+5. PR #34 → main          (ADR-018, doc-only)
+6. PR #27 → main          (Application — cache invalidator, fully unblocked)
+
+After #33 + #34:
+7. PR #18-rollover → main (rollover arm, on #33)
+8. PR #18-archive → main  (archive arm, on #33 + #34)
+```
+
+## 11. Branch naming check (CLAUDE.md conformance)
+
+All proposed branches conform to `type/plane-short-description`:
+
+- `feat/data-store-interfaces` ✓
+- `feat/data-metadatastore-compliance-suite` ✓
+- `feat/application-identity-domain-service` ✓
+- `feat/workflow-plane-bootstrap` ✓
+- `feat/workflow-billing-partition-rollover` ✓
+- `feat/application-identity-cache-invalidator` ✓
+- `adr/data-billing-archival-tier` ✓ (uses `adr` type, plane = data — consistent with prior `adr/data-cache-payload-and-invalidation` from #36)
+
+Every PR closes ≥ 1 issue (CLAUDE.md invariant). PR titles mirror issue titles.
+
+## 12. Out of scope (explicit)
+
+- Edge plane (Envoy WASM filters) — no open issues; sequenced after Phase 1 is closed.
+- Git plane (Gitaly client wrappers, storage tiering code) — no open issues yet.
+- MCP server — gated on protocol-version spike (July 2026).
+- PR engine, webhooks, CI Firecracker provisioning — out of Phase 1; future epics.
+
+## 13. Review delta — 2026-05-06 expert review
+
+Five reviewers ran in parallel: adr-historian, data-plane, application-plane, workflow-plane, comprehensive-review:architect-review. Convergent findings folded back into the plan as amendments. Sections to update before any PR opens.
+
+### 13.1 Amendments to scope of #14
+
+- **Fill reader/writer bodies in #14, not stubs.** The `IdentityReader.GetUserByID/GetUserByEmail/GetAgentByID` + `IdentityWriter.InsertHumanUser/InsertAgentIdentity/UpdateAgentReputationScore` queries are schema contracts (#19, merged) — keeping them as `errNotImplemented` punts ~300 lines of pgx into #15 as data-plane code reviewed by application reviewers. Fill them in #14; keep #15 a pure application-plane PR.
+- **Add `store.IsRetryable(err) bool` helper.** Wraps the pgconn `40001` SQLState check so application code does not import pgconn. Without this, two retry policies will emerge.
+- **Typed `Domain` enum + single source of truth.** Domains are duplicated in `outbox/wiring/wiring.go::AllDomains`, `kafka/topics.go`, migration filenames, and now `WriteOutbox`. Introduce `plane/data/store.Domain` (string-typed), constants `DomainIdentity, DomainRepositories, …`, with a `Domain.Topic()` helper. Refactor `wiring.DomainConfig.Domain` to consume it.
+- **Compliance suite (#35) must assert UUIDv7 (or equivalent monotonic) generation for `event_id`** — covers collision risk under concurrent inserts.
+
+### 13.2 Amendments to scope of #15
+
+- **Split #15 into 3 pieces** — `service.go` interface + `models.go` + stub-impl + service-level tests can land as a draft PR in parallel with #35. `postgres_service.go` gates on #35. Integration tests run after both. Saves one merge cycle on the critical path.
+- **Service interface gaps to add up front:**
+  - `GetAgentsByParentUser(ctx, userID)` — uses existing `idx_agent_identities_parent_user_id`; PR engine + edge identity resolution will need it.
+  - `LookupIdentityForCache(ctx, principalID) (*IdentityCacheEntry, error)` — loader callback for `cache.GetIdentity`. Without it, edge plane reaches past the service into `IdentityReader`. Real plane-boundary risk.
+  - Revocation methods deferred to a sibling issue (see §13.6).
+- **Reputation: `SetAgentReputationScore(ctx, agentID, score)` not `UpdateAgentReputationScore(ctx, agentID, delta)`.** Compute outside the Tx, persist inside; payload carries `delta = newScore - oldScore`. Avoids 40001 retry storms on read-modify-write.
+- **`credential_hash` policy lives in the service.** Signature `CreateUser(ctx, email string, plaintextCredential string)`; service hashes via argon2id behind a `CredentialHasher` interface (ADR-017 swap surface). Edge plane never sees plaintext post-TLS. May need ADR for argon2id parameters.
+- **Metering-ready event envelope.** `agent.created` payload must carry `agent_class`, `rate_bucket`, `quota_account_id` from day one — even with no metering consumer. Avoids schema retrofit when metering plane lands.
+
+### 13.3 Amendments to scope of #33
+
+- **Namespace must be env-derived.** `gitscale-prod`, `gitscale-staging`, `gitscale-dev` — never literal `gitscale`. Namespaces are the retention/RBAC boundary; merging envs forces cross-env ACLs.
+- **Delete or split the adapter package.** Two acceptable shapes:
+  - **Delete `plane/workflow/adapters/data/`** entirely; activities import `plane/data/store` + `plane/data/cache` interfaces directly (architect verdict).
+  - **Split into `plane/workflow/adapters/{store,cache,appclient}/`** so the import graph reflects what each activity actually needs (workflow-plane verdict).
+  - Pick one; do not keep an umbrella `adapters/data/`.
+- **Determinism lint canon.** Externalize rules to `plane/workflow/determinism-rules.txt` (editable without script changes). Add: `crypto/rand`, `uuid.New*`, bare `go ` in workflow files, `make(chan …)`, `select { case <-ch: }` on Go channels, `sync.*`, `time.After`, `time.NewTimer`, `http.`/`net.` imports. Keep the warning-level `range over map` flag but only when the body contains a `workflow.` call.
+- **Schedule API over cron string** for #18 — discoverable, pausable, supports backfill.
+- **Canary workflow exercises one read-only activity through the adapter** (not no-op). Add a second fixture under `plane/workflow/testdata/bad/` with a deliberate determinism violation and assert `lint-determinism.sh` fails on it — proves the lint isn't silently passing.
+- **Worker-options pinning.** `MaxConcurrentActivityExecutionSize`, `MaxConcurrentWorkflowTaskPollers`, `WorkerStopTimeout` set explicitly in `cmd/workflow-worker/main.go`.
+- **OTel interceptor.** Wire `temporal.io/sdk/contrib/opentelemetry` in the registry; activity spans child off workflow spans.
+- **Default `RetryPolicy` per activity** — no infinite retries. `CreatePartition`: `MaximumAttempts: 5`.
+- **`workflow.GetVersion` discipline** + project default `continue-as-new` threshold helper land in #33.
+- **Registry leaves a slot for `ApprovalActivity`** (ADR-015) so first plan-approval workflow does not require a registry refactor.
+- **Single-domain activity rule.** No activity spans more than one domain's outbox row. Cross-domain workflows compose per-domain saga steps with explicit compensation.
+- **Real reason for the plane-boundary rule.** Update §6.#33 rationale: it is *not* "outbox transaction must hit app plane" (technically false). It is (a) domain invariants live in the app plane (uniqueness, clamping, event-type selection), (b) auth/audit context (`actor_id`, `principal_kind`) is stamped only in app plane, (c) single-writer-per-aggregate keeps schema migrations sane.
+
+### 13.4 Amendments to scope of #18
+
+- **Ship split as planned (#18-rollover + #18-archive).** Architect concurs; workflow-plane confirms split is not artificial.
+- **`CreatePartition` activity wraps the DDL in a transactional advisory lock** keyed on `(table, year, month)` — serializes concurrent retries from worker replicas. `IF NOT EXISTS` alone is not always benign on PG with attached-partition checks.
+- **Idempotency unit test.** Run the activity twice against the same target; assert no error, no duplicate partition.
+
+### 13.5 ADR posture changes
+
+- **ADR-017 needs a small amendment** clarifying that the named `EventQueue` swap surface is satisfied by `plane/data/outbox.KafkaProducer` (with the matching compliance suite at `plane/data/compliance/eventqueue.go`). Plan wording "drops EventQueue" is misleading — the interface materially exists under a different name. File a one-paragraph amendment alongside #14, OR rename `outbox.KafkaProducer` to `outbox.EventQueue`.
+- **New ADR-019: workflow-plane state mutations route via application-plane RPC.** This is a new plane-boundary contract, not a gap-fill — it will affect every future workflow. File before #33 merges.
+- **Stop citing ADR-006 for the `40001` retry-surface contract.** ADR-006 doesn't contain that wording. The contract is correct but lives in the PR description, not in ADR text.
+
+### 13.6 New issues to file before / during execution
+
+| New issue | Pri | Plane | Trigger |
+|---|---|---|---|
+| Identity service revocation methods + emitters (`user.disabled`, `agent.revoked`, `org.member_removed`, `principal.permissions_changed`) | P1 | application | gates #27; required for #27 to ship with a real round-trip test |
+| `[Data] Typed Domain enum + SSOT` | P2 | data | rolled into #14 or filed separately |
+| `[Workflow] Outbox row TTL expirer per ADR-008` | P2 | workflow | hidden TODO in ADR-008 line 531; no code today |
+| `[ADR] Reconcile EventQueue naming with outbox.KafkaProducer` | P2 | docs | §13.5 |
+| `[ADR-019] Workflow plane state mutations via app-plane RPC` | P1 | docs | gates #33 |
+| `[Data] Generic updated_at trigger across 5 domains` | P2 | data | columns default `now()` on insert; UPDATE does not bump |
+| `[Data] Add created_at/updated_at to identity.org_memberships and oauth_apps` | P2 | data | inconsistent with rest of identity domain |
+| `[Data] usage_events 2027-05+ partition gap before #18 ships` | P1 | data | calendar bomb — May 2027 inserts will fail until #18-rollover ships |
+| `[Observability] Rename outbox metric to outbox_consumer_high_water_lag_seconds` | P3 | data | ADR-008 wording vs current metric name |
+
+### 13.7 Risks added to §8
+
+- **Migration drift across long-lived branches.** #14, #35, #15 all touch `plane/data/store/postgres/` over weeks. CI must run migrations on a fresh DB *and* on a DB seeded by the prior set; rebase-on-main daily.
+- **`event_id` collision** under concurrent inserts if generation is naive UUIDv4 or `now()`-based. Compliance suite (#35) asserts UUIDv7 or equivalent.
+- **CI minute inflation** from per-package testcontainers + Temporal dev-server + Redpanda. Mitigate via shared fixtures (`testing.M` + `t.Cleanup`).
+- **Runtime config skew** between `cmd/workflow-worker` and existing `cmd/outbox-consumer` (Kafka brokers, Redis URL). Centralize config or document the duplication.
+- **#27 ships with no producer** — known-broken contract with flat lag metrics and no end-to-end signal. Defer until revocation emitters exist.
+
+### 13.8 Phase-2 landmines flagged
+
+- **Worker registry should be partitioned by traffic class (agent vs human), not by domain.** Phase-2 edge plane will need per-class throttling at workflow layer. Note in #33 README to prevent re-org.
+- **Session lifecycle events (`agent.session_started`, etc.) are explicitly Phase-2** — document so the edge plane knows materialized views must wait.
+- **#34 archival decision interacts with Git-plane cold-tier bucket.** ADR-018 should pick a separate bucket OR block on Git-plane storage spike to avoid noisy-neighbor.
+
+### 13.9 Final critical path (post-amendment)
+
+```
+Wave 0 (parallel):
+  #14   data    fills reader/writer bodies + IsRetryable + Domain enum
+  #33   workflow  with namespace=env-derived, adapter split, Schedule API, OTel
+  #34   adr     billing archival tier (decision-only)
+  ADR-019 amendment    plane-boundary rule for workflow writes
+  ADR-017 amendment    EventQueue ↔ outbox.KafkaProducer reconciliation
+  Identity revocation issue  filed (gate for #27)
+
+Wave 1 (after #14):
+  #35   data    compliance suite, UUIDv7 assertion
+  #15-stub  application  service interface + models + stub impl + tests (parallel with #35)
+
+Wave 2 (after #35):
+  #15-postgres application  postgres_service.go wired against MetadataStore
+
+Wave 3 (after #15-postgres):
+  #15-revocation application  Disable/Revoke methods + emitters
+  Phase 1 epic #5 closes here
+
+Wave 4 (after #33 + #15-revocation):
+  #27   application  identity cache invalidator (now has live producers)
+
+Wave 5 (after #33; archive arm gated on #34):
+  #18-rollover   workflow  CreatePartition + Schedule API + advisory lock
+  #18-archive    workflow  DetachAndArchivePartition (after #34)
+```
+
+Critical path: `#14 → #35 → #15-postgres → #15-revocation → #5 close`. #15-stub overlaps #35.

--- a/docs/superpowers/specs/2026-05-06-issue-15-identity-service-design.md
+++ b/docs/superpowers/specs/2026-05-06-issue-15-identity-service-design.md
@@ -1,0 +1,369 @@
+# Spec: #15 Identity domain service
+
+**Date:** 2026-05-06
+**Issue:** #15 `[Application] Identity domain service: HumanUser + AgentIdentity CRUD over MetadataStore`
+**Branches:** `feat/application-identity-service-stub`, `feat/application-identity-service-postgres`, `feat/application-identity-service-revocation`
+**Depends on:** #14 (MetadataStore + Tx interfaces), #35 (compliance suite — gates postgres-arm only)
+**Closes:** #5 Phase 1 epic (along with #14, #35)
+
+## 1. Context
+
+`plane/application/` is empty (only `doc.go`). #15 is the first application-plane service. It implements CRUD for `HumanUser` and `AgentIdentity` using the `MetadataStore` interface defined in #14, and is the first consumer of the outbox: state mutations atomically write source row + `identity_outbox` row in the same Tx (ADR-008).
+
+#15 is also the first emitter of identity events — `user.created`, `agent.created`, `agent.reputation_updated`. The identity-cache invalidator (#27) and future metering plane both depend on these events.
+
+ADRs: ADR-006 (PostgreSQL semantics), ADR-008 (outbox invariant), ADR-010 (JWT-SVID identity claims), ADR-017 (swap surface).
+
+Review surfaced multiple decisions that justify a spec rather than executing the original issue body verbatim. This document locks them.
+
+## 2. Decisions
+
+### D1 — Ship #15 in three sequenced PRs
+
+**Decision.**
+
+| PR | Branch | Depends on | Scope |
+|---|---|---|---|
+| **#15-stub** | `feat/application-identity-service-stub` | #14 only | `Service` interface + `models.go` + in-memory stub impl + service-level tests using stub `MetadataStore` |
+| **#15-postgres** | `feat/application-identity-service-postgres` | #14 + #35 | `postgres_service.go` wired against real `MetadataStore` postgres impl + integration tests |
+| **#15-revocation** | `feat/application-identity-service-revocation` | #15-postgres | `DisableUser`, `RevokeAgent`, `UpdateAgentPermissions`, org membership writes + emitters; gRPC surface for `appclient.IdentityClient` |
+
+**Rationale.** Original issue body bundled all three. Splitting reviews 1 merge cycle in parallel: #15-stub overlaps #35 (compliance suite). #15-revocation is the unblocker for #27.
+
+### D2 — Service interface, final list
+
+```go
+// plane/application/identity/service.go
+
+type Service interface {
+    // Reads
+    GetUser(ctx context.Context, id uuid.UUID) (*HumanUser, error)
+    GetUserByEmail(ctx context.Context, email string) (*HumanUser, error)
+    GetAgent(ctx context.Context, id uuid.UUID) (*AgentIdentity, error)
+    GetAgentsByParentUser(ctx context.Context, userID uuid.UUID) ([]*AgentIdentity, error)
+    LookupIdentityForCache(ctx context.Context, principalID uuid.UUID) (*cache.IdentityCacheEntry, error)
+
+    // Creates (#15-stub + #15-postgres)
+    CreateUser(ctx context.Context, email, plaintextCredential string) (*HumanUser, error)
+    CreateAgent(ctx context.Context, parentUserID uuid.UUID, displayName string, scope []string) (*AgentIdentity, error)
+
+    // Reputation (#15-postgres)
+    SetAgentReputationScore(ctx context.Context, agentID uuid.UUID, score float64) error
+
+    // Revocation surface (#15-revocation)
+    DisableUser(ctx context.Context, id uuid.UUID, reason string) error
+    RevokeAgent(ctx context.Context, id uuid.UUID, reason string) error
+    UpdateAgentPermissions(ctx context.Context, id uuid.UUID, scope []string) error
+
+    // Org membership (#15-revocation)
+    AddOrgMember(ctx context.Context, orgID, userID uuid.UUID, role string) error
+    RemoveOrgMember(ctx context.Context, orgID, userID uuid.UUID) error
+}
+```
+
+**Method-level rationale.**
+
+- `GetAgentsByParentUser` — uses existing `idx_agent_identities_parent_user_id`; PR engine + edge identity resolution will need it. Cheap to ship now.
+- `LookupIdentityForCache` — loader callback for `cache.GetIdentity`. Without it, edge plane reaches past the service into `IdentityReader` (plane-boundary breach).
+- `SetAgentReputationScore` — see D4.
+- `DisableUser` / `RevokeAgent` / `UpdateAgentPermissions` — emit the events that #27 consumes.
+- `AddOrgMember` / `RemoveOrgMember` — emit `org.member_added` / `org.member_removed` (the latter is one of #27's target events).
+
+**Out of scope.** OAuth-app CRUD, `RotateCredential`, transfer of agent ownership, multi-org agent membership.
+
+### D3 — `credential_hash` policy lives in the service
+
+**Decision.** `CreateUser(ctx, email, plaintextCredential string)`. The service hashes via a `CredentialHasher` interface (ADR-017 swap surface):
+
+```go
+// plane/application/identity/credential.go
+type CredentialHasher interface {
+    Hash(plaintext string) (hashed string, err error)
+    Verify(plaintext, hashed string) (ok bool, needsRehash bool)
+}
+
+// Default impl: argon2id with parameters m=64MB, t=3, p=2.
+type Argon2idHasher struct{ /* params */ }
+```
+
+**Rationale.** If callers hash, three different hash functions emerge across edge / signup / admin paths within six months. The column constraint is "hash, not plaintext" — a security invariant. Hashing internal preserves that.
+
+**Open follow-up.** Argon2id parameters MAY warrant their own ADR if cross-team review wants them pinned. For #15 purposes, pin in code with constants; revisit if compliance asks.
+
+**Edge plane never sees plaintext** post-TLS-termination at Envoy. Signup endpoint (Phase-2) hands the service plaintext over a process boundary internal to the application plane.
+
+### D4 — Reputation as `Set`, not `delta`
+
+**Decision.** `SetAgentReputationScore(ctx, agentID, score float64)` clamps `score` to `[0.0, 1.0]` before write. Emits `agent.reputation_updated` with payload:
+
+```json
+{
+  "agent_id": "<uuid>",
+  "old_score": 0.8000,
+  "new_score": 0.6500,
+  "delta": -0.1500,
+  "computed_at": "<RFC3339Nano>"
+}
+```
+
+**Rejected.** `UpdateAgentReputationScore(ctx, agentID, delta float64)` (read-modify-write). Concurrent updates trigger 40001 retry storms; each retry replays the read-modify-write. Reputation scoring runs offline (analytics → compute new score → call service); the caller already knows the target score.
+
+**Implication.** `delta` in the payload is computed by the service from `(new - old)` after read; this is a read step inside the same Tx that performs the write — cheap, no concurrency hazard.
+
+### D5 — Outbox payload is metering-ready from day one
+
+**Decision.** `agent.created` and `user.created` payloads include the metering plane's required fields even though no metering consumer exists yet:
+
+```json
+// agent.created
+{
+  "agent_id": "<uuid>",
+  "parent_user_id": "<uuid>",
+  "display_name": "code-reviewer",
+  "permission_scope": ["repo:read", "issue:write"],
+  "rate_bucket": "agent_default",
+  "session_quota": 4,
+  "tokens_per_week_cap": 100000000,
+  "reputation_score": 0.5000,
+  "quota_account_id": "<uuid|null>",
+  "principal_class": "agent",
+  "created_at": "<RFC3339Nano>",
+  "_envelope_version": 1
+}
+
+// user.created
+{
+  "user_id": "<uuid>",
+  "email": "<email>",
+  "rate_bucket": "human_default",
+  "quota_account_id": "<uuid|null>",
+  "principal_class": "user",
+  "created_at": "<RFC3339Nano>",
+  "_envelope_version": 1
+}
+```
+
+**Rationale.** Adding these fields after the fact requires a migration on every consumer (search, webhook, billing, audit) once they exist. Cheap to include now.
+
+**`_envelope_version`** — payload-level version distinct from the envelope-level `EventEnvelope.version`. Allows in-place backwards-compatible evolution of identity payloads (per #12 spec D4) without bumping the topic version.
+
+### D6 — Revocation event payloads include `affected_principal_ids[]`
+
+**Decision.** `org.member_removed` and `principal.permissions_changed` include an explicit array of affected principal IDs, NOT just `aggregate_id`:
+
+```json
+// org.member_removed (aggregate_id = org_id)
+{
+  "org_id": "<uuid>",
+  "removed_user_id": "<uuid>",
+  "removed_by": "<uuid>",
+  "affected_principal_ids": ["<user_uuid>"],
+  "reason": "<string>",
+  "removed_at": "<RFC3339Nano>",
+  "_envelope_version": 1
+}
+
+// principal.permissions_changed (aggregate_id = agent_id or user_id)
+{
+  "principal_id": "<uuid>",
+  "principal_class": "agent",
+  "old_scope": ["repo:read"],
+  "new_scope": ["repo:read", "issue:write"],
+  "affected_principal_ids": ["<agent_uuid>"],
+  "changed_at": "<RFC3339Nano>",
+  "_envelope_version": 1
+}
+```
+
+**Rationale.** #27 invalidates `IdentityKey<aggregate_id>`. For `org.member_removed`, `aggregate_id` is the org, not the user whose cache entry must die. Without `affected_principal_ids[]`, the invalidator either guesses or scans. Including the list makes #27's logic mechanical.
+
+**Schema implication.** `events/identity/org.member_removed.schema.json` and `events/identity/principal.permissions_changed.schema.json` declare `affected_principal_ids` as required.
+
+### D7 — Postgres impl uses `MetadataStore.Transact` exclusively
+
+**Decision.** Every state-mutating method calls `store.Transact(ctx, func(tx Tx) error)`. Inside the Tx:
+
+1. Validate input.
+2. `tx.Identity().Insert<X>` (or update).
+3. `tx.WriteOutbox(DomainIdentity, "human_user", userID, "user.created", payload)`.
+4. Return nil → commit.
+
+Outside the Tx: nothing observable to the caller.
+
+**40001 handling.** `Transact` returns the original `40001` error. Service-level methods wrap with the `store.IsRetryable(err)` helper from #14 + bounded retry (max 3 attempts, 10–100ms jitter). Retry loop in `plane/application/identity/retry.go`.
+
+**No ad-hoc Tx.** Service code never opens a Tx outside `MetadataStore.Transact`.
+
+### D8 — Stub impl mirrors postgres semantics for testability
+
+**Decision.** `plane/application/identity/stub_service.go` uses a stub `MetadataStore` (same factory as #35 compliance suite). Stub records:
+
+- All inserted `HumanUser` / `AgentIdentity` rows.
+- All outbox writes (domain, aggregate_type, aggregate_id, event_type, payload).
+
+Service-level tests assert outbox writes happen in the same Tx as source-row writes (rollback removes both — the stub's `Tx` records writes only on commit).
+
+**Skips.** 40001 race tests are skipped on the stub with explicit `t.Skip("40001 race covered by postgres compliance suite")`.
+
+### D9 — Plane-boundary imports
+
+**Allowed imports for `plane/application/identity/`:**
+
+- `plane/data/store` (interface)
+- `plane/data/cache` (interface, for `LookupIdentityForCache` consumers; service itself does not call cache)
+- `plane/data/kafka` (envelope + topic constants only — no producer)
+
+**Forbidden imports:**
+
+- `plane/data/outbox` (only the polling consumer publishes)
+- `plane/data/store/postgres` (concrete) — the service receives the interface from main
+- Any `pgx*` package — the interface hides it
+- Any other plane's internal package
+
+### D10 — Wiring + binary
+
+**Decision.** Identity service ships as a library + a thin binary:
+
+```
+plane/application/identity/         # library (Service + impl + models)
+cmd/identity-service/main.go        # gRPC server (#15-revocation lands the gRPC surface)
+```
+
+#15-stub + #15-postgres ship the library only. #15-revocation lands `cmd/identity-service/main.go` along with the gRPC surface that `appclient.IdentityClient` (from #33) consumes.
+
+## 3. Files to add
+
+### #15-stub
+
+```
+plane/application/identity/doc.go
+plane/application/identity/models.go            # HumanUser, AgentIdentity
+plane/application/identity/service.go           # Service interface
+plane/application/identity/credential.go        # CredentialHasher + Argon2idHasher
+plane/application/identity/retry.go             # bounded serializable retry helper
+plane/application/identity/events.go            # event-type constants + payload structs
+plane/application/identity/stub_service.go      # uses stub MetadataStore from #14
+plane/application/identity/stub_service_test.go
+```
+
+### #15-postgres
+
+```
+plane/application/identity/postgres_service.go
+plane/application/identity/postgres_service_test.go
+plane/application/identity/integration_test.go  # testcontainers PG; asserts source+outbox same Tx
+plane/data/events/identity/user.created.schema.json
+plane/data/events/identity/agent.created.schema.json
+plane/data/events/identity/agent.reputation_updated.schema.json
+```
+
+### #15-revocation
+
+```
+plane/application/identity/revocation.go
+plane/application/identity/revocation_test.go
+plane/application/identity/integration_revocation_test.go
+plane/data/events/identity/user.disabled.schema.json
+plane/data/events/identity/agent.revoked.schema.json
+plane/data/events/identity/principal.permissions_changed.schema.json
+plane/data/events/identity/org.member_added.schema.json
+plane/data/events/identity/org.member_removed.schema.json
+internal/proto/identity/v1/identity.proto
+internal/proto/identity/v1/identity.pb.go      # generated
+internal/proto/identity/v1/identity_grpc.pb.go # generated
+cmd/identity-service/main.go
+plane/workflow/appclient/identity_grpc.go      # gRPC impl of appclient.IdentityClient
+```
+
+## 4. Files to modify
+
+| Path | Change |
+|---|---|
+| `plane/data/store/postgres/identity_reader.go` | bodies filled in #14; #15 uses them |
+| `plane/data/store/postgres/identity_writer.go` | bodies filled in #14; #15 uses them |
+| `plane/workflow/appclient/identity.go` | gRPC client impl in #15-revocation (interface from #33) |
+
+## 5. Implementation plan
+
+### #15-stub (depends on #14 only)
+
+1. `models.go` — domain types.
+2. `events.go` — event type constants + payload structs (D5, D6).
+3. `service.go` — `Service` interface (D2).
+4. `credential.go` — `CredentialHasher` + `Argon2idHasher`.
+5. `retry.go` — `WithSerializableRetry` helper using `store.IsRetryable`.
+6. `stub_service.go` — implementation atop stub `MetadataStore`.
+7. `stub_service_test.go` — unit tests for every method, asserting outbox writes via stub recorder.
+8. PR opens as draft alongside #35.
+
+### #15-postgres (depends on #14 + #35)
+
+9. `postgres_service.go` — impl using real `MetadataStore.Transact`.
+10. `postgres_service_test.go` — uses postgres `MetadataStore` against testcontainers.
+11. `integration_test.go` — asserts source row + outbox row in same Tx; rollback removes both.
+12. JSON schemas for `user.created`, `agent.created`, `agent.reputation_updated`.
+13. Run `lint-events` (from #31) — schemas must validate.
+14. PR opens after #35 merges.
+
+### #15-revocation (depends on #15-postgres)
+
+15. `revocation.go` — `DisableUser`, `RevokeAgent`, `UpdateAgentPermissions`, `AddOrgMember`, `RemoveOrgMember` impls.
+16. JSON schemas for `user.disabled`, `agent.revoked`, `principal.permissions_changed`, `org.member_added`, `org.member_removed`.
+17. `internal/proto/identity/v1/identity.proto` + generation.
+18. `cmd/identity-service/main.go` — gRPC server.
+19. `plane/workflow/appclient/identity_grpc.go` — gRPC client impl of `IdentityClient` interface from #33.
+20. Integration test for full revocation flow + cache invalidation observability.
+
+## 6. Acceptance criteria
+
+### #15-stub
+
+- [ ] `Service` interface exports the methods listed in D2.
+- [ ] `Argon2idHasher` hashes + verifies; pinned parameters documented in code.
+- [ ] Stub impl passes service-level test suite.
+- [ ] All outbox writes carry metering-ready payloads (D5).
+- [ ] `go test ./plane/application/identity/...` clean (unit only).
+
+### #15-postgres
+
+- [ ] Postgres impl uses `MetadataStore.Transact` exclusively.
+- [ ] Integration test: `CreateUser` writes `human_users` row + `identity_outbox` row in same Tx; rollback removes both.
+- [ ] Integration test: 40001 retry helper succeeds within 3 attempts under contended writes.
+- [ ] All identity event schemas validate against `lint-events`.
+- [ ] `go test -tags integration ./plane/application/identity/...` clean.
+
+### #15-revocation
+
+- [ ] All revocation methods emit the documented events with `affected_principal_ids[]`.
+- [ ] gRPC service compiles and serves; `appclient.IdentityClient` round-trips successfully.
+- [ ] `cmd/identity-service` boots against docker-compose.
+- [ ] #27 integration test (under #27's PR) consumes a `user.disabled` event end-to-end.
+
+## 7. Open follow-ups (not in this issue)
+
+- **Argon2id parameter ADR** — file if cross-team review wants them governance-locked.
+- **Multi-org agent membership** — out of scope; current schema permits one parent_user only.
+- **OAuth-app CRUD** — separate issue post-Phase-1.
+- **Identity gRPC surface for edge plane** — `cmd/identity-service` ships in #15-revocation; edge plane integration is Phase-2.
+- **Metering plane consumer** — D5 makes the event payloads metering-ready; the consumer itself is Phase-2.
+
+## 8. Risk mitigations
+
+| Risk | Mitigation |
+|---|---|
+| Service interface grows ad-hoc across 3 PRs | This spec locks the final list; deviation requires a spec amendment |
+| 40001 retry helper used inconsistently across methods | All state mutations route through `WithSerializableRetry`; lint check `grep -L "WithSerializableRetry" postgres_service.go` in CI |
+| Stub drift from postgres impl | Compliance suite (#35) is shared; service-level tests use stub MetadataStore + assert outbox-recorder shape mirrors postgres dispatch table |
+| Argon2id params ship with weak defaults | Pinned at m=64MB, t=3, p=2 (OWASP 2026 baseline); ADR follow-up if reviewer wants stricter |
+| `affected_principal_ids[]` missing from old payload schemas in legacy tools | These are new event types; no legacy consumers exist; payload version pinned at 1 |
+
+## 9. Cross-references
+
+- ADR-006 (PostgreSQL), ADR-008 (outbox), ADR-010 (JWT-SVID identity claims), ADR-017 (swap surface).
+- ADR-019 (workflow→app-plane boundary, this PR cycle) — `cmd/identity-service` is the gRPC target.
+- #14 (MetadataStore + Tx) — direct dependency.
+- #35 (compliance suite) — gates #15-postgres.
+- #27 (identity cache invalidator) — consumes #15-revocation events.
+- #33 (workflow bootstrap) — `appclient.IdentityClient` interface defined there, impl lands here.
+- `gitscale-outbox-check` skill — D7 enforces the dual-write avoidance.
+- `gitscale-event-schema` skill — D5/D6 schema additions trigger backwards-compat review.

--- a/docs/superpowers/specs/2026-05-06-issue-33-workflow-bootstrap-design.md
+++ b/docs/superpowers/specs/2026-05-06-issue-33-workflow-bootstrap-design.md
@@ -1,0 +1,355 @@
+# Spec: #33 Workflow plane bootstrap
+
+**Date:** 2026-05-06
+**Issue:** #33 `[Workflow] Plane bootstrap — Temporal worker, namespace, task queue, registry (ADR-003)`
+**Branch:** `feat/workflow-plane-bootstrap`
+**Depends on:** ADR-019 (workflow→app-plane boundary) — must merge first
+**Blocks:** #18 (billing partition rollover), all future workflows
+
+## 1. Context
+
+`plane/workflow/` is empty (only `doc.go`). #33 is the first workflow-plane code. Three workflows are queued behind it: #18 (billing partition rollover), future agent-session orchestration, future CI pipelines (Firecracker provisioning). All three need a shared bootstrap: worker entrypoint, namespace + task-queue conventions, registration scaffolding, plane-boundary adapters, determinism enforcement.
+
+ADR-003 (Temporal) is silent on layout, registration, and queue naming — those are gap-fills locked here.
+
+## 2. Decisions
+
+### D1 — Temporal namespace is env-derived, not literal
+
+**Decision.** Namespace = `gitscale-${env}` where `env ∈ {prod, staging, dev}`. Read from env var `TEMPORAL_NAMESPACE` at worker start; fail fast if unset.
+
+**Rejected.** Single literal `gitscale` namespace. Namespaces are the retention/RBAC/archival boundary in Temporal; a single literal name forces cross-env ACLs and conflates dev history with prod history.
+
+**Rejected.** Per-tenant namespaces. Known anti-pattern at scale — namespaces are shard-expensive. Tenant isolation lives in workflow ID prefix + search attributes (Phase-2 concern).
+
+**Implication.** `cmd/workflow-worker/main.go` reads `TEMPORAL_NAMESPACE` from env, no default.
+
+### D2 — Task queues by workload, not by tenant
+
+**Decision.** Three task queues named at launch:
+
+| Queue | Owner | Status at #33 |
+|---|---|---|
+| `billing-maintenance` | data-plane operations (#18 ships first) | active |
+| `agent-sessions` | future agent-session workflows | constant only |
+| `ci-pipelines` | future Firecracker provisioning | constant only |
+
+Constants live in `plane/workflow/queues.go`:
+
+```go
+package workflow
+
+const (
+    QueueBillingMaintenance = "billing-maintenance"
+    QueueAgentSessions      = "agent-sessions"
+    QueueCIPipelines        = "ci-pipelines"
+)
+```
+
+**Rationale.** Coarse-by-workload keeps Temporal's task-queue routing meaningful. Per-tenant or per-domain queues lead to queue-explosion + uneven worker load.
+
+### D3 — No `adapters/data/` umbrella; selective wrapping
+
+**Decision.**
+
+- **Direct import** of `plane/data/store` and `plane/data/cache` interfaces from activity constructors. No re-export, no umbrella adapter. Architect verdict: redundant interface layer over `MetadataStore` / `CacheStore` will drift.
+- **New package** `plane/workflow/appclient/` for HTTP/gRPC clients into application-plane services (e.g. `IdentityClient`). This IS a new wrapper, not a re-export, because the transport layer is genuinely workflow-plane code.
+
+**Activity constructor shape.**
+
+```go
+type CreatePartitionActivity struct {
+    metadataStore store.MetadataStore // direct interface from plane/data/store
+}
+
+type CreateUserActivity struct {
+    identityClient appclient.IdentityClient // wraps gRPC into plane/application/identity
+}
+```
+
+**Rationale.** Direct imports are safe because `plane/data/store` and `plane/data/cache` already define the swap surfaces (ADR-017). Re-wrapping them produces two parallel interfaces that drift. `appclient/` is justified because no equivalent interface exists in the app plane today.
+
+**Constraint.** Activities MUST receive interfaces, never concretes. Workflow code MUST NOT import either package directly (only activities do).
+
+### D4 — Registry by task-queue bundle
+
+**Decision.** `plane/workflow/registry.go`:
+
+```go
+package workflow
+
+// Bundle is the unit of registration for one task queue. A worker registers
+// exactly one Bundle per queue it serves.
+type Bundle struct {
+    TaskQueue  string
+    Workflows  []any // workflow funcs or struct-method pairs
+    Activities []any
+}
+
+// Registrar is implemented by *worker.Worker.
+type Registrar interface {
+    RegisterWorkflow(any)
+    RegisterActivity(any)
+}
+
+// Apply registers all workflows and activities in this Bundle on the given worker.
+func (b Bundle) Apply(r Registrar) {
+    for _, wf := range b.Workflows {
+        r.RegisterWorkflow(wf)
+    }
+    for _, a := range b.Activities {
+        r.RegisterActivity(a)
+    }
+}
+```
+
+`cmd/workflow-worker/main.go` collects Bundles from each domain package and applies one Bundle per queue. New workflows plug in by exporting a `Bundle()` function from their package; `main.go` pulls the bundle without modification.
+
+**Slot for ADR-015 ApprovalActivity.** A `Bundle` from `plane/workflow/approval/` (future) registers the `ApprovalActivity` on every queue that may need plan-approval gating. No registry change required when ADR-015 lands.
+
+### D5 — Determinism enforcement = externalised rules + lint script
+
+**Decision.** Rules live in `plane/workflow/lint/determinism-rules.txt` (one regex per line, `#`-comments). `plane/workflow/lint/lint-determinism.sh` reads rules + greps Go files under `plane/workflow/**/workflow*.go` and `plane/workflow/**/workflows/*.go`.
+
+**Initial rule set.**
+
+```
+# Time and randomness
+\btime\.Now\(\)
+\btime\.After\(
+\btime\.NewTimer\(
+\bmath/rand\b
+\bcrypto/rand\b
+\bgoogle\.uuid\.New[^V]
+# I/O and config
+\bos\.Getenv\(
+\bnet/http\b
+\bnet\.[A-Z]
+# Concurrency primitives
+\bsync\.[A-Z]
+\bgo\s+func\(
+\bmake\(chan\b
+# Control flow over maps (warning, not failure, unless body has workflow.)
+^\s*for\s+.*\s+:=\s+range\s+.+(?=.*workflow\.)
+```
+
+`workflow.SideEffect` and `workflow.MutableSideEffect` are the escape hatches. Activity files (`activity*.go`, `activities/*.go`) are exempt — activities are the I/O boundary per ADR-003.
+
+**CI step.** `.github/workflows/go.yml` adds `make lint-determinism` (config + script committed in same PR — CLAUDE.md CI linter rule).
+
+**Test fixture.** `plane/workflow/lint/testdata/bad/forbidden_time_now.go` and friends exist; integration test runs `lint-determinism.sh` against them and asserts non-zero exit. Proves the lint isn't silently passing.
+
+### D6 — Schedule API, not cron string
+
+**Decision.** Workflows wanting cron behaviour (#18) use Temporal's Schedule API (`client.ScheduleClient().Create(...)`), not the legacy `cron_schedule` workflow option.
+
+**Rationale.** Schedule API is discoverable (`tctl schedule list`), pausable, supports backfill, and survives namespace migrations. Cron strings are opaque and untyped.
+
+**Implementation.** Helper `plane/workflow/schedule.go`:
+
+```go
+func EnsureSchedule(ctx context.Context, c client.Client, spec ScheduleSpec) error
+```
+
+Idempotent: creates if absent, updates if drifted.
+
+### D7 — OTel interceptor wired in registry
+
+**Decision.** `cmd/workflow-worker/main.go` builds the worker with `temporal.io/sdk/contrib/opentelemetry` interceptors so workflow + activity spans are emitted with proper parent-child linkage.
+
+**Resource attributes.**
+
+| Attr | Value |
+|---|---|
+| `service.name` | `gitscale-workflow-worker` |
+| `service.namespace` | `gitscale-${env}` |
+| `service.instance.id` | hostname or k8s pod name |
+
+OTLP endpoint via env var `OTEL_EXPORTER_OTLP_ENDPOINT`.
+
+### D8 — Worker options pinned + env-tunable
+
+**Decision.** Defaults in code; override via env.
+
+| Option | Default | Env |
+|---|---|---|
+| `MaxConcurrentActivityExecutionSize` | 100 | `WORKER_MAX_CONCURRENT_ACTIVITIES` |
+| `MaxConcurrentWorkflowTaskPollers` | 4 | `WORKER_WORKFLOW_POLLERS` |
+| `MaxConcurrentActivityTaskPollers` | 4 | `WORKER_ACTIVITY_POLLERS` |
+| `WorkerStopTimeout` | 30s | `WORKER_STOP_TIMEOUT` |
+| `EnableSessionWorker` | false | — |
+
+### D9 — Default RetryPolicy per activity
+
+**Decision.** No activity uses Temporal's default unlimited retries. Helper:
+
+```go
+package workflow
+
+func DefaultRetryPolicy() *temporal.RetryPolicy {
+    return &temporal.RetryPolicy{
+        InitialInterval:    1 * time.Second,
+        BackoffCoefficient: 2.0,
+        MaximumInterval:    60 * time.Second,
+        MaximumAttempts:    5,
+        // NonRetryableErrorTypes: per-activity, set in ActivityOptions
+    }
+}
+```
+
+Workflows that want different policy override per-activity in `ActivityOptions`. `CreatePartition` (#18) explicitly sets `MaximumAttempts: 5` — DDL retries should not loop forever.
+
+### D10 — Single-domain activity rule
+
+**Decision.** No activity writes more than one domain's outbox row. Cross-domain workflows compose per-domain saga steps with explicit compensation.
+
+**Enforcement.** Code review only at this stage (no static check). Documented in `plane/workflow/README.md` and ADR-019.
+
+### D11 — `workflow.GetVersion` + continue-as-new helpers land in #33
+
+**Decision.** Project-wide constants:
+
+```go
+package workflow
+
+const (
+    // ContinueAsNewThreshold is the default event-history size threshold
+    // beyond which a long-running workflow should call ContinueAsNew.
+    ContinueAsNewThreshold = 8000
+)
+
+// ShouldContinueAsNew is the canonical check; long workflows call it after each step.
+func ShouldContinueAsNew(ctx workflow.Context) bool {
+    info := workflow.GetInfo(ctx)
+    return info.GetCurrentHistoryLength() >= ContinueAsNewThreshold
+}
+```
+
+`#18` does not need this (single-shot per cron firing) but the helper lands in #33 so future agent-session workflows have a default ready.
+
+### D12 — Canary workflow exercises one read-only activity through real adapter
+
+**Decision.** Canary is NOT no-op. Shape:
+
+```go
+// plane/workflow/canary/workflow.go
+func HealthRoundTripWorkflow(ctx workflow.Context) (string, error) {
+    var got string
+    err := workflow.ExecuteActivity(ctx, ReadHealthKeyActivity).Get(ctx, &got)
+    return got, err
+}
+```
+
+`ReadHealthKeyActivity` does `cache.Get(ctx, "gitscale:${env}:workflow:health")`. Integration test:
+
+1. Spin Temporal dev server + Redis testcontainer.
+2. Set the health key directly.
+3. Trigger the canary workflow via `client.ExecuteWorkflow`.
+4. Assert returned value matches.
+
+This proves: registry wiring, queue routing, adapter wiring (cache import), OTel propagation, env-derived namespace, worker options. Bare no-op proves only that the worker starts.
+
+## 3. Files to add
+
+```
+cmd/workflow-worker/main.go
+plane/workflow/queues.go
+plane/workflow/registry.go
+plane/workflow/schedule.go
+plane/workflow/retrypolicy.go
+plane/workflow/continueasnew.go
+plane/workflow/appclient/identity.go         # interface only at #33; impl follows #15-revocation
+plane/workflow/appclient/doc.go
+plane/workflow/lint/determinism-rules.txt
+plane/workflow/lint/lint-determinism.sh
+plane/workflow/lint/testdata/bad/forbidden_time_now.go
+plane/workflow/lint/testdata/bad/forbidden_uuid_new.go
+plane/workflow/lint/testdata/good/clean_workflow.go
+plane/workflow/canary/workflow.go
+plane/workflow/canary/activity.go
+plane/workflow/canary/bundle.go
+plane/workflow/canary/integration_test.go
+plane/workflow/README.md                     # documents D1–D12
+.github/workflows/go.yml                     # adds make lint-determinism
+Makefile                                     # adds lint-determinism target
+```
+
+## 4. Files to modify
+
+| Path | Change |
+|---|---|
+| `Makefile` | add `lint-determinism` target |
+| `.github/workflows/go.yml` | add CI step running `make lint-determinism` |
+| `.env.example` | add `TEMPORAL_NAMESPACE`, `TEMPORAL_HOST`, `WORKER_*` defaults |
+| `docker-compose.yml` | add Temporal dev server (port 7233) for local dev |
+
+## 5. Implementation plan
+
+### Phase A — boilerplate (no Temporal deps)
+
+1. `plane/workflow/queues.go` — task queue constants.
+2. `plane/workflow/registry.go` — `Bundle` + `Registrar` + `Apply`.
+3. `plane/workflow/retrypolicy.go` — `DefaultRetryPolicy`.
+4. `plane/workflow/continueasnew.go` — threshold + `ShouldContinueAsNew`.
+5. `plane/workflow/lint/determinism-rules.txt` + `lint-determinism.sh` + testdata.
+6. `Makefile` lint target + CI step.
+7. Verify `make lint-determinism` exits 1 on bad fixtures, 0 on good.
+
+### Phase B — Temporal worker
+
+8. `go.mod`: add `go.temporal.io/sdk` + `go.temporal.io/sdk/contrib/opentelemetry`.
+9. `cmd/workflow-worker/main.go` — Temporal client, namespace from env, OTel interceptors, signal handling, graceful `worker.Stop()`.
+10. `plane/workflow/schedule.go` — `EnsureSchedule` helper.
+11. `.env.example` + `docker-compose.yml` — local dev wiring.
+
+### Phase C — appclient interface
+
+12. `plane/workflow/appclient/identity.go` — `IdentityClient` interface (impl deferred to #15-revocation Wave; stub returns `errNotImplemented`).
+
+### Phase D — canary
+
+13. `plane/workflow/canary/{workflow,activity,bundle}.go`.
+14. `plane/workflow/canary/integration_test.go` — Temporal dev server + Redis testcontainer.
+15. `cmd/workflow-worker/main.go` registers the canary bundle on `QueueBillingMaintenance`.
+
+### Phase E — docs
+
+16. `plane/workflow/README.md` — document D1–D12, plane boundary, single-domain rule, registry conventions.
+17. PR description includes ADR-019 cross-link + acceptance-criteria checklist.
+
+## 6. Acceptance criteria
+
+- [ ] `cmd/workflow-worker` builds; binary boots with `TEMPORAL_NAMESPACE=gitscale-dev` against docker-compose Temporal.
+- [ ] Canary integration test passes (real Redis testcontainer, Temporal dev server).
+- [ ] `make lint-determinism` is wired into CI and demonstrably fails on bad fixtures.
+- [ ] `plane/workflow/README.md` documents D1–D12.
+- [ ] No `plane/workflow/adapters/data/` package exists.
+- [ ] `appclient.IdentityClient` interface compiles; impl stub returns sentinel.
+- [ ] Worker stops gracefully on SIGTERM (in-flight activities drain within `WorkerStopTimeout`).
+
+## 7. Open items deferred to follow-up issues
+
+- **`appclient.IdentityClient` gRPC implementation** — depends on #15-revocation defining the gRPC surface. Tracked under #15-revocation.
+- **`agent-sessions` and `ci-pipelines` queue workflows** — out of scope; constants only at #33.
+- **Tenant isolation via search attributes** — Phase-2.
+- **Replica coordination** — Temporal handles this natively via task queues; no custom sharding.
+
+## 8. Risk mitigations
+
+| Risk | Mitigation |
+|---|---|
+| Determinism lint regex set incomplete | Externalized rules file; new rules added without script change |
+| Worker config skew between dev / staging / prod | All knobs env-tunable; defaults pinned in code; `.env.example` is the contract |
+| OTel collector mis-configured silently | Worker logs OTLP target at startup; alarm on missing spans in canary integration test |
+| `appclient` stub merged but no impl follow-up | Issue #33 explicitly cross-links the gRPC follow-up under #15-revocation |
+| Temporal dev server flake in CI | Use `go.temporal.io/sdk/testsuite` time-skipping environment for unit tests; only canary integration test boots the dev server |
+
+## 9. Cross-references
+
+- ADR-003 (Temporal orchestration) — governs determinism, activity-as-IO-boundary.
+- ADR-008 (outbox) — D10 single-domain rule preserves transactional outbox invariant.
+- ADR-015 (plan approval) — D4 registry leaves slot for `ApprovalActivity`.
+- ADR-017 (interface swap surface) — D3 direct-import of `plane/data/store` + `plane/data/cache` interfaces.
+- ADR-019 (workflow→app-plane boundary, this PR cycle) — formalises D3 + D10.
+- `gitscale-temporal-determinism` skill — canonical rule reference for D5.
+- `gitscale-plane-boundary` skill — enforces D3 import constraints.

--- a/docs/superpowers/specs/2026-05-06-issue-34-billing-archival-tier-spike.md
+++ b/docs/superpowers/specs/2026-05-06-issue-34-billing-archival-tier-spike.md
@@ -1,0 +1,235 @@
+# Spike + ADR draft: #34 Billing `usage_events` archival tier and format
+
+**Date:** 2026-05-06
+**Issue:** #34 `[ADR] Billing usage_events archival tier and format`
+**Status:** Spike complete; recommended decisions ready for ADR-018
+**Branch:** `adr/data-billing-archival-tier`
+**Blocks:** #18-archive (the archive arm of the partition rollover workflow)
+
+## 1. Context
+
+`005_billing.sql` (#23, merged) creates `billing.usage_events` partitioned monthly with 12 initial partitions covering 2026-05 through 2027-04. Issue #18 will add a Temporal workflow that:
+
+1. Rolls partitions forward (creates the next month's partition before EoM).
+2. Detaches and archives partitions older than the retention horizon.
+
+The archival activity needs a target storage tier and format. **No ADR currently specifies this.** ADR-002 (Git tiering) covers Git data; ADR-011 (per-org encryption with scoped dedup) governs cold-tier Git encryption. Neither covers operational analytics / billing data.
+
+#34 lists 7 open questions. This spike resolves each with a recommendation backed by the data-shape and access-pattern profile of `usage_events`.
+
+## 2. Data-shape profile
+
+From `005_billing.sql`:
+
+| Property | Value |
+|---|---|
+| Table | `billing.usage_events` |
+| Partitioning | `PARTITION BY RANGE (ts)` |
+| Partition stride | 1 month |
+| Row volume estimate | ~10⁹ rows / month at scale (agent traffic dominates per CLAUDE.md core principle 1) |
+| Row size estimate | ~200 bytes (UUIDs + numeric counters + JSONB cost_vector) |
+| Monthly partition size estimate | ~200 GB raw / ~60 GB Parquet+zstd |
+| Read pattern | Audit (rare, broad scan), reconciliation (rare, broad scan), dispute investigation (very rare, point lookup) |
+| Write pattern | Append-only via outbox-driven idempotent insert (`external_event_id UNIQUE`) |
+| Compliance horizon | US tax + SOC2: 7 years for invoice-supporting data |
+
+The profile is unambiguous: **cold, append-only, broad-scan analytical reads, mandatory long retention**. This is the canonical analytics-lake profile.
+
+## 3. Decision matrix — seven open questions
+
+### Q1 — Storage target
+
+| Option | Pros | Cons | Verdict |
+|---|---|---|---|
+| **Same S3-compatible bucket as Git cold tier** | One bucket to operate; existing IAM scope | Mixed access patterns (Git cold = small random reads on EC stripes; billing archive = large sequential scans on Parquet) → cache + lifecycle policies fight each other; encryption scope (ADR-011) is per-org for Git, but billing data is org-keyed not repo-keyed → org-master-key reuse semantically ambiguous | **Reject** |
+| **Separate analytics-lake bucket** | Clean access-pattern segregation; lifecycle policy simple (Glacier transition at 90 days); IAM scope minimal (read = analyst+reconciler; write = workflow worker only) | One more bucket; one more IAM policy | **Recommend** |
+
+**Recommendation: separate analytics-lake bucket** named `gitscale-analytics-${env}`. Lifecycle: standard tier 0–90 days, Glacier Instant Retrieval 90 days–2 years, Glacier Deep Archive 2y–7y, expire at 7y+30d.
+
+### Q2 — Erasure coding vs replication
+
+| Option | Pros | Cons | Verdict |
+|---|---|---|---|
+| **(10,4) Reed-Solomon EC (mirrors ADR-002 cold-tier)** | ~93% storage-cost saving vs replication; existing project EC tooling | Complex for a small dataset; reconstruct cost on broad scans is real; data set is < 25 TB even after 7 years (~0.01% of Git cold tier) | **Reject** |
+| **3× replication (S3 default)** | Operationally trivial — S3 does it; no code path to maintain; suits broad-scan analytical reads | Higher per-GB cost than EC | **Recommend** |
+| **S3 + Glacier tiers (lifecycle managed)** | S3 picks the right durability shape per tier; ~95% cost reduction without us building EC for analytics | Restore latency from Glacier Deep is hours | **Adopt** for old partitions (>2y) |
+
+**Recommendation: 3× replication via S3 standard tier for ≤90 days; lifecycle to Glacier classes for older partitions.** No project-side EC for billing archive. This is a different cost-shape than Git cold tier (where every read is interactive) — billing reads are batch-acceptable.
+
+### Q3 — Format
+
+| Option | Pros | Cons | Verdict |
+|---|---|---|---|
+| **JSONL** | Trivial to write; easy to grep | ~3× the storage of Parquet; no column projection; no predicate pushdown | **Reject** |
+| **Parquet + zstd** | Columnar; ~70% smaller than JSONL; predicate pushdown via Athena/Trino/DuckDB; rich timestamp + numeric type support; mature Go writers (`parquet-go`) | Schema discipline required; small writer learning curve | **Recommend** |
+| **Avro** | Strong schema; Confluent ecosystem | Row-oriented; loses predicate-pushdown advantage; bigger than Parquet | **Reject** |
+
+**Recommendation: Parquet + zstd compression, one file per detached partition** (~60 GB compressed for a typical month). Schema embedded in the file's footer. Writer: `github.com/parquet-go/parquet-go`.
+
+**File layout.**
+
+```
+s3://gitscale-analytics-${env}/billing/usage_events/
+  year=2026/month=05/
+    usage_events_2026_05.parquet          # main file
+    usage_events_2026_05.manifest.json    # row count, hash, schema version, source partition name
+    usage_events_2026_05.checksum.sha256  # integrity check
+```
+
+Hive-style partitioning (`year=YYYY/month=MM/`) makes Athena/Trino partition pruning work without configuration.
+
+### Q4 — Query path
+
+| Option | Pros | Cons | Verdict |
+|---|---|---|---|
+| **Athena (AWS) / Trino (cloud-agnostic)** | SQL surface; Hive partitioning; minimal new infrastructure | Cost per scan; needs IAM + Glue Data Catalog (Athena) or Trino cluster | **Recommend** Athena where AWS-native; Trino where multi-cloud |
+| **DuckDB on local laptop** | Zero infrastructure; analyst-friendly | No central governance; downloads up to TBs to laptop | **Adopt** as fallback; document |
+| **Restore to PG via FDW** | SQL-identical to live data | Slow; requires PG-side resources; doesn't scale to 7y of data | **Adopt** only for dispute-investigation point lookups |
+| **Write-and-forget** | Simplest | Auditors will ask; saying "we have it but cannot read it" is a finding | **Reject** |
+
+**Recommendation: primary query path is Athena (AWS) or Trino (multi-cloud); fallback DuckDB; restore-via-FDW for dispute investigation only.** Glue Data Catalog (or Hive metastore) is registered as part of the archive activity — the workflow registers each new file in the catalog after upload.
+
+### Q5 — Retention horizon
+
+| Driver | Floor |
+|---|---|
+| US tax / SOC2 / invoice-supporting data | 7 years |
+| GDPR (EU customers) | "no longer than necessary" — 7y is defensible; 10y is not |
+| Industry baseline for billing audit | 7 years |
+
+**Recommendation: 18 months hot in PG (active live + 6 month retention overlap), then archive. Total retention 7 years from partition creation. Original issue body proposed 13 months hot; bumping to 18 lets Q1+Q2 reconciliation across calendar-year close happen against live data.**
+
+After 7 years, lifecycle policy expires the file from S3.
+
+**Calendar:**
+
+| Age range | Storage |
+|---|---|
+| 0–18 months | PG live partition |
+| 18 months – 2 years | S3 Standard (Parquet) |
+| 2y – 7y | S3 Glacier Instant Retrieval |
+| 7y – 7y 30d | S3 Glacier Deep Archive (grace) |
+| 7y 30d+ | expired |
+
+### Q6 — Restore path
+
+**Recommendation: tiered, by use case.**
+
+| Use case | Path | Latency |
+|---|---|---|
+| Analyst point query (most common) | Athena query on Parquet directly — no restore needed | seconds–minutes |
+| Reconciliation across multiple months | Athena multi-partition scan | minutes–hours |
+| Dispute investigation requiring SQL semantics identical to live PG | Manual Temporal workflow `RestorePartition(year, month)` — pulls Parquet, loads into a quarantine table in PG, attaches as read-only FDW partition | hours |
+| Bulk export for legal hold | Direct S3 download | depends on volume |
+
+The `RestorePartition` workflow is **out of scope for #18-archive** — it ships as a follow-up. ADR-018 acknowledges its existence; #18-archive does not implement it.
+
+### Q7 — Encryption at rest
+
+**Recommendation: ADR-011 inheritance with scope adjustment.**
+
+| Property | ADR-011 (Git cold tier) | This decision (billing archive) |
+|---|---|---|
+| KEK location | HashiCorp Vault | HashiCorp Vault |
+| KEK scope | Per-org master | **Single platform-master KEK for billing** |
+| DEK derivation | `HKDF(org_master, repo_id)` | `HKDF(platform_master, year-month)` |
+| Object encryption | Per-object content key derivation | Per-file (one KEK use per Parquet file) |
+| Dedup | Within-repo always; cross-repo within-org behind flag | **N/A** — no dedup; usage_events are unique by `external_event_id` |
+| Crypto-shred semantics | Per-repo DEK destroy = O(1) repo deletion | **Per-month DEK destroy = O(1) month-level deletion** for retention enforcement |
+
+**Rationale.** Per-org keys are wrong here: usage_events span all orgs in a single time window; per-org files would explode the file count and break the lifecycle/Athena-pruning model. A platform-level KEK with per-month DEK preserves crypto-shred semantics (retention deletes the month's DEK = the data is unrecoverable) without exploding file cardinality.
+
+**Compliance note.** GDPR right-to-erasure for billing data is bounded by the legal-retention floor — we cannot delete usage_events for an EU customer before the 7y horizon, but we can guarantee post-horizon erasure via DEK destruction.
+
+## 4. Recommended ADR-018 text
+
+The text below is ready to land as ADR-018 in `docs/architecture.md §8`.
+
+---
+
+### ADR-018: Adopted analytics-lake archival for billing `usage_events` (separate bucket, Parquet+zstd, S3 lifecycle, platform-KEK with per-month DEK)
+
+- **Status:** Proposed
+- **Date:** 2026-05-06
+- **Context:** `billing.usage_events` is a high-volume, append-only operational-analytics table partitioned monthly in PostgreSQL. After the hot retention horizon, partitions must be archived in a queryable, durable, encrypted, retention-managed format. ADR-002's Git cold-tier shape (per-org encryption, EC striping) is a poor fit: usage_events span all orgs in a single time window, reads are broad scans rather than small random reads, and the data set is small relative to Git cold storage.
+
+- **Decision:**
+
+  **Storage target.** Separate S3-compatible bucket `gitscale-analytics-${env}` distinct from the Git cold-tier bucket. Hive-partitioned layout `billing/usage_events/year=YYYY/month=MM/usage_events_YYYY_MM.parquet`, plus matching `.manifest.json` and `.checksum.sha256` siblings.
+
+  **Format.** Parquet with zstd compression. Schema embedded; one file per source PG partition. Writer is the `DetachAndArchivePartition` activity in the billing partition rollover workflow (#18-archive).
+
+  **Durability.** S3 standard 3× replication for ≤90 days, lifecycle-transitioned to Glacier Instant Retrieval 90d–2y, Glacier Deep Archive 2y–7y, expired at 7y+30d. No project-managed erasure coding; S3 native durability suffices for this workload's read profile.
+
+  **Hot retention.** 18 months in PG (active + reconciliation overlap), then archive. Total retention 7 years from partition creation; aligned with US tax / SOC2 / industry billing-audit floors.
+
+  **Query path.** Athena (AWS) or Trino (multi-cloud) is the primary analyst query path. Glue Data Catalog (or Hive metastore) is updated by the archive activity after each upload. DuckDB-on-laptop is an acceptable fallback for ad-hoc work. A separate `RestorePartition` Temporal workflow handles dispute investigations that require SQL parity with live PG (out of scope for #18-archive; deferred).
+
+  **Encryption.** Platform-level KEK in HashiCorp Vault. Per-month DEK derived as `HKDF(platform_billing_master, "year-month")`. Each Parquet file is encrypted with one DEK use. Crypto-shred semantics preserved for post-7y deletion: destroying the month's DEK renders the corresponding archive unrecoverable. ADR-011's per-org encryption pattern is intentionally NOT applied here — usage_events span orgs in a single time window, and per-org files would explode cardinality and break Athena partition pruning.
+
+  **Cross-org dedup.** Not applicable. `usage_events.external_event_id UNIQUE` guarantees row uniqueness; there is no dedup decision to make.
+
+- **Consequences:**
+
+  Audit and reconciliation queries are SQL-native via Athena/Trino without restore. Storage cost is ~95% lower at year 2+ vs always-on PG. Crypto-shred preserves post-retention erasure guarantees. The decision is decoupled from ADR-002 (Git cold tier): the two cold tiers can evolve independently. `RestorePartition` capability is acknowledged but deferred. The shape locks in for 7 years of data — schema evolution must be backwards-compatible at the Parquet level (Parquet supports column-add gracefully; column-rename or column-drop is a breaking change and requires a v2 directory).
+
+---
+
+## 5. Implementation plan (for the doc-only PR)
+
+### Files to modify
+
+- `docs/architecture.md` — append ADR-018 text (§ 4 above) after ADR-017 in §8.
+- `docs/architecture.md` §8 ADR-002 — add cross-reference: *"For operational-analytics archives (e.g. billing.usage_events), see ADR-018."*
+- `docs/architecture.md` §8 ADR-011 — add cross-reference: *"Billing archive encryption follows a different KEK scope per ADR-018."*
+
+### Acceptance criteria
+
+- [ ] ADR-018 appears in `docs/architecture.md §8` with `Status: Proposed`.
+- [ ] `make lint-md` introduces zero NEW errors in the modified range.
+- [ ] ADR-002 + ADR-011 carry cross-reference lines.
+- [ ] Issue #34 closed by this PR.
+- [ ] Issue #18-archive references ADR-018 as the unblocker.
+
+## 6. Implementation plan (for #18-archive — referenced from this spec, not implemented in this PR)
+
+The archival workflow's Temporal activity needs to:
+
+1. Detach partition: `ALTER TABLE billing.usage_events DETACH PARTITION billing.usage_events_YYYY_MM CONCURRENTLY`.
+2. Stream rows from detached partition → Parquet writer → S3 multipart upload.
+3. Compute SHA-256 of the Parquet file; write `.checksum.sha256`.
+4. Write `.manifest.json` (row count, schema version, source partition name, archive timestamp, KEK version).
+5. Update Glue Data Catalog / Hive metastore with the new partition pointer.
+6. Drop the detached partition: `DROP TABLE billing.usage_events_YYYY_MM`.
+7. Emit `billing.partition_archived` event to outbox via app-plane RPC (per ADR-019).
+
+Each step is a separate activity; the workflow handles retry + compensation. Compensation: if step 6 fails after S3 upload succeeds, the workflow logs and pages — the partition exists in both places, but no data is lost.
+
+## 7. Risk mitigations
+
+| Risk | Mitigation |
+|---|---|
+| Parquet schema evolution breaks old readers | Use Parquet's optional-field semantics; new fields default to null in old files. Document in archive manifest's `schema_version`. Forbid field rename/drop without a v2 directory. |
+| Glue Data Catalog drifts from S3 reality | Archive workflow writes the catalog entry as a final step; if it fails, the partition is "dark" until a reconciliation workflow runs (out of scope; tracked separately). |
+| KEK rotation during a multi-year retention | DEK is derived from `(platform_master, year-month)`; rotating `platform_master` requires re-wrapping all DEKs. Use Vault's transit engine which handles versioned KEKs natively. Manifest records `kek_version`. |
+| Cost runaway from analyst Athena scans | Per-tenant cost allocation tag on the bucket; alarm on monthly spend > $X; enforce partition-pruning on every ad-hoc query via a query template with `WHERE year=?` mandatory. |
+| Restore latency from Glacier Deep Archive (12+ hours) | Document explicitly in incident runbooks. For dispute investigation typically the 90d–2y range is sufficient (Glacier IR = minutes), so Deep Archive restore is genuinely rare. |
+| Compliance officer wants > 7y retention for some jurisdictions | Lifecycle policy is per-prefix; a `legal-hold/` prefix can be configured with no expiration. ADR doesn't require ongoing change. |
+
+## 8. Cross-references
+
+- ADR-002 (Git cold-tier 10,4 Reed-Solomon) — different access pattern; ADR-018 explicitly diverges.
+- ADR-008 (outbox) — `billing.partition_archived` event uses the standard outbox pattern via app-plane RPC.
+- ADR-011 (per-org encryption) — different KEK scope; ADR-018 explicitly diverges.
+- ADR-012 (two-tier billing counters) — usage_events is the analytics-counter side; archive is the cold tail.
+- ADR-019 (workflow→app-plane boundary) — `billing.partition_archived` outbox emit goes via app-plane RPC, not direct from workflow.
+- #18-archive — depends on this ADR; archive activity built atop the decisions here.
+- Open architecture question: erasure coding library (June 2026) — explicitly does NOT block this ADR; ADR-018 chooses not to use project EC for billing archives, so the library decision is irrelevant here.
+
+## 9. Open follow-ups (not in #34 / ADR-018 scope)
+
+- **`RestorePartition` workflow** — separate issue under workflow plane.
+- **Glue / Hive catalog wiring** — separate issue under data plane (Terraform + IAM).
+- **Cost allocation tagging convention** — separate issue under observability.
+- **Athena query template library** — separate issue under data plane.
+- **Multi-region replication of analytics-lake bucket** — disaster-recovery concern; defer until DR plan is in place.


### PR DESCRIPTION
## Summary

- Commits 14 design artifacts (5 specs + 9 plans) referenced by every Phase-1 closeout PR. Without them, those references dangle.
- Amends CLAUDE.md to scope the \"every merged PR closes ≥1 issue\" invariant to \`feat/\`, \`fix/\`, \`spike/\`, \`adr/\` branches. \`chore/\` and \`docs/\` skip — branch prefix encodes intent.

## ADR-impact

\`none\` — doc + governance only; no ADR text touched.

## Test plan

- [x] \`make lint-md\` clean.
- [x] \`prompts/\` stays gitignored; \`runs/\` stays gitignored except \`*.completion.md\`.
- [x] CLAUDE.md change defines what counts as a chore (no user/operator-visible behaviour change).

## Self-review

Two logical commits:
1. \`docs(meta): commit superpowers specs and plans for waves 0-4\`
2. \`docs(meta): scope PR-closes-issue invariant to feat/fix/spike/adr\`

Closes #84.

🤖 Generated with [Claude Code](https://claude.com/claude-code)