### PR TITLE
[Data] Add created_at/updated_at to identity.org_memberships and oauth_apps

### DIFF
--- a/docs/superpowers/plans/2026-05-08-issue-47-identity-temporal-columns-plan.md
+++ b/docs/superpowers/plans/2026-05-08-issue-47-identity-temporal-columns-plan.md
@@ -1,0 +1,278 @@
+# Issue #47 identity temporal columns — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:subagent-driven-development.
+
+**Goal:** Add `created_at`+`updated_at` to `identity.org_memberships`; add `updated_at` to `identity.oauth_apps`; attach `identity.set_updated_at()` trigger to both.
+
+**Spec:** `docs/superpowers/specs/2026-05-08-issue-47-identity-temporal-columns-design.md`
+
+**Branch:** `feat/data-identity-temporal-columns`
+
+---
+
+## File map
+
+### Create
+- `plane/data/migrations/NNN_identity_temporal_columns.sql`
+- `plane/data/store/postgres/identity_temporal_columns_test.go`
+
+### Modify
+- `plane/data/store/postgres/compliance_test.go` — append to migrations slice
+
+---
+
+## Pre-flight
+
+- [ ] **Step P.1: Worktree**
+
+```bash
+cd /home/mitta/clients/gitscale/repos/gitscale-platform/gitscale
+git fetch --all --prune
+git worktree add -b feat/data-identity-temporal-columns \
+    /home/mitta/clients/gitscale/repos/gitscale.worktrees/feat-data-identity-temporal-columns \
+    origin/main
+cd /home/mitta/clients/gitscale/repos/gitscale.worktrees/feat-data-identity-temporal-columns
+git status --porcelain
+```
+
+- [ ] **Step P.2: Pick NNN**
+
+```bash
+ls plane/data/migrations/ | grep -E '^[0-9]{3}_' | sort | tail -3
+```
+
+Use the next available number. At spec-write time the answer is `007`.
+
+---
+
+## Task 1: Migration
+
+**File:** `plane/data/migrations/NNN_identity_temporal_columns.sql`
+
+- [ ] **Step 1.1: Write**
+
+```sql
+BEGIN;
+
+ALTER TABLE identity.org_memberships
+    ADD COLUMN IF NOT EXISTS created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    ADD COLUMN IF NOT EXISTS updated_at TIMESTAMPTZ NOT NULL DEFAULT now();
+
+DROP TRIGGER IF EXISTS trg_org_memberships_updated_at ON identity.org_memberships;
+CREATE TRIGGER trg_org_memberships_updated_at
+    BEFORE UPDATE ON identity.org_memberships
+    FOR EACH ROW EXECUTE FUNCTION identity.set_updated_at();
+
+ALTER TABLE identity.oauth_apps
+    ADD COLUMN IF NOT EXISTS updated_at TIMESTAMPTZ NOT NULL DEFAULT now();
+
+DROP TRIGGER IF EXISTS trg_oauth_apps_updated_at ON identity.oauth_apps;
+CREATE TRIGGER trg_oauth_apps_updated_at
+    BEFORE UPDATE ON identity.oauth_apps
+    FOR EACH ROW EXECUTE FUNCTION identity.set_updated_at();
+
+COMMIT;
+```
+
+- [ ] **Step 1.2: Append filename to compliance_test slice**
+
+In `plane/data/store/postgres/compliance_test.go`, append the new migration filename.
+
+- [ ] **Step 1.3: Run compliance**
+
+```bash
+go test -tags integration -race -run TestSchemaCompliance ./plane/data/store/postgres/... -count=1
+```
+
+Expected: PASS.
+
+---
+
+## Task 2: Behaviour test
+
+**File:** `plane/data/store/postgres/identity_temporal_columns_test.go`
+
+- [ ] **Step 2.1: Write**
+
+```go
+//go:build integration
+
+package postgres_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	storetest "github.com/gitscale-platform/gitscale/plane/data/store/postgres/postgrestest"
+)
+
+func TestOrgMemberships_TemporalColumnsBumpOnUpdate(t *testing.T) {
+	ctx := context.Background()
+	pool := storetest.NewPool(t)
+
+	// Seed: org + user + membership.
+	var orgID, userID string
+	if err := pool.QueryRow(ctx,
+		`INSERT INTO identity.organisations (id, slug) VALUES (gen_random_uuid(), 'org-temporal') RETURNING id`).Scan(&orgID); err != nil {
+		t.Fatal(err)
+	}
+	if err := pool.QueryRow(ctx,
+		`INSERT INTO identity.human_users (id, email, credential_hash) VALUES (gen_random_uuid(), 'temporal@example.com', 'x') RETURNING id`).Scan(&userID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := pool.Exec(ctx,
+		`INSERT INTO identity.org_memberships (org_id, user_id, role) VALUES ($1, $2, 'developer')`, orgID, userID); err != nil {
+		t.Fatal(err)
+	}
+
+	var before time.Time
+	if err := pool.QueryRow(ctx,
+		`SELECT updated_at FROM identity.org_memberships WHERE org_id=$1 AND user_id=$2`, orgID, userID).Scan(&before); err != nil {
+		t.Fatal(err)
+	}
+	time.Sleep(10 * time.Millisecond)
+	if _, err := pool.Exec(ctx,
+		`UPDATE identity.org_memberships SET role='maintainer' WHERE org_id=$1 AND user_id=$2`, orgID, userID); err != nil {
+		t.Fatal(err)
+	}
+	var after time.Time
+	if err := pool.QueryRow(ctx,
+		`SELECT updated_at FROM identity.org_memberships WHERE org_id=$1 AND user_id=$2`, orgID, userID).Scan(&after); err != nil {
+		t.Fatal(err)
+	}
+	if !after.After(before) {
+		t.Fatalf("updated_at not bumped: before=%v after=%v", before, after)
+	}
+}
+
+func TestOAuthApps_UpdatedAtBumpsOnUpdate(t *testing.T) {
+	ctx := context.Background()
+	pool := storetest.NewPool(t)
+
+	var orgID, appID string
+	if err := pool.QueryRow(ctx,
+		`INSERT INTO identity.organisations (id, slug) VALUES (gen_random_uuid(), 'org-oauth') RETURNING id`).Scan(&orgID); err != nil {
+		t.Fatal(err)
+	}
+	if err := pool.QueryRow(ctx,
+		`INSERT INTO identity.oauth_apps (id, org_id, name, client_id, client_secret_hash) VALUES (gen_random_uuid(), $1, 'app', 'cid-1', 'h') RETURNING id`, orgID).Scan(&appID); err != nil {
+		t.Fatal(err)
+	}
+	var before time.Time
+	if err := pool.QueryRow(ctx, `SELECT updated_at FROM identity.oauth_apps WHERE id=$1`, appID).Scan(&before); err != nil {
+		t.Fatal(err)
+	}
+	time.Sleep(10 * time.Millisecond)
+	if _, err := pool.Exec(ctx, `UPDATE identity.oauth_apps SET name='app-2' WHERE id=$1`, appID); err != nil {
+		t.Fatal(err)
+	}
+	var after time.Time
+	if err := pool.QueryRow(ctx, `SELECT updated_at FROM identity.oauth_apps WHERE id=$1`, appID).Scan(&after); err != nil {
+		t.Fatal(err)
+	}
+	if !after.After(before) {
+		t.Fatalf("updated_at not bumped: before=%v after=%v", before, after)
+	}
+}
+```
+
+(If the actual column for `human_users.credential_hash` differs, mirror
+exactly what `001_identity.sql` declares — the schema is local context.)
+
+- [ ] **Step 2.2: Run**
+
+```bash
+go test -tags integration -race -run "TestOrgMemberships_TemporalColumnsBumpOnUpdate|TestOAuthApps_UpdatedAtBumpsOnUpdate" ./plane/data/store/postgres/... -count=1
+```
+
+Expected: PASS.
+
+- [ ] **Step 2.3: Commit**
+
+```bash
+git add plane/data/migrations/ plane/data/store/postgres/
+git commit -m "$(cat <<'EOF'
+feat(data): created_at/updated_at on org_memberships + oauth_apps (#47)
+
+Backfills the schema-consistency gap: org_memberships gains both temporal
+columns; oauth_apps gains updated_at. Both wired to
+identity.set_updated_at() trigger from 006_identity_revocation.
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: Final gates + open PR
+
+- [ ] **Step 3.1: Test sweep**
+
+```bash
+go build ./...
+go vet ./...
+golangci-lint run
+go test -tags integration -race ./plane/data/store/postgres/... -count=1
+```
+
+- [ ] **Step 3.2: Skills**
+
+- `gitscale-go-conventions`
+- `database-design:sql-pro`
+
+- [ ] **Step 3.3: Self-review battery**
+
+- code-reviewer, silent-failure-hunter, type-design-analyzer, pr-test-analyzer, adr-historian.
+
+- [ ] **Step 3.4: Push + open PR**
+
+```bash
+git push -u origin feat/data-identity-temporal-columns
+gh pr create --title "[Data] Add created_at/updated_at to identity.org_memberships and oauth_apps" --body "$(cat <<'EOF'
+## Summary
+
+- Adds `created_at`+`updated_at` to `identity.org_memberships`.
+- Adds `updated_at` to `identity.oauth_apps`.
+- Attaches `identity.set_updated_at()` trigger to both.
+
+## ADR-impact
+
+none.
+
+## Test plan
+
+- [x] Compliance test bootstraps PG with the new migration
+- [x] UPDATE on each table bumps `updated_at`
+- [x] Migration is idempotent (`ADD COLUMN IF NOT EXISTS`, `DROP TRIGGER IF EXISTS`)
+
+Spec: docs/superpowers/specs/2026-05-08-issue-47-identity-temporal-columns-design.md
+Plan: docs/superpowers/plans/2026-05-08-issue-47-identity-temporal-columns-plan.md
+
+<details><summary>Self-review</summary>
+
+- code-reviewer: <result>
+- silent-failure-hunter: <result>
+- type-design-analyzer: <result>
+- pr-test-analyzer: <result>
+- adr-historian: <result>
+
+</details>
+
+Closes #47.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## Self-review (plan author)
+
+**Spec coverage:** all six acceptance items map to Tasks 1, 2, and 3.
+
+**Placeholder scan:** none.
+
+**Type consistency:** N/A.

--- a/docs/superpowers/specs/2026-05-08-issue-47-identity-temporal-columns-design.md
+++ b/docs/superpowers/specs/2026-05-08-issue-47-identity-temporal-columns-design.md
@@ -1,0 +1,120 @@
+# Spec — Issue #47 created_at/updated_at on identity.org_memberships + oauth_apps
+
+Date: 2026-05-08
+Issue: https://github.com/gitscale-platform/gitscale/issues/47
+Plane: data
+Priority: p2 (Wave 0)
+ADR-impact: none (schema consistency fix)
+
+## Problem
+
+`identity.org_memberships` has neither `created_at` nor `updated_at`.
+`identity.oauth_apps` has `created_at` but no `updated_at`. Audit queries
+that assume every identity table carries the standard temporal pair miss
+both. Fixing the gap is a one-shot ALTER + trigger attach.
+
+## Goals
+
+1. Add `created_at` + `updated_at` to `identity.org_memberships`.
+2. Add `updated_at` to `identity.oauth_apps`.
+3. Attach the existing `identity.set_updated_at()` trigger (from
+   `006_identity_revocation.sql`) to both tables.
+4. Compliance test asserts both columns exist and the trigger bumps
+   `updated_at` on UPDATE.
+
+## Non-goals
+
+- Backfill historical rows. The defaults set `created_at = now()` and
+  `updated_at = now()` on every existing row — close enough; no audit
+  consumer depends on the pre-migration era.
+- Renaming the trigger function to `public.set_updated_at()`. That depends
+  on #46; this PR uses `identity.set_updated_at()` (which already exists on
+  `main`) so it can ship independently.
+
+## Architecture
+
+### Migration
+
+File: `plane/data/migrations/NNN_identity_temporal_columns.sql` (NNN
+selected at rebase time).
+
+```sql
+BEGIN;
+
+-- org_memberships gains both columns.
+ALTER TABLE identity.org_memberships
+    ADD COLUMN IF NOT EXISTS created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    ADD COLUMN IF NOT EXISTS updated_at TIMESTAMPTZ NOT NULL DEFAULT now();
+
+DROP TRIGGER IF EXISTS trg_org_memberships_updated_at ON identity.org_memberships;
+CREATE TRIGGER trg_org_memberships_updated_at
+    BEFORE UPDATE ON identity.org_memberships
+    FOR EACH ROW EXECUTE FUNCTION identity.set_updated_at();
+
+-- oauth_apps gains updated_at and the trigger.
+ALTER TABLE identity.oauth_apps
+    ADD COLUMN IF NOT EXISTS updated_at TIMESTAMPTZ NOT NULL DEFAULT now();
+
+DROP TRIGGER IF EXISTS trg_oauth_apps_updated_at ON identity.oauth_apps;
+CREATE TRIGGER trg_oauth_apps_updated_at
+    BEFORE UPDATE ON identity.oauth_apps
+    FOR EACH ROW EXECUTE FUNCTION identity.set_updated_at();
+
+COMMIT;
+```
+
+`ADD COLUMN IF NOT EXISTS` keeps the migration safe to re-apply.
+
+### Compliance test
+
+Append to `plane/data/store/postgres/compliance_test.go`'s migrations list:
+the new file.
+
+Add per-table behaviour test in
+`plane/data/store/postgres/identity_temporal_columns_test.go`
+(`//go:build integration`):
+
+```go
+func TestOrgMembershipsTemporalColumnsBumpOnUpdate(t *testing.T) {
+    // INSERT a row, snapshot updated_at, UPDATE role, assert updated_at advanced
+}
+func TestOAuthAppsUpdatedAtBumpsOnUpdate(t *testing.T) {
+    // INSERT a row, snapshot updated_at, UPDATE name, assert updated_at advanced
+}
+```
+
+### Optional store-layer alignment
+
+`plane/data/store/metadata.go::OrgMembership` (struct) currently has only
+`OrgID`, `UserID`, `Role`. Adding `CreatedAt time.Time` and `UpdatedAt
+time.Time` is **out of scope** for #47 — would force changes to every
+caller. That's a follow-up if/when the application plane needs the values.
+The migration is forward-compatible: the column exists, and the store can
+opt in to selecting it later without a migration.
+
+## Test plan
+
+| Layer | Test |
+|---|---|
+| Compliance | new migration applies cleanly on fresh PG |
+| Per-table | UPDATE org_memberships → updated_at advances; same for oauth_apps |
+| Idempotency | re-apply migration — no error, no schema diff |
+
+## Acceptance checklist
+
+- [ ] `created_at` + `updated_at` present on `identity.org_memberships`
+- [ ] `updated_at` present on `identity.oauth_apps`
+- [ ] `identity.set_updated_at()` trigger attached to both tables
+- [ ] Compliance test bootstraps PG with the new migration
+- [ ] Per-table behaviour tests pass
+- [ ] Migration uses `IF NOT EXISTS` for column adds and `DROP TRIGGER IF
+      EXISTS` for trigger creates
+
+## Open questions
+
+None.
+
+## References
+
+- `plane/data/migrations/001_identity.sql` (table definitions)
+- `plane/data/migrations/006_identity_revocation.sql` (existing trigger function)

--- a/plane/data/migrations/009_identity_temporal_columns.sql
+++ b/plane/data/migrations/009_identity_temporal_columns.sql
@@ -1,0 +1,31 @@
+-- 009_identity_temporal_columns.sql
+-- Schema-consistency fix: identity.org_memberships had no temporal columns;
+-- identity.oauth_apps had created_at but no updated_at. Audit queries that
+-- assume the standard pair on every identity table missed both. This
+-- migration backfills the gap and wires both tables to the existing
+-- identity.set_updated_at() trigger function (from 006_identity_revocation).
+--
+-- Idempotent: ADD COLUMN IF NOT EXISTS + DROP TRIGGER IF EXISTS make
+-- re-application safe. Existing rows receive now() as their default for
+-- both columns; no audit consumer depends on the pre-migration era.
+
+BEGIN;
+
+ALTER TABLE identity.org_memberships
+    ADD COLUMN IF NOT EXISTS created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    ADD COLUMN IF NOT EXISTS updated_at TIMESTAMPTZ NOT NULL DEFAULT now();
+
+DROP TRIGGER IF EXISTS trg_org_memberships_updated_at ON identity.org_memberships;
+CREATE TRIGGER trg_org_memberships_updated_at
+    BEFORE UPDATE ON identity.org_memberships
+    FOR EACH ROW EXECUTE FUNCTION identity.set_updated_at();
+
+ALTER TABLE identity.oauth_apps
+    ADD COLUMN IF NOT EXISTS updated_at TIMESTAMPTZ NOT NULL DEFAULT now();
+
+DROP TRIGGER IF EXISTS trg_oauth_apps_updated_at ON identity.oauth_apps;
+CREATE TRIGGER trg_oauth_apps_updated_at
+    BEFORE UPDATE ON identity.oauth_apps
+    FOR EACH ROW EXECUTE FUNCTION identity.set_updated_at();
+
+COMMIT;

--- a/plane/data/store/postgres/compliance_test.go
+++ b/plane/data/store/postgres/compliance_test.go
@@ -56,6 +56,7 @@ func TestPostgresMetadataStoreCompliance(t *testing.T) {
 			"006_identity_revocation.sql",
 			"007_billing_partition_archives.sql",
 			"008_updated_at_triggers.sql",
+			"009_identity_temporal_columns.sql",
 		} {
 			sql, err := os.ReadFile(filepath.Join(migrationsDir, f))
 			if err != nil {

--- a/plane/data/store/postgres/identity_temporal_columns_test.go
+++ b/plane/data/store/postgres/identity_temporal_columns_test.go
@@ -1,0 +1,125 @@
+//go:build integration
+
+package postgres_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// TestOrgMembershipsTemporalColumnsBumpOnUpdate asserts that migration 009
+// added created_at + updated_at to identity.org_memberships and that an
+// UPDATE advances updated_at via the identity.set_updated_at() trigger.
+func TestOrgMembershipsTemporalColumnsBumpOnUpdate(t *testing.T) {
+	pool := setupPostgres(t)
+	ctx := context.Background()
+
+	orgID := uuid.New()
+	if _, err := pool.Exec(ctx,
+		`INSERT INTO identity.organisations (id, slug) VALUES ($1, 'org-temporal')`,
+		orgID,
+	); err != nil {
+		t.Fatalf("seed identity.organisations: %v", err)
+	}
+
+	userID := uuid.New()
+	if _, err := pool.Exec(ctx,
+		`INSERT INTO identity.human_users (id, email, credential_hash) VALUES ($1, 'temporal@example.com', 'x')`,
+		userID,
+	); err != nil {
+		t.Fatalf("seed identity.human_users: %v", err)
+	}
+
+	if _, err := pool.Exec(ctx,
+		`INSERT INTO identity.org_memberships (org_id, user_id, role) VALUES ($1, $2, 'developer')`,
+		orgID, userID,
+	); err != nil {
+		t.Fatalf("seed identity.org_memberships: %v", err)
+	}
+
+	var createdAt, before time.Time
+	if err := pool.QueryRow(ctx,
+		`SELECT created_at, updated_at FROM identity.org_memberships WHERE org_id=$1 AND user_id=$2`,
+		orgID, userID,
+	).Scan(&createdAt, &before); err != nil {
+		t.Fatalf("read temporal columns before update: %v", err)
+	}
+	if createdAt.IsZero() {
+		t.Fatalf("created_at was zero; expected default now()")
+	}
+
+	// PostgreSQL now() resolves at statement-start; sleep to guarantee a
+	// strictly-greater timestamp regardless of clock granularity.
+	time.Sleep(10 * time.Millisecond)
+
+	if _, err := pool.Exec(ctx,
+		`UPDATE identity.org_memberships SET role='maintainer' WHERE org_id=$1 AND user_id=$2`,
+		orgID, userID,
+	); err != nil {
+		t.Fatalf("update identity.org_memberships: %v", err)
+	}
+
+	var after time.Time
+	if err := pool.QueryRow(ctx,
+		`SELECT updated_at FROM identity.org_memberships WHERE org_id=$1 AND user_id=$2`,
+		orgID, userID,
+	).Scan(&after); err != nil {
+		t.Fatalf("read updated_at after update: %v", err)
+	}
+	if !after.After(before) {
+		t.Fatalf("updated_at not bumped: before=%v after=%v", before, after)
+	}
+}
+
+// TestOAuthAppsUpdatedAtBumpsOnUpdate asserts that migration 009 added
+// updated_at to identity.oauth_apps and that an UPDATE advances it via the
+// identity.set_updated_at() trigger.
+func TestOAuthAppsUpdatedAtBumpsOnUpdate(t *testing.T) {
+	pool := setupPostgres(t)
+	ctx := context.Background()
+
+	orgID := uuid.New()
+	if _, err := pool.Exec(ctx,
+		`INSERT INTO identity.organisations (id, slug) VALUES ($1, 'org-oauth')`,
+		orgID,
+	); err != nil {
+		t.Fatalf("seed identity.organisations: %v", err)
+	}
+
+	appID := uuid.New()
+	if _, err := pool.Exec(ctx,
+		`INSERT INTO identity.oauth_apps (id, org_id, name, client_id, client_secret_hash)
+		 VALUES ($1, $2, 'app', 'cid-1', 'h')`,
+		appID, orgID,
+	); err != nil {
+		t.Fatalf("seed identity.oauth_apps: %v", err)
+	}
+
+	var before time.Time
+	if err := pool.QueryRow(ctx,
+		`SELECT updated_at FROM identity.oauth_apps WHERE id=$1`, appID,
+	).Scan(&before); err != nil {
+		t.Fatalf("read updated_at before update: %v", err)
+	}
+
+	time.Sleep(10 * time.Millisecond)
+
+	if _, err := pool.Exec(ctx,
+		`UPDATE identity.oauth_apps SET name='app-2' WHERE id=$1`, appID,
+	); err != nil {
+		t.Fatalf("update identity.oauth_apps: %v", err)
+	}
+
+	var after time.Time
+	if err := pool.QueryRow(ctx,
+		`SELECT updated_at FROM identity.oauth_apps WHERE id=$1`, appID,
+	).Scan(&after); err != nil {
+		t.Fatalf("read updated_at after update: %v", err)
+	}
+	if !after.After(before) {
+		t.Fatalf("updated_at not bumped: before=%v after=%v", before, after)
+	}
+}

--- a/plane/data/store/postgres/postgres_test.go
+++ b/plane/data/store/postgres/postgres_test.go
@@ -67,6 +67,7 @@ func runMigrations(t *testing.T, ctx context.Context, pool *pgxpool.Pool) {
 		"006_identity_revocation.sql",
 		"007_billing_partition_archives.sql",
 		"008_updated_at_triggers.sql",
+		"009_identity_temporal_columns.sql",
 	}
 	for _, f := range files {
 		sql, err := os.ReadFile(filepath.Join(migrationsDir, f))


### PR DESCRIPTION
## Summary

- Adds `created_at` + `updated_at` to `identity.org_memberships`.
- Adds `updated_at` to `identity.oauth_apps`.
- Attaches the existing `identity.set_updated_at()` trigger function (from `006_identity_revocation.sql`) to both tables.

## ADR-impact

None — schema-consistency fix.

## Test plan

- [x] Compliance test bootstraps PG with the new migration (`009_identity_temporal_columns.sql` appended in both `compliance_test.go` and `postgres_test.go` migration slices).
- [x] `TestOrgMembershipsTemporalColumnsBumpOnUpdate` — UPDATE bumps `updated_at`; `created_at` defaults to `now()`.
- [x] `TestOAuthAppsUpdatedAtBumpsOnUpdate` — UPDATE bumps `updated_at`.
- [x] Migration is idempotent (`ADD COLUMN IF NOT EXISTS`, `DROP TRIGGER IF EXISTS`).
- [x] `go build ./...`, `go vet ./...`, `golangci-lint run ./plane/data/...` clean.
- [x] Full integration suite `go test -tags integration -race ./plane/data/store/postgres/...` passes.

Spec: `docs/superpowers/specs/2026-05-08-issue-47-identity-temporal-columns-design.md`
Plan: `docs/superpowers/plans/2026-05-08-issue-47-identity-temporal-columns-plan.md`

Closes #47.