### PR TITLE
[Meta] Revert direct-push of 93c18c9

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -50,9 +50,7 @@
       "Bash(gh issue view *)",
       "Bash(gh issue list *)",
 
-      "mcp__plugin_context7_context7__*",
-
-      "Bash(*ralph-loop*/scripts/*)"
+      "mcp__plugin_context7_context7__*"
     ]
   },
   "enabledPlugins": {


### PR DESCRIPTION
## Summary

- Reverts `93c18c9` (settings.json allowlist entry for ralph-loop scripts), which was accidentally direct-pushed to `main` instead of being added to PR #85.
- The change itself is benign; the *act* of bypassing PR review is the problem.
- The reverted content will be re-added to #85 in its proper branch.

## ADR-impact

`none`.

## Test plan

- [x] Diff is exactly the inverse of `93c18c9`.
- [x] No other files touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)