### PR TITLE
[Data] Generic updated_at trigger across 5 schema domains

### DIFF
--- a/docs/superpowers/plans/2026-05-08-issue-46-updated-at-trigger-plan.md
+++ b/docs/superpowers/plans/2026-05-08-issue-46-updated-at-trigger-plan.md
@@ -1,0 +1,334 @@
+# Issue #46 updated_at trigger across 5 schema domains — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `public.set_updated_at()` trigger function and attach it to every existing table that already has an `updated_at` column but no auto-bump trigger.
+
+**Architecture:** One SQL migration adding the function in the neutral `public` schema and seven `CREATE TRIGGER` statements (identity.organisations, repositories.repositories, collaboration.pull_requests/issues/comments, billing.quota_accounts/invoices). Compliance test asserts the bump per table.
+
+**Tech Stack:** PostgreSQL, Go testcontainer compliance suite.
+
+**Spec:** `docs/superpowers/specs/2026-05-08-issue-46-updated-at-trigger-design.md`
+
+**Branch:** `feat/data-updated-at-trigger` (worktree: `../gitscale.worktrees/feat-data-updated-at-trigger`)
+
+---
+
+## File map
+
+### Create
+- `plane/data/migrations/NNN_updated_at_triggers.sql` (NNN selected at rebase time; baseline is 007 if no other Wave-2 migrations have merged ahead)
+- `plane/data/store/postgres/updated_at_trigger_test.go` — integration-tagged
+
+### Modify
+- `plane/data/store/postgres/compliance_test.go` — append the new migration filename to the `migrations := []string{...}` slice
+
+---
+
+## Pre-flight
+
+- [ ] **Step P.1: Worktree**
+
+```bash
+cd /home/mitta/clients/gitscale/repos/gitscale-platform/gitscale
+git fetch --all --prune
+git worktree add -b feat/data-updated-at-trigger \
+    /home/mitta/clients/gitscale/repos/gitscale.worktrees/feat-data-updated-at-trigger \
+    origin/main
+cd /home/mitta/clients/gitscale/repos/gitscale.worktrees/feat-data-updated-at-trigger
+git status --porcelain
+```
+
+Expected: clean.
+
+- [ ] **Step P.2: Identify the next migration number**
+
+```bash
+ls plane/data/migrations/ | grep -E '^[0-9]{3}_' | sort | tail -3
+```
+
+Pick the next available `NNN`. At spec-write time the answer is `007`.
+At rebase, the implementer revisits this if intermediate migrations have
+landed on `main`.
+
+- [ ] **Step P.3: Baseline**
+
+```bash
+go build ./...
+go test -tags integration -race ./plane/data/store/postgres/... -count=1
+```
+
+Expected: green.
+
+---
+
+## Task 1: Migration
+
+**File:** `plane/data/migrations/NNN_updated_at_triggers.sql`
+
+- [ ] **Step 1.1: Write the migration**
+
+```sql
+-- NNN_updated_at_triggers.sql
+-- Generic updated_at = now() trigger across schema domains.
+-- identity.human_users and identity.agent_identities are already covered
+-- by 006_identity_revocation.sql; that function (identity.set_updated_at)
+-- is left in place for that domain.
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public.set_updated_at()
+RETURNS TRIGGER LANGUAGE plpgsql AS $$
+BEGIN
+    NEW.updated_at = now();
+    RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_organisations_updated_at ON identity.organisations;
+CREATE TRIGGER trg_organisations_updated_at
+    BEFORE UPDATE ON identity.organisations
+    FOR EACH ROW EXECUTE FUNCTION public.set_updated_at();
+
+DROP TRIGGER IF EXISTS trg_repositories_updated_at ON repositories.repositories;
+CREATE TRIGGER trg_repositories_updated_at
+    BEFORE UPDATE ON repositories.repositories
+    FOR EACH ROW EXECUTE FUNCTION public.set_updated_at();
+
+DROP TRIGGER IF EXISTS trg_pull_requests_updated_at ON collaboration.pull_requests;
+CREATE TRIGGER trg_pull_requests_updated_at
+    BEFORE UPDATE ON collaboration.pull_requests
+    FOR EACH ROW EXECUTE FUNCTION public.set_updated_at();
+
+DROP TRIGGER IF EXISTS trg_issues_updated_at ON collaboration.issues;
+CREATE TRIGGER trg_issues_updated_at
+    BEFORE UPDATE ON collaboration.issues
+    FOR EACH ROW EXECUTE FUNCTION public.set_updated_at();
+
+DROP TRIGGER IF EXISTS trg_comments_updated_at ON collaboration.comments;
+CREATE TRIGGER trg_comments_updated_at
+    BEFORE UPDATE ON collaboration.comments
+    FOR EACH ROW EXECUTE FUNCTION public.set_updated_at();
+
+DROP TRIGGER IF EXISTS trg_quota_accounts_updated_at ON billing.quota_accounts;
+CREATE TRIGGER trg_quota_accounts_updated_at
+    BEFORE UPDATE ON billing.quota_accounts
+    FOR EACH ROW EXECUTE FUNCTION public.set_updated_at();
+
+DROP TRIGGER IF EXISTS trg_invoices_updated_at ON billing.invoices;
+CREATE TRIGGER trg_invoices_updated_at
+    BEFORE UPDATE ON billing.invoices
+    FOR EACH ROW EXECUTE FUNCTION public.set_updated_at();
+
+COMMIT;
+```
+
+- [ ] **Step 1.2: Append filename to compliance_test migration list**
+
+In `plane/data/store/postgres/compliance_test.go`, find the `migrations := []string{…}` slice. Append the new filename (e.g. `"007_updated_at_triggers.sql"`).
+
+- [ ] **Step 1.3: Run compliance test**
+
+```bash
+go test -tags integration -race -run TestSchemaCompliance ./plane/data/store/postgres/... -count=1
+```
+
+Expected: PASS — migration applies cleanly, schema is consistent.
+
+---
+
+## Task 2: Trigger behaviour test
+
+**File:** `plane/data/store/postgres/updated_at_trigger_test.go`
+
+- [ ] **Step 2.1: Inspect each table's required NOT-NULL columns**
+
+For every table in the cases list below, identify:
+1. The minimal columns required to INSERT a row (the rest can default).
+2. A harmless field to UPDATE.
+
+Tables: `identity.organisations`, `repositories.repositories`,
+`collaboration.pull_requests`, `collaboration.issues`,
+`collaboration.comments`, `billing.quota_accounts`, `billing.invoices`.
+
+```bash
+grep -A 30 "^CREATE TABLE identity.organisations" plane/data/migrations/001_identity.sql
+# repeat per table from 002, 003, 005
+```
+
+- [ ] **Step 2.2: Write the test**
+
+```go
+//go:build integration
+
+package postgres_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	storetest "github.com/gitscale-platform/gitscale/plane/data/store/postgres/postgrestest"
+)
+
+type triggerCase struct {
+	name      string
+	seed      string // SQL returning a row id
+	updateSQL string // takes the id as $1
+	idCol     string
+}
+
+func TestUpdatedAtTriggerBumpsOnUpdate(t *testing.T) {
+	ctx := context.Background()
+	pool := storetest.NewPool(t)
+
+	cases := []triggerCase{
+		{
+			name:      "identity.organisations",
+			seed:      `INSERT INTO identity.organisations (id, slug) VALUES (gen_random_uuid(), 'trg-org') RETURNING id`,
+			updateSQL: `UPDATE identity.organisations SET slug='trg-org-updated' WHERE id=$1`,
+			idCol:     "id",
+		},
+		// ... fill in remaining 6 cases per Step 2.1's column inspection
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var id string
+			if err := pool.QueryRow(ctx, tc.seed).Scan(&id); err != nil {
+				t.Fatalf("seed: %v", err)
+			}
+			var before time.Time
+			if err := pool.QueryRow(ctx, `SELECT updated_at FROM `+tc.name+` WHERE `+tc.idCol+`=$1`, id).Scan(&before); err != nil {
+				t.Fatalf("read before: %v", err)
+			}
+			time.Sleep(10 * time.Millisecond)
+			if _, err := pool.Exec(ctx, tc.updateSQL, id); err != nil {
+				t.Fatalf("update: %v", err)
+			}
+			var after time.Time
+			if err := pool.QueryRow(ctx, `SELECT updated_at FROM `+tc.name+` WHERE `+tc.idCol+`=$1`, id).Scan(&after); err != nil {
+				t.Fatalf("read after: %v", err)
+			}
+			if !after.After(before) {
+				t.Fatalf("%s: updated_at not bumped (before=%v after=%v)", tc.name, before, after)
+			}
+		})
+	}
+}
+```
+
+- [ ] **Step 2.3: Run**
+
+```bash
+go test -tags integration -race -run TestUpdatedAtTrigger ./plane/data/store/postgres/... -count=1
+```
+
+Expected: PASS for all subtests.
+
+- [ ] **Step 2.4: Commit (combined: migration + test)**
+
+```bash
+git add plane/data/migrations/NNN_updated_at_triggers.sql \
+        plane/data/store/postgres/compliance_test.go \
+        plane/data/store/postgres/updated_at_trigger_test.go
+git commit -m "$(cat <<'EOF'
+feat(data): public.set_updated_at trigger across 5 domains (#46)
+
+Attaches BEFORE UPDATE trigger to identity.organisations,
+repositories.repositories, collaboration.pull_requests/issues/comments,
+billing.quota_accounts/invoices. Closes the silent-data-rot gap where
+updated_at columns were never bumped on UPDATE.
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: Final gates + open PR
+
+- [ ] **Step 3.1: Test sweep**
+
+```bash
+go build ./...
+go vet ./...
+golangci-lint run
+go test -tags integration -race ./plane/data/store/postgres/... -count=1
+```
+
+- [ ] **Step 3.2: Skills (data plane)**
+
+- `gitscale-go-conventions`
+- `database-design:sql-pro`
+
+- [ ] **Step 3.3: Self-review battery (parallel)**
+
+- `pr-review-toolkit:code-reviewer`
+- `pr-review-toolkit:silent-failure-hunter`
+- `pr-review-toolkit:type-design-analyzer` (no new public Go types — likely no-op)
+- `pr-review-toolkit:pr-test-analyzer`
+- `adr-historian` (no ADR impact)
+
+- [ ] **Step 3.4: Push + open PR**
+
+```bash
+git push -u origin feat/data-updated-at-trigger
+gh pr create --title "[Data] Generic updated_at trigger across 5 schema domains" --body "$(cat <<'EOF'
+## Summary
+
+- Adds `public.set_updated_at()` trigger function and attaches it to seven
+  tables that have an `updated_at` column but no bump trigger:
+  identity.organisations, repositories.repositories,
+  collaboration.pull_requests/issues/comments,
+  billing.quota_accounts/invoices.
+- Compliance test asserts each table's `updated_at` advances on UPDATE.
+
+## ADR-impact
+
+none.
+
+## Test plan
+
+- [x] `go test -tags integration -race ./plane/data/store/postgres/...` (compliance + per-table behaviour)
+- [x] Migration is idempotent (DROP TRIGGER IF EXISTS + CREATE OR REPLACE)
+
+Spec: docs/superpowers/specs/2026-05-08-issue-46-updated-at-trigger-design.md
+Plan: docs/superpowers/plans/2026-05-08-issue-46-updated-at-trigger-plan.md
+
+<details><summary>Self-review</summary>
+
+- code-reviewer: <result>
+- silent-failure-hunter: <result>
+- type-design-analyzer: <result>
+- pr-test-analyzer: <result>
+- adr-historian: <result>
+
+</details>
+
+Closes #46.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 3.5: Watch CI**
+
+```bash
+gh pr checks <number> --watch
+```
+
+---
+
+## Self-review (plan author)
+
+**Spec coverage:** function defined, triggers attached to all 7 tables,
+compliance test, idempotency.
+
+**Placeholder scan:** Step 2.1 directs the implementer to inspect each
+table's required columns to fill in seed/update SQL. Acceptable — schema
+is local context.
+
+**Type consistency:** N/A (SQL migration; no Go types).

--- a/docs/superpowers/specs/2026-05-08-issue-46-updated-at-trigger-design.md
+++ b/docs/superpowers/specs/2026-05-08-issue-46-updated-at-trigger-design.md
@@ -1,0 +1,211 @@
+# Spec — Issue #46 Generic updated_at trigger across 5 schema domains
+
+Date: 2026-05-08
+Issue: https://github.com/gitscale-platform/gitscale/issues/46
+Plane: data
+Priority: p2 (Wave 0)
+ADR-impact: none (silent-data-rot fix)
+
+## Problem
+
+Most tables across the five schema domains carry an `updated_at TIMESTAMPTZ
+NOT NULL DEFAULT now()` column, but no trigger bumps it on UPDATE. The
+column stays at insert-time forever — silent data rot. Audit queries that
+filter by `updated_at` miss every change. Migration `006_identity_revocation.sql`
+already defined `identity.set_updated_at()` and attached it to
+`identity.human_users` and `identity.agent_identities`. The remaining
+domains (and `identity.organisations`) are uncovered.
+
+## Goals
+
+1. One generic trigger function callable from any schema. Place it under a
+   neutral schema (`public`) so each domain attaches without re-defining.
+2. Attach the trigger to every existing table that has an `updated_at`
+   column and is not yet covered.
+3. Idempotent migration (safe to re-apply on a fresh DB or against a partly-
+   migrated environment).
+4. Compliance-test coverage: a single integration test asserts UPDATE bumps
+   `updated_at` for every covered table.
+
+## Non-goals
+
+- Adding `updated_at` to tables that lack it (that's #47 and similar
+  follow-ups; this spec is about wiring the trigger to *existing* columns).
+- Removing the existing `identity.set_updated_at()` function. Leave it in
+  place to avoid coupling this PR to a callsite refactor; deprecate later
+  in a follow-up if desired.
+- Triggering on outbox tables — outbox rows are write-once except for
+  `processed_at`; bumping `updated_at` would muddle replay semantics. (Outbox
+  tables don't carry `updated_at` anyway.)
+
+## Architecture
+
+### Function
+
+`public.set_updated_at()`:
+
+```sql
+CREATE OR REPLACE FUNCTION public.set_updated_at()
+RETURNS TRIGGER LANGUAGE plpgsql AS $$
+BEGIN
+    NEW.updated_at = now();
+    RETURN NEW;
+END;
+$$;
+```
+
+Placed in `public` so triggers can reference one definition regardless of
+the table's schema. The existing `identity.set_updated_at()` is left
+untouched (see Non-goals).
+
+### Migration
+
+File: `plane/data/migrations/NNN_updated_at_triggers.sql` where `NNN` is
+the next sequential number at PR-rebase time. (At spec-write time, master
+is at 006; in-flight Wave-2 branches add their own — the rebase routine
+selects the final number.)
+
+```sql
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public.set_updated_at()
+RETURNS TRIGGER LANGUAGE plpgsql AS $$
+BEGIN
+    NEW.updated_at = now();
+    RETURN NEW;
+END;
+$$;
+
+-- identity.organisations (human_users, agent_identities already covered by 006_identity_revocation.sql)
+DROP TRIGGER IF EXISTS trg_organisations_updated_at ON identity.organisations;
+CREATE TRIGGER trg_organisations_updated_at
+    BEFORE UPDATE ON identity.organisations
+    FOR EACH ROW EXECUTE FUNCTION public.set_updated_at();
+
+-- repositories
+DROP TRIGGER IF EXISTS trg_repositories_updated_at ON repositories.repositories;
+CREATE TRIGGER trg_repositories_updated_at
+    BEFORE UPDATE ON repositories.repositories
+    FOR EACH ROW EXECUTE FUNCTION public.set_updated_at();
+
+-- collaboration
+DROP TRIGGER IF EXISTS trg_pull_requests_updated_at ON collaboration.pull_requests;
+CREATE TRIGGER trg_pull_requests_updated_at
+    BEFORE UPDATE ON collaboration.pull_requests
+    FOR EACH ROW EXECUTE FUNCTION public.set_updated_at();
+
+DROP TRIGGER IF EXISTS trg_issues_updated_at ON collaboration.issues;
+CREATE TRIGGER trg_issues_updated_at
+    BEFORE UPDATE ON collaboration.issues
+    FOR EACH ROW EXECUTE FUNCTION public.set_updated_at();
+
+DROP TRIGGER IF EXISTS trg_comments_updated_at ON collaboration.comments;
+CREATE TRIGGER trg_comments_updated_at
+    BEFORE UPDATE ON collaboration.comments
+    FOR EACH ROW EXECUTE FUNCTION public.set_updated_at();
+
+-- billing
+DROP TRIGGER IF EXISTS trg_quota_accounts_updated_at ON billing.quota_accounts;
+CREATE TRIGGER trg_quota_accounts_updated_at
+    BEFORE UPDATE ON billing.quota_accounts
+    FOR EACH ROW EXECUTE FUNCTION public.set_updated_at();
+
+DROP TRIGGER IF EXISTS trg_invoices_updated_at ON billing.invoices;
+CREATE TRIGGER trg_invoices_updated_at
+    BEFORE UPDATE ON billing.invoices
+    FOR EACH ROW EXECUTE FUNCTION public.set_updated_at();
+
+COMMIT;
+```
+
+### CI tables
+
+Inspecting `004_ci.sql`: `workflow_runs`, `ci_jobs`, `runner_assignments`,
+`ci_outbox`. **None of these have `updated_at`.** The CI tables track
+state-machine transitions via dedicated `started_at`, `completed_at`,
+`assigned_at` columns. So the CI domain is correctly uncovered by this
+trigger; no change needed.
+
+### Compliance test
+
+Append to `plane/data/store/postgres/compliance_test.go` (or a new
+`updated_at_trigger_test.go` in the same package, build tag `integration`):
+
+```go
+//go:build integration
+
+package postgres_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	storetest "github.com/gitscale-platform/gitscale/plane/data/store/postgres/postgrestest"
+)
+
+func TestUpdatedAtTriggerBumpsOnUpdate(t *testing.T) {
+	ctx := context.Background()
+	pool := storetest.NewPool(t)
+
+	cases := []struct {
+		schema, table string
+		seed          string
+		updateSQL     string
+	}{
+		{"identity", "organisations", `INSERT INTO identity.organisations (id, slug) VALUES (gen_random_uuid(), 'org-test') RETURNING id`, `UPDATE identity.organisations SET slug='org-test-2' WHERE id=$1`},
+		{"repositories", "repositories", /* …seed + update, mirror the schema */},
+		{"collaboration", "pull_requests", /* … */},
+		{"collaboration", "issues", /* … */},
+		{"collaboration", "comments", /* … */},
+		{"billing", "quota_accounts", /* … */},
+		{"billing", "invoices", /* … */},
+	}
+	for _, tc := range cases {
+		t.Run(tc.schema+"."+tc.table, func(t *testing.T) {
+			var id string
+			if err := pool.QueryRow(ctx, tc.seed).Scan(&id); err != nil {
+				t.Fatal(err)
+			}
+			var before, after time.Time
+			pool.QueryRow(ctx, "SELECT updated_at FROM "+tc.schema+"."+tc.table+" WHERE id=$1", id).Scan(&before)
+			time.Sleep(10 * time.Millisecond)
+			if _, err := pool.Exec(ctx, tc.updateSQL, id); err != nil {
+				t.Fatal(err)
+			}
+			pool.QueryRow(ctx, "SELECT updated_at FROM "+tc.schema+"."+tc.table+" WHERE id=$1", id).Scan(&after)
+			if !after.After(before) {
+				t.Fatalf("%s.%s: updated_at not bumped (before=%v after=%v)", tc.schema, tc.table, before, after)
+			}
+		})
+	}
+}
+```
+
+The implementer fills in real `seed` and `updateSQL` strings per each
+table's column shape — the schema is local context.
+
+## Test plan
+
+| Layer | Test |
+|---|---|
+| Migration apply | Compliance test bootstraps PG with all migrations including the new one |
+| Trigger behaviour | Per-table UPDATE bumps `updated_at` |
+| Idempotency | Re-apply migration in the same session: no error |
+
+## Acceptance checklist
+
+- [ ] `public.set_updated_at()` defined
+- [ ] Trigger attached to every existing table with `updated_at`
+- [ ] Compliance test demonstrates bump on UPDATE
+- [ ] Migration is `BEGIN`+`COMMIT` and uses `DROP TRIGGER IF EXISTS` for idempotency
+- [ ] PR description lists the seven covered tables explicitly
+
+## Open questions
+
+None.
+
+## References
+
+- Existing `identity.set_updated_at()` in `006_identity_revocation.sql`
+- Tables enumerated by grep over `plane/data/migrations/*.sql`

--- a/plane/data/migrations/008_updated_at_triggers.sql
+++ b/plane/data/migrations/008_updated_at_triggers.sql
@@ -1,0 +1,61 @@
+-- 008_updated_at_triggers.sql
+-- Generic updated_at = now() trigger across schema domains.
+-- identity.human_users and identity.agent_identities are already covered
+-- by 006_identity_revocation.sql; that function (identity.set_updated_at)
+-- is left in place for that domain. Remaining tables that carry an
+-- updated_at column are wired here so audit queries that filter by
+-- updated_at observe actual mutations (closes silent-data-rot gap).
+--
+-- Idempotent: CREATE OR REPLACE on the function and DROP TRIGGER IF EXISTS
+-- before each CREATE TRIGGER means re-application is safe.
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public.set_updated_at()
+RETURNS TRIGGER LANGUAGE plpgsql AS $$
+BEGIN
+    NEW.updated_at = now();
+    RETURN NEW;
+END;
+$$;
+
+-- identity (human_users, agent_identities already covered by 006_identity_revocation.sql)
+DROP TRIGGER IF EXISTS trg_organisations_updated_at ON identity.organisations;
+CREATE TRIGGER trg_organisations_updated_at
+    BEFORE UPDATE ON identity.organisations
+    FOR EACH ROW EXECUTE FUNCTION public.set_updated_at();
+
+-- repositories
+DROP TRIGGER IF EXISTS trg_repositories_updated_at ON repositories.repositories;
+CREATE TRIGGER trg_repositories_updated_at
+    BEFORE UPDATE ON repositories.repositories
+    FOR EACH ROW EXECUTE FUNCTION public.set_updated_at();
+
+-- collaboration
+DROP TRIGGER IF EXISTS trg_pull_requests_updated_at ON collaboration.pull_requests;
+CREATE TRIGGER trg_pull_requests_updated_at
+    BEFORE UPDATE ON collaboration.pull_requests
+    FOR EACH ROW EXECUTE FUNCTION public.set_updated_at();
+
+DROP TRIGGER IF EXISTS trg_issues_updated_at ON collaboration.issues;
+CREATE TRIGGER trg_issues_updated_at
+    BEFORE UPDATE ON collaboration.issues
+    FOR EACH ROW EXECUTE FUNCTION public.set_updated_at();
+
+DROP TRIGGER IF EXISTS trg_comments_updated_at ON collaboration.comments;
+CREATE TRIGGER trg_comments_updated_at
+    BEFORE UPDATE ON collaboration.comments
+    FOR EACH ROW EXECUTE FUNCTION public.set_updated_at();
+
+-- billing
+DROP TRIGGER IF EXISTS trg_quota_accounts_updated_at ON billing.quota_accounts;
+CREATE TRIGGER trg_quota_accounts_updated_at
+    BEFORE UPDATE ON billing.quota_accounts
+    FOR EACH ROW EXECUTE FUNCTION public.set_updated_at();
+
+DROP TRIGGER IF EXISTS trg_invoices_updated_at ON billing.invoices;
+CREATE TRIGGER trg_invoices_updated_at
+    BEFORE UPDATE ON billing.invoices
+    FOR EACH ROW EXECUTE FUNCTION public.set_updated_at();
+
+COMMIT;

--- a/plane/data/store/postgres/compliance_test.go
+++ b/plane/data/store/postgres/compliance_test.go
@@ -55,6 +55,7 @@ func TestPostgresMetadataStoreCompliance(t *testing.T) {
 			"003_collaboration.sql", "004_ci.sql", "005_billing.sql",
 			"006_identity_revocation.sql",
 			"007_billing_partition_archives.sql",
+			"008_updated_at_triggers.sql",
 		} {
 			sql, err := os.ReadFile(filepath.Join(migrationsDir, f))
 			if err != nil {

--- a/plane/data/store/postgres/postgres_test.go
+++ b/plane/data/store/postgres/postgres_test.go
@@ -64,6 +64,9 @@ func runMigrations(t *testing.T, ctx context.Context, pool *pgxpool.Pool) {
 		"003_collaboration.sql",
 		"004_ci.sql",
 		"005_billing.sql",
+		"006_identity_revocation.sql",
+		"007_billing_partition_archives.sql",
+		"008_updated_at_triggers.sql",
 	}
 	for _, f := range files {
 		sql, err := os.ReadFile(filepath.Join(migrationsDir, f))

--- a/plane/data/store/postgres/updated_at_trigger_test.go
+++ b/plane/data/store/postgres/updated_at_trigger_test.go
@@ -1,0 +1,182 @@
+//go:build integration
+
+package postgres_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// TestUpdatedAtTriggerBumpsOnUpdate asserts that migration 008 attaches
+// a BEFORE UPDATE trigger to every covered table, advancing updated_at
+// on a no-op UPDATE. One subtest per table; each seeds its own row(s).
+func TestUpdatedAtTriggerBumpsOnUpdate(t *testing.T) {
+	pool := setupPostgres(t)
+	ctx := context.Background()
+
+	// quota account is needed both for its own subtest and as a parent for
+	// billing.invoices. Seed once outside the table-list and reference it.
+	quotaAccountID := uuid.New()
+	if _, err := pool.Exec(ctx,
+		`INSERT INTO billing.quota_accounts (id, org_id) VALUES ($1, $2)`,
+		quotaAccountID, uuid.New(),
+	); err != nil {
+		t.Fatalf("seed billing.quota_accounts: %v", err)
+	}
+
+	// repositories.repositories needs an org row by FK convention (soft ref,
+	// no FK), but pull_requests/issues are also soft refs on repo_id. Seed
+	// a repo row to anchor PR/issue subtests.
+	repoID := uuid.New()
+	if _, err := pool.Exec(ctx,
+		`INSERT INTO repositories.repositories (id, org_id, name, slug, owner_id)
+		 VALUES ($1, $2, 'trg-repo', 'trg-repo', $3)`,
+		repoID, uuid.New(), uuid.New(),
+	); err != nil {
+		t.Fatalf("seed repositories.repositories anchor: %v", err)
+	}
+
+	type triggerCase struct {
+		name      string             // schema.table for fully-qualified SELECT
+		idCol     string             // column used to look up the row
+		seed      func() (any, error) // returns the id of the seeded row
+		updateSQL string             // takes the id as $1
+	}
+
+	cases := []triggerCase{
+		{
+			name:  "identity.organisations",
+			idCol: "id",
+			seed: func() (any, error) {
+				id := uuid.New()
+				_, err := pool.Exec(ctx,
+					`INSERT INTO identity.organisations (id, slug) VALUES ($1, 'trg-org')`,
+					id,
+				)
+				return id, err
+			},
+			updateSQL: `UPDATE identity.organisations SET display_name='renamed' WHERE id=$1`,
+		},
+		{
+			name:  "repositories.repositories",
+			idCol: "id",
+			seed: func() (any, error) {
+				id := uuid.New()
+				_, err := pool.Exec(ctx,
+					`INSERT INTO repositories.repositories (id, org_id, name, slug, owner_id)
+					 VALUES ($1, $2, 'trg-r', 'trg-r-`+uuid.NewString()[:8]+`', $3)`,
+					id, uuid.New(), uuid.New(),
+				)
+				return id, err
+			},
+			updateSQL: `UPDATE repositories.repositories SET default_branch='trunk' WHERE id=$1`,
+		},
+		{
+			name:  "collaboration.pull_requests",
+			idCol: "id",
+			seed: func() (any, error) {
+				id := uuid.New()
+				_, err := pool.Exec(ctx,
+					`INSERT INTO collaboration.pull_requests
+					 (id, repo_id, number, title, author_id, author_type, base_branch, head_branch)
+					 VALUES ($1, $2, 1, 'trg-pr', $3, 'human', 'main', 'feat')`,
+					id, repoID, uuid.New(),
+				)
+				return id, err
+			},
+			updateSQL: `UPDATE collaboration.pull_requests SET title='trg-pr-2' WHERE id=$1`,
+		},
+		{
+			name:  "collaboration.issues",
+			idCol: "id",
+			seed: func() (any, error) {
+				id := uuid.New()
+				_, err := pool.Exec(ctx,
+					`INSERT INTO collaboration.issues
+					 (id, repo_id, number, title, author_id, author_type)
+					 VALUES ($1, $2, 1, 'trg-iss', $3, 'human')`,
+					id, repoID, uuid.New(),
+				)
+				return id, err
+			},
+			updateSQL: `UPDATE collaboration.issues SET title='trg-iss-2' WHERE id=$1`,
+		},
+		{
+			name:  "collaboration.comments",
+			idCol: "id",
+			seed: func() (any, error) {
+				id := uuid.New()
+				_, err := pool.Exec(ctx,
+					`INSERT INTO collaboration.comments
+					 (id, parent_type, parent_id, author_id, author_type, body)
+					 VALUES ($1, 'pr', $2, $3, 'human', 'first')`,
+					id, uuid.New(), uuid.New(),
+				)
+				return id, err
+			},
+			updateSQL: `UPDATE collaboration.comments SET body='edited' WHERE id=$1`,
+		},
+		{
+			name:  "billing.quota_accounts",
+			idCol: "id",
+			seed: func() (any, error) {
+				// Reuse the pre-seeded quota account; the row already exists.
+				return quotaAccountID, nil
+			},
+			updateSQL: `UPDATE billing.quota_accounts SET plan_tier='pro' WHERE id=$1`,
+		},
+		{
+			name:  "billing.invoices",
+			idCol: "id",
+			seed: func() (any, error) {
+				id := uuid.New()
+				_, err := pool.Exec(ctx,
+					`INSERT INTO billing.invoices
+					 (id, account_id, period_start, period_end)
+					 VALUES ($1, $2, '2026-05-01T00:00:00Z', '2026-06-01T00:00:00Z')`,
+					id, quotaAccountID,
+				)
+				return id, err
+			},
+			updateSQL: `UPDATE billing.invoices SET status='finalized' WHERE id=$1`,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			id, err := tc.seed()
+			if err != nil {
+				t.Fatalf("seed %s: %v", tc.name, err)
+			}
+
+			selectSQL := `SELECT updated_at FROM ` + tc.name + ` WHERE ` + tc.idCol + `=$1`
+
+			var before time.Time
+			if err := pool.QueryRow(ctx, selectSQL, id).Scan(&before); err != nil {
+				t.Fatalf("read updated_at before update: %v", err)
+			}
+
+			// PostgreSQL now() resolves to statement-start with microsecond
+			// precision; sleep long enough to guarantee a strictly-greater
+			// timestamp regardless of clock granularity.
+			time.Sleep(10 * time.Millisecond)
+
+			if _, err := pool.Exec(ctx, tc.updateSQL, id); err != nil {
+				t.Fatalf("update %s: %v", tc.name, err)
+			}
+
+			var after time.Time
+			if err := pool.QueryRow(ctx, selectSQL, id).Scan(&after); err != nil {
+				t.Fatalf("read updated_at after update: %v", err)
+			}
+
+			if !after.After(before) {
+				t.Fatalf("%s: updated_at not bumped (before=%v after=%v)", tc.name, before, after)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `public.set_updated_at()` trigger function and attaches it via migration `008_updated_at_triggers.sql` to seven tables that have an `updated_at` column but no bump trigger:
  - `identity.organisations`
  - `repositories.repositories`
  - `collaboration.pull_requests`
  - `collaboration.issues`
  - `collaboration.comments`
  - `billing.quota_accounts`
  - `billing.invoices`
- `identity.human_users` and `identity.agent_identities` remain on the domain-local function from `006_identity_revocation.sql` (per spec non-goal).
- CI tables (`workflow_runs`, `ci_jobs`, `runner_assignments`, `ci_outbox`) carry no `updated_at` column — correctly uncovered.
- Compliance test migration list appended with `008_updated_at_triggers.sql`.
- New per-table integration test (`updated_at_trigger_test.go`) seeds a row per covered table, performs a real UPDATE, and asserts `updated_at` advances.

## ADR-impact

None. Silent-data-rot fix on existing schema.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `golangci-lint run --build-tags integration ./plane/data/store/postgres/...` (0 issues in changed package; pre-existing findings in `plane/data/outbox/integration_test.go` are unrelated)
- [x] `go test -tags integration -race ./plane/data/store/postgres/... -count=1` (compliance + per-table behaviour PASS, 78s)
- [x] Migration is idempotent (`CREATE OR REPLACE` + `DROP TRIGGER IF EXISTS`)

Spec: `docs/superpowers/specs/2026-05-08-issue-46-updated-at-trigger-design.md`
Plan: `docs/superpowers/plans/2026-05-08-issue-46-updated-at-trigger-plan.md`

Closes #46.

🤖 Generated with [Claude Code](https://claude.com/claude-code)