### PR TITLE
[Workflow] Glue Data Catalog registration activity

### DIFF
--- a/cmd/workflow-worker/main.go
+++ b/cmd/workflow-worker/main.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/glue"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/gitscale-platform/gitscale/plane/data/cache"
 	"github.com/gitscale-platform/gitscale/plane/data/outbox"
@@ -197,15 +198,44 @@ func run(logger *slog.Logger) error {
 			if err != nil {
 				return fmt.Errorf("export activity: %w", err)
 			}
+
+			// GlueRegisterActivity (#77, ADR-018 §Query path). Reuses the same
+			// AWS SDK config as the S3 client; AWS_REGION applies. Database
+			// and table names are constants matching terraform/analytics.
+			glueCtx, cancelGlue := context.WithTimeout(context.Background(), 10*time.Second)
+			glueCfg, err := awsconfig.LoadDefaultConfig(glueCtx,
+				awsconfig.WithRegion(envDefault("AWS_REGION", envDefault("S3_REGION", "us-east-1"))),
+			)
+			cancelGlue()
+			if err != nil {
+				return fmt.Errorf("aws config (glue): %w", err)
+			}
+			glueClient := glue.NewFromConfig(glueCfg, func(o *glue.Options) {
+				if endpoint := os.Getenv("GLUE_ENDPOINT"); endpoint != "" {
+					o.BaseEndpoint = aws.String(endpoint)
+				}
+			})
+			glueRegister, err := billing.NewGlueRegisterActivity(
+				glueClient,
+				envDefault("GLUE_DATABASE", "gitscale_analytics"),
+				envDefault("GLUE_TABLE", "usage_events"),
+			)
+			if err != nil {
+				return fmt.Errorf("glue register activity: %w", err)
+			}
+
 			archiveDeps = &billing.ArchiveDeps{
-				Detach: detach,
-				Export: export,
-				Emit:   emit,
-				Drop:   drop,
+				Detach:       detach,
+				Export:       export,
+				Emit:         emit,
+				GlueRegister: glueRegister,
+				Drop:         drop,
 			}
 			logger.Info("billing archive deps wired",
 				"bucket", bucket,
-				"billing_addr", os.Getenv("BILLING_SERVICE_ADDR"))
+				"billing_addr", os.Getenv("BILLING_SERVICE_ADDR"),
+				"glue_database", envDefault("GLUE_DATABASE", "gitscale_analytics"),
+				"glue_table", envDefault("GLUE_TABLE", "usage_events"))
 		} else {
 			logger.Info("S3_BUCKET unset; skipping archive deps + schedule")
 		}

--- a/docs/superpowers/plans/2026-05-08-issue-77-glue-data-catalog-plan.md
+++ b/docs/superpowers/plans/2026-05-08-issue-77-glue-data-catalog-plan.md
@@ -1,0 +1,137 @@
+# Issue #77 Glue Data Catalog registration — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:subagent-driven-development.
+
+**Goal:** Add `GlueRegisterActivity`, insert it into `PartitionArchiveWorkflow` between Emit and Drop, wire from `cmd/workflow-worker`, and integration-test against localstack.
+
+**Spec:** `docs/superpowers/specs/2026-05-08-issue-77-glue-data-catalog-design.md`
+
+**Branch:** `feat/workflow-glue-register-activity`
+
+---
+
+## File map
+
+### Create
+- `plane/workflow/billing/glue_register_activity.go`
+- `plane/workflow/billing/glue_register_activity_test.go`
+- `plane/workflow/billing/glue_register_activity_integration_test.go`
+- `terraform/analytics/main.tf` (stub)
+- `terraform/analytics/README.md` (stub)
+
+### Modify
+- `plane/workflow/billing/archive_workflow.go` — insert GlueRegister call between EmitArchiveEvent and DropPartition
+- `plane/workflow/billing/archive_workflow_test.go` — adapt mock chain to include GlueRegister
+- `plane/workflow/billing/bundle.go` — add `GlueRegister *GlueRegisterActivity` to `ArchiveDeps`; register activity
+- `cmd/workflow-worker/main.go` — build Glue client + GlueRegisterActivity in the env-gated archive block (Wave-1 #76 introduced this block)
+- `go.mod`, `go.sum` — add `github.com/aws/aws-sdk-go-v2/service/glue`
+
+---
+
+## Pre-flight
+
+- [ ] **Step P.1: Worktree from latest origin/main**
+- [ ] **Step P.2: Verify baseline tests pass**
+
+---
+
+## Task 1: Activity + unit test
+
+- [ ] **Step 1.1: glue_register_activity.go**
+
+Implementation per spec. `GlueClient` interface narrows the AWS SDK
+surface for testability. `Execute` calls `CreatePartition`; treats
+`AlreadyExistsException` as success.
+
+- [ ] **Step 1.2: glue_register_activity_test.go**
+
+Unit test using a `fakeGlueClient` that records calls. Cases: happy path,
+already-exists conflict (idempotent), other error (propagated).
+
+- [ ] **Step 1.3: Build + test + commit**
+
+---
+
+## Task 2: Workflow integration
+
+- [ ] **Step 2.1: Insert into archive_workflow.go**
+
+Between `EmitArchiveEventActivity` and `DropPartitionActivity`, add
+`GlueRegisterActivity.Execute`. Determinism preserved (sequential
+activities).
+
+- [ ] **Step 2.2: Update archive_workflow_test.go**
+
+Mock chain gains the GlueRegister step.
+
+- [ ] **Step 2.3: bundle.go — `ArchiveDeps.GlueRegister`**
+
+Add the field; register the activity name in `Apply`.
+
+- [ ] **Step 2.4: Build + run all unit tests + commit**
+
+---
+
+## Task 3: Worker wiring
+
+- [ ] **Step 3.1: cmd/workflow-worker/main.go**
+
+In the env-gated archive block (introduced by #76), build:
+
+```go
+glueClient := glue.NewFromConfig(awsCfg)
+glueRegister, err := billing.NewGlueRegisterActivity(glueClient, "gitscale_analytics", "usage_events")
+```
+
+Append to `archiveDeps.GlueRegister`.
+
+- [ ] **Step 3.2: go.mod**
+
+```bash
+go get github.com/aws/aws-sdk-go-v2/service/glue@latest
+go mod tidy
+```
+
+- [ ] **Step 3.3: Build + commit**
+
+---
+
+## Task 4: localstack integration test
+
+- [ ] **Step 4.1: glue_register_activity_integration_test.go**
+
+testcontainer for localstack with `SERVICES=glue`. Pre-create the database
+and table. Run the activity. Assert via `GetPartition`. Re-run to verify
+idempotency.
+
+- [ ] **Step 4.2: Run + commit**
+
+---
+
+## Task 5: Terraform stubs
+
+- [ ] **Step 5.1: terraform/analytics/main.tf**
+
+```hcl
+# STUB — provision via ops. Tracks issue #77 + ADR-018.
+# resource "aws_glue_catalog_database" "gitscale_analytics" {
+#   name = "gitscale_analytics"
+# }
+# resource "aws_glue_catalog_table" "usage_events" {
+#   database_name = aws_glue_catalog_database.gitscale_analytics.name
+#   name          = "usage_events"
+#   partition_keys = [
+#     { name = "year",  type = "string" },
+#     { name = "month", type = "string" },
+#   ]
+#   storage_descriptor { ... }   # parquet hive serde
+# }
+```
+
+- [ ] **Step 5.2: terraform/analytics/README.md** documents the resource list and the IAM policy required by the workflow worker SPIFFE identity (`glue:CreatePartition`) and analyst role (`glue:GetPartition` + S3 read).
+
+---
+
+## Task 6: Final gates + open PR
+
+- [ ] Test sweep, skills (`gitscale-go-conventions`, `gitscale-temporal-determinism`, `gitscale-plane-boundary`, `gitscale-adr-guard`), self-review battery, push, `gh pr create`. Closes #77. Cross-link spec + plan.

--- a/docs/superpowers/specs/2026-05-08-issue-77-glue-data-catalog-design.md
+++ b/docs/superpowers/specs/2026-05-08-issue-77-glue-data-catalog-design.md
@@ -1,0 +1,115 @@
+# Spec — Issue #77 Glue Data Catalog registration activity
+
+Date: 2026-05-08
+Issue: #77
+Plane: workflow + data (Terraform)
+Priority: p2 (Wave 2; deps #76)
+ADR-impact: conforming (ADR-018 §Query path)
+
+## Goals
+
+1. Register every archived monthly partition with the AWS Glue Data Catalog
+   so Athena queries against `gitscale_analytics.usage_events` return rows
+   for archived months.
+2. Add `GlueRegisterActivity` to the workflow activity chain after
+   `EmitOutbox` and before `DropPartition`.
+3. Idempotent registration via `glue:CreatePartition` with
+   `EntityNotFoundException`-on-replay handled.
+4. Localstack-Glue integration test.
+
+## Non-goals
+
+- Authoring the full Terraform module (separate ops effort tracked
+  externally; this PR delivers the workflow-side activity and a stub TF
+  reference).
+- IAM policy changes (delegated to ops).
+- Hive metastore alternative (Glue is the chosen backend per ADR-018).
+
+## Architecture
+
+### Activity
+
+`plane/workflow/billing/glue_register_activity.go`:
+
+```go
+type GlueClient interface {
+    CreatePartition(ctx context.Context, in *glue.CreatePartitionInput, opts ...func(*glue.Options)) (*glue.CreatePartitionOutput, error)
+}
+
+type GlueRegisterActivity struct {
+    client      GlueClient
+    database    string // "gitscale_analytics"
+    table       string // "usage_events"
+}
+
+func NewGlueRegisterActivity(client GlueClient, database, table string) (*GlueRegisterActivity, error)
+
+type GlueRegisterInput struct {
+    Year  int
+    Month int
+    LakeURI string // s3://bucket/prefix/year=YYYY/month=MM/
+}
+
+func (a *GlueRegisterActivity) Execute(ctx context.Context, in GlueRegisterInput) error
+```
+
+`Execute` calls `glue.CreatePartition` with:
+
+- `DatabaseName: a.database`
+- `TableName: a.table`
+- `PartitionInput`:
+  - `Values: ["YYYY", "MM"]`
+  - `StorageDescriptor.Location: s3://bucket/prefix/year=YYYY/month=MM/`
+  - `StorageDescriptor.InputFormat: "org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat"`
+  - `StorageDescriptor.OutputFormat: "org.apache.hadoop.hive.ql.io.parquet.MapredParquetOutputFormat"`
+  - `StorageDescriptor.SerdeInfo`: parquet hive serde
+
+On `AlreadyExistsException` (Glue's idempotency-conflict error), return nil.
+On any other error, return wrapped error so Temporal retries.
+
+### Workflow change
+
+`PartitionArchiveWorkflow` activity sequence becomes:
+
+```
+DetachPartition → ExportActivity → EmitArchiveEventActivity → GlueRegisterActivity → DropPartition
+```
+
+`Bundle.ArchiveDeps` gains `GlueRegister *GlueRegisterActivity`.
+
+`cmd/workflow-worker/main.go` builds the Glue client from env (`AWS_REGION`,
+shared AWS SDK config) and constructs the activity in the same env-gated
+block as #76's other archive deps.
+
+### Terraform reference
+
+A `terraform/analytics/main.tf` stub is added documenting the required
+resources (Glue database, Glue table with Hive partition spec, IAM policy
+for the worker SPIFFE identity). Marked `# STUB — provision via ops` with
+links to the issue and ADR-018. Full TF authoring is out of scope.
+
+### Integration test
+
+`plane/workflow/billing/glue_register_activity_integration_test.go`
+(`//go:build integration`):
+
+- Boot localstack with Glue enabled.
+- Pre-create the `gitscale_analytics.usage_events` table.
+- Run `GlueRegisterActivity.Execute` for `(2024, 5)`.
+- Assert: `GetPartition(values=["2024","05"])` returns the registered row.
+- Re-run; assert no error (idempotency).
+
+## Acceptance checklist
+
+- [ ] `GlueRegisterActivity` implemented (idempotent CreatePartition)
+- [ ] Workflow updated to call it between `Emit` and `Drop`
+- [ ] `ArchiveDeps.GlueRegister` field added; wired in cmd/workflow-worker
+- [ ] localstack-Glue integration test asserts partition appears in catalog
+- [ ] Terraform reference stub committed under `terraform/analytics/`
+- [ ] PR description references ADR-018
+
+## References
+
+- ADR-018 §Query path
+- aws-sdk-go-v2 `service/glue`
+- localstack glue: https://docs.localstack.cloud/user-guide/aws/glue/

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,9 @@ go 1.25.0
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.41.7
+	github.com/aws/aws-sdk-go-v2/config v1.32.17
 	github.com/aws/aws-sdk-go-v2/feature/s3/transfermanager v0.1.21
+	github.com/aws/aws-sdk-go-v2/service/glue v1.141.0
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.101.0
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/vault/api v1.23.0
@@ -40,7 +42,6 @@ require (
 	github.com/Microsoft/go-winio v0.6.2 // indirect
 	github.com/andybalholm/brotli v1.1.1 // indirect
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.10 // indirect
-	github.com/aws/aws-sdk-go-v2/config v1.32.17 // indirect
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.16 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.23 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.23 // indirect

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.25.0
 require (
 	github.com/aws/aws-sdk-go-v2 v1.41.7
 	github.com/aws/aws-sdk-go-v2/config v1.32.17
+	github.com/aws/aws-sdk-go-v2/credentials v1.19.16
 	github.com/aws/aws-sdk-go-v2/feature/s3/transfermanager v0.1.21
 	github.com/aws/aws-sdk-go-v2/service/glue v1.141.0
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.101.0
@@ -42,7 +43,6 @@ require (
 	github.com/Microsoft/go-winio v0.6.2 // indirect
 	github.com/andybalholm/brotli v1.1.1 // indirect
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.10 // indirect
-	github.com/aws/aws-sdk-go-v2/credentials v1.19.16 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.23 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.23 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.23 // indirect

--- a/go.sum
+++ b/go.sum
@@ -279,6 +279,8 @@ github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.23 h1:bpd8vxhlQi2r1hiueO
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.23/go.mod h1:15DfR2nw+CRHIk0tqNyifu3G1YdAOy68RftkhMDDwYk=
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.24 h1:OQqn11BtaYv1WLUowvcA30MpzIu8Ti4pcLPIIyoKZrA=
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.24/go.mod h1:X5ZJyfwVrWA96GzPmUCWFQaEARPR7gCrpq2E92PJwAE=
+github.com/aws/aws-sdk-go-v2/service/glue v1.141.0 h1:QeZdzcEB+eB76YvIHqZyxsmxH+f9f2kKDdz48UC4HCM=
+github.com/aws/aws-sdk-go-v2/service/glue v1.141.0/go.mod h1:FZCvt95CcJWRkZNRcmMW1uQkpDHmyUSkZfz3awyZgqg=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.9 h1:FLudkZLt5ci0ozzgkVo8BJGwvqNaZbTWb3UcucAateA=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.9/go.mod h1:w7wZ/s9qK7c8g4al+UyoF1Sp/Z45UwMGcqIzLWVQHWk=
 github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.9.15 h1:ieLCO1JxUWuxTZ1cRd0GAaeX7O6cIxnwk7tc1LsQhC4=

--- a/plane/workflow/billing/archive_workflow.go
+++ b/plane/workflow/billing/archive_workflow.go
@@ -29,10 +29,13 @@ type ArchiveResult struct {
 // PartitionArchiveWorkflow archives billing.usage_events_YYYY_MM to the
 // analytics-lake object store and drops the partition from PostgreSQL.
 //
-// Activity sequence: DetachPartition → Export → EmitOutbox → DropPartition.
+// Activity sequence: DetachPartition → Export → EmitOutbox →
+// GlueRegister → DropPartition.
 // Drop failure after emit surfaces as a workflow error — data exists in both
 // PG (detached) and object store; no data loss. Runbook: verify object store
 // integrity then DROP TABLE manually or re-run the workflow.
+// GlueRegister is idempotent (AlreadyExists treated as success), so re-runs
+// after partial completion are safe.
 func PartitionArchiveWorkflow(ctx workflow.Context, in ArchiveInput) (ArchiveResult, error) {
 	if in.Year < 2026 || in.Year > 2099 {
 		return ArchiveResult{}, fmt.Errorf("archive: year %d out of supported range [2026, 2099]", in.Year)
@@ -83,6 +86,17 @@ func PartitionArchiveWorkflow(ctx workflow.Context, in ArchiveInput) (ArchiveRes
 		},
 	).Get(emitCtx, nil); err != nil {
 		return ArchiveResult{}, fmt.Errorf("archive: emit: %w", err)
+	}
+
+	glueCtx := workflow.WithActivityOptions(ctx, emitOpts)
+	if err := workflow.ExecuteActivity(glueCtx, ActivityNameGlueRegister,
+		GlueRegisterInput{
+			Year:    in.Year,
+			Month:   in.Month,
+			LakeURI: exportResult.LakeURI,
+		},
+	).Get(glueCtx, nil); err != nil {
+		return ArchiveResult{}, fmt.Errorf("archive: glue register: %w", err)
 	}
 
 	dropCtx := workflow.WithActivityOptions(ctx, shortOpts)

--- a/plane/workflow/billing/archive_workflow_test.go
+++ b/plane/workflow/billing/archive_workflow_test.go
@@ -28,6 +28,10 @@ func registerArchiveActivityStubs(env *testsuite.TestWorkflowEnvironment) {
 		activity.RegisterOptions{Name: ActivityNameEmitArchiveEvent},
 	)
 	env.RegisterActivityWithOptions(
+		func(context.Context, GlueRegisterInput) error { return nil },
+		activity.RegisterOptions{Name: ActivityNameGlueRegister},
+	)
+	env.RegisterActivityWithOptions(
 		func(context.Context, DropInput) error { return nil },
 		activity.RegisterOptions{Name: ActivityNameDropPartition},
 	)
@@ -55,6 +59,11 @@ func TestPartitionArchiveWorkflow_happyPath(t *testing.T) {
 		LakeURI:       "s3://test-bucket/billing/usage_events/year=2026/month=05/usage_events_2026_05.parquet",
 		RowCount:      100,
 		BytesWritten:  4096,
+	}).Return(nil)
+	env.OnActivity(ActivityNameGlueRegister, mock.Anything, GlueRegisterInput{
+		Year:    2026,
+		Month:   5,
+		LakeURI: "s3://test-bucket/billing/usage_events/year=2026/month=05/usage_events_2026_05.parquet",
 	}).Return(nil)
 	env.OnActivity(ActivityNameDropPartition, mock.Anything, DropInput{Year: 2026, Month: 5}).
 		Return(nil)
@@ -102,6 +111,7 @@ func TestPartitionArchiveWorkflow_exportRetryOnFirstFailure(t *testing.T) {
 	env.OnActivity(ActivityNameExport, mock.Anything, ExportInput{Year: 2026, Month: 5}).
 		Return(exportResult, nil)
 	env.OnActivity(ActivityNameEmitArchiveEvent, mock.Anything, mock.Anything).Return(nil)
+	env.OnActivity(ActivityNameGlueRegister, mock.Anything, mock.Anything).Return(nil)
 	env.OnActivity(ActivityNameDropPartition, mock.Anything, DropInput{Year: 2026, Month: 5}).
 		Return(nil)
 
@@ -155,6 +165,7 @@ func TestPartitionArchiveWorkflow_dropFailureSurfacesError(t *testing.T) {
 	env.OnActivity(ActivityNameExport, mock.Anything, mock.Anything).
 		Return(ExportResult{LakeURI: "s3://b/k", RowCount: 1, BytesWritten: 100, SHA256Hex: "x"}, nil)
 	env.OnActivity(ActivityNameEmitArchiveEvent, mock.Anything, mock.Anything).Return(nil)
+	env.OnActivity(ActivityNameGlueRegister, mock.Anything, mock.Anything).Return(nil)
 	env.OnActivity(ActivityNameDropPartition, mock.Anything, mock.Anything).
 		Return(errors.New("pg: table does not exist"))
 

--- a/plane/workflow/billing/bundle.go
+++ b/plane/workflow/billing/bundle.go
@@ -9,10 +9,11 @@ import (
 // archive workflow + activity registration (e.g. when real deps such as the
 // object store are not yet wired).
 type ArchiveDeps struct {
-	Detach *DetachPartitionActivity
-	Export *ExportActivity
-	Emit   *EmitArchiveEventActivity
-	Drop   *DropPartitionActivity
+	Detach       *DetachPartitionActivity
+	Export       *ExportActivity
+	Emit         *EmitArchiveEventActivity
+	GlueRegister *GlueRegisterActivity
+	Drop         *DropPartitionActivity
 }
 
 // Bundle returns the registration set for the billing-maintenance task queue.
@@ -29,6 +30,7 @@ func Bundle(rollover *CreatePartitionActivity, archive *ArchiveDeps) gswf.Bundle
 			gswf.NamedActivity{Name: ActivityNameDetachPartition, Activity: archive.Detach.Execute},
 			gswf.NamedActivity{Name: ActivityNameExport, Activity: archive.Export.Execute},
 			gswf.NamedActivity{Name: ActivityNameEmitArchiveEvent, Activity: archive.Emit.Execute},
+			gswf.NamedActivity{Name: ActivityNameGlueRegister, Activity: archive.GlueRegister.Execute},
 			gswf.NamedActivity{Name: ActivityNameDropPartition, Activity: archive.Drop.Execute},
 		)
 	}

--- a/plane/workflow/billing/glue_register_activity.go
+++ b/plane/workflow/billing/glue_register_activity.go
@@ -1,0 +1,109 @@
+package billing
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/glue"
+	gluetypes "github.com/aws/aws-sdk-go-v2/service/glue/types"
+)
+
+const ActivityNameGlueRegister = "billing.GlueRegister"
+
+// GlueClient narrows the AWS SDK Glue surface to the calls used by this
+// activity, so tests can supply an in-memory fake without spinning up
+// localstack. Mirrors the *glue.Client method signature.
+type GlueClient interface {
+	CreatePartition(ctx context.Context, in *glue.CreatePartitionInput, opts ...func(*glue.Options)) (*glue.CreatePartitionOutput, error)
+}
+
+// GlueRegisterInput is the input to GlueRegisterActivity.Execute.
+//
+// LakeURI is the s3:// URI of the partition's directory, e.g.
+// s3://bucket/billing/usage_events/year=2026/month=05/.
+// Year and Month identify the partition values registered with Glue.
+type GlueRegisterInput struct {
+	Year    int
+	Month   int
+	LakeURI string
+}
+
+// GlueRegisterActivity registers an archived monthly partition with the
+// AWS Glue Data Catalog (database `gitscale_analytics`, table
+// `usage_events`) so Athena queries against the analytics lake see archived
+// months. Conforming to ADR-018 §Query path.
+//
+// Idempotent: glue.CreatePartition returns AlreadyExistsException on replay,
+// which Execute treats as success.
+type GlueRegisterActivity struct {
+	client   GlueClient
+	database string
+	table    string
+}
+
+// NewGlueRegisterActivity constructs the activity. Returns an error if any
+// argument is empty so the worker boot path fails fast (ADR-008/019 style).
+func NewGlueRegisterActivity(client GlueClient, database, table string) (*GlueRegisterActivity, error) {
+	if client == nil {
+		return nil, errors.New("billing.NewGlueRegisterActivity: client is nil")
+	}
+	if database == "" {
+		return nil, errors.New("billing.NewGlueRegisterActivity: database is empty")
+	}
+	if table == "" {
+		return nil, errors.New("billing.NewGlueRegisterActivity: table is empty")
+	}
+	return &GlueRegisterActivity{client: client, database: database, table: table}, nil
+}
+
+// Hive parquet SerDe constants. Matches the table definition in
+// terraform/analytics/main.tf — Athena requires these to read the archive.
+const (
+	parquetInputFormat  = "org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat"
+	parquetOutputFormat = "org.apache.hadoop.hive.ql.io.parquet.MapredParquetOutputFormat"
+	parquetSerde        = "org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe"
+)
+
+// Execute registers (year, month) → LakeURI with Glue. Treats
+// AlreadyExistsException as success so retries / re-runs are safe.
+func (a *GlueRegisterActivity) Execute(ctx context.Context, in GlueRegisterInput) error {
+	if in.Year < 2026 || in.Year > 2099 {
+		return fmt.Errorf("glue register: year %d out of range", in.Year)
+	}
+	if in.Month < 1 || in.Month > 12 {
+		return fmt.Errorf("glue register: month %d out of range", in.Month)
+	}
+	if in.LakeURI == "" {
+		return errors.New("glue register: LakeURI is empty")
+	}
+
+	yearStr := fmt.Sprintf("%04d", in.Year)
+	monthStr := fmt.Sprintf("%02d", in.Month)
+
+	input := &glue.CreatePartitionInput{
+		DatabaseName: aws.String(a.database),
+		TableName:    aws.String(a.table),
+		PartitionInput: &gluetypes.PartitionInput{
+			Values: []string{yearStr, monthStr},
+			StorageDescriptor: &gluetypes.StorageDescriptor{
+				Location:     aws.String(in.LakeURI),
+				InputFormat:  aws.String(parquetInputFormat),
+				OutputFormat: aws.String(parquetOutputFormat),
+				SerdeInfo: &gluetypes.SerDeInfo{
+					SerializationLibrary: aws.String(parquetSerde),
+				},
+			},
+		},
+	}
+
+	if _, err := a.client.CreatePartition(ctx, input); err != nil {
+		var alreadyExists *gluetypes.AlreadyExistsException
+		if errors.As(err, &alreadyExists) {
+			return nil
+		}
+		return fmt.Errorf("glue.CreatePartition: %w", err)
+	}
+	return nil
+}

--- a/plane/workflow/billing/glue_register_activity_integration_test.go
+++ b/plane/workflow/billing/glue_register_activity_integration_test.go
@@ -1,0 +1,133 @@
+//go:build integration
+
+package billing
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/aws/aws-sdk-go-v2/service/glue"
+	gluetypes "github.com/aws/aws-sdk-go-v2/service/glue/types"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/wait"
+)
+
+// bootLocalstackGlue boots a localstack container with Glue enabled and
+// returns a *glue.Client pointing at it. Pre-creates the
+// gitscale_analytics.usage_events table with the same Hive partition spec
+// that terraform/analytics/main.tf documents.
+func bootLocalstackGlue(t *testing.T) *glue.Client {
+	t.Helper()
+	ctx := context.Background()
+
+	req := testcontainers.ContainerRequest{
+		Image:        "localstack/localstack:3.5",
+		ExposedPorts: []string{"4566/tcp"},
+		Env: map[string]string{
+			"SERVICES":      "glue",
+			"DEFAULT_REGION": "us-east-1",
+		},
+		WaitingFor: wait.ForHTTP("/_localstack/health").
+			WithPort("4566/tcp").
+			WithStartupTimeout(90 * time.Second),
+	}
+	c, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
+		ContainerRequest: req, Started: true,
+	})
+	if err != nil {
+		t.Fatalf("localstack container: %v", err)
+	}
+	t.Cleanup(func() { _ = c.Terminate(ctx) })
+
+	host, _ := c.Host(ctx)
+	port, _ := c.MappedPort(ctx, "4566/tcp")
+	endpoint := fmt.Sprintf("http://%s:%s", host, port.Port())
+
+	cfg, err := awsconfig.LoadDefaultConfig(ctx,
+		awsconfig.WithRegion("us-east-1"),
+		awsconfig.WithCredentialsProvider(credentials.NewStaticCredentialsProvider("test", "test", "")),
+	)
+	if err != nil {
+		t.Fatalf("aws config: %v", err)
+	}
+	client := glue.NewFromConfig(cfg, func(o *glue.Options) {
+		o.BaseEndpoint = aws.String(endpoint)
+	})
+
+	if _, err := client.CreateDatabase(ctx, &glue.CreateDatabaseInput{
+		DatabaseInput: &gluetypes.DatabaseInput{Name: aws.String("gitscale_analytics")},
+	}); err != nil {
+		t.Fatalf("create db: %v", err)
+	}
+	if _, err := client.CreateTable(ctx, &glue.CreateTableInput{
+		DatabaseName: aws.String("gitscale_analytics"),
+		TableInput: &gluetypes.TableInput{
+			Name: aws.String("usage_events"),
+			PartitionKeys: []gluetypes.Column{
+				{Name: aws.String("year"), Type: aws.String("string")},
+				{Name: aws.String("month"), Type: aws.String("string")},
+			},
+			StorageDescriptor: &gluetypes.StorageDescriptor{
+				Location:     aws.String("s3://gitscale-analytics-lake/billing/usage_events/"),
+				InputFormat:  aws.String(parquetInputFormat),
+				OutputFormat: aws.String(parquetOutputFormat),
+				SerdeInfo: &gluetypes.SerDeInfo{
+					SerializationLibrary: aws.String(parquetSerde),
+				},
+				Columns: []gluetypes.Column{
+					{Name: aws.String("event_id"), Type: aws.String("string")},
+					{Name: aws.String("ts"), Type: aws.String("timestamp")},
+				},
+			},
+			TableType: aws.String("EXTERNAL_TABLE"),
+		},
+	}); err != nil {
+		t.Fatalf("create table: %v", err)
+	}
+	return client
+}
+
+func TestGlueRegisterActivity_Integration_LocalstackRoundTrip(t *testing.T) {
+	if testing.Short() {
+		t.Skip("integration")
+	}
+	client := bootLocalstackGlue(t)
+	a, err := NewGlueRegisterActivity(client, "gitscale_analytics", "usage_events")
+	if err != nil {
+		t.Fatalf("new: %v", err)
+	}
+	in := GlueRegisterInput{
+		Year:    2026,
+		Month:   5,
+		LakeURI: "s3://gitscale-analytics-lake/billing/usage_events/year=2026/month=05/",
+	}
+	ctx := context.Background()
+	if err := a.Execute(ctx, in); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	got, err := client.GetPartition(ctx, &glue.GetPartitionInput{
+		DatabaseName:    aws.String("gitscale_analytics"),
+		TableName:       aws.String("usage_events"),
+		PartitionValues: []string{"2026", "05"},
+	})
+	if err != nil {
+		t.Fatalf("GetPartition: %v", err)
+	}
+	if got.Partition == nil || got.Partition.StorageDescriptor == nil {
+		t.Fatalf("partition or storage descriptor nil: %+v", got)
+	}
+	if loc := aws.ToString(got.Partition.StorageDescriptor.Location); loc != in.LakeURI {
+		t.Errorf("location=%q want %q", loc, in.LakeURI)
+	}
+
+	// Re-run: AlreadyExists must be swallowed.
+	if err := a.Execute(ctx, in); err != nil {
+		t.Errorf("idempotent re-run failed: %v", err)
+	}
+}

--- a/plane/workflow/billing/glue_register_activity_test.go
+++ b/plane/workflow/billing/glue_register_activity_test.go
@@ -1,0 +1,132 @@
+package billing
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/glue"
+	gluetypes "github.com/aws/aws-sdk-go-v2/service/glue/types"
+)
+
+type fakeGlueClient struct {
+	calls []*glue.CreatePartitionInput
+	err   error
+}
+
+func (f *fakeGlueClient) CreatePartition(ctx context.Context, in *glue.CreatePartitionInput, opts ...func(*glue.Options)) (*glue.CreatePartitionOutput, error) {
+	f.calls = append(f.calls, in)
+	if f.err != nil {
+		return nil, f.err
+	}
+	return &glue.CreatePartitionOutput{}, nil
+}
+
+func TestGlueRegisterActivity_NewValidatesArgs(t *testing.T) {
+	if _, err := NewGlueRegisterActivity(nil, "db", "tbl"); err == nil {
+		t.Error("nil client should error")
+	}
+	fc := &fakeGlueClient{}
+	if _, err := NewGlueRegisterActivity(fc, "", "tbl"); err == nil {
+		t.Error("empty database should error")
+	}
+	if _, err := NewGlueRegisterActivity(fc, "db", ""); err == nil {
+		t.Error("empty table should error")
+	}
+	if _, err := NewGlueRegisterActivity(fc, "db", "tbl"); err != nil {
+		t.Errorf("valid args: %v", err)
+	}
+}
+
+func TestGlueRegisterActivity_HappyPath(t *testing.T) {
+	fc := &fakeGlueClient{}
+	a, err := NewGlueRegisterActivity(fc, "gitscale_analytics", "usage_events")
+	if err != nil {
+		t.Fatalf("new: %v", err)
+	}
+	in := GlueRegisterInput{
+		Year:    2026,
+		Month:   5,
+		LakeURI: "s3://bucket/billing/usage_events/year=2026/month=05/",
+	}
+	if err := a.Execute(context.Background(), in); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if len(fc.calls) != 1 {
+		t.Fatalf("calls=%d want 1", len(fc.calls))
+	}
+	got := fc.calls[0]
+	if *got.DatabaseName != "gitscale_analytics" {
+		t.Errorf("db=%q", *got.DatabaseName)
+	}
+	if *got.TableName != "usage_events" {
+		t.Errorf("table=%q", *got.TableName)
+	}
+	pi := got.PartitionInput
+	if len(pi.Values) != 2 || pi.Values[0] != "2026" || pi.Values[1] != "05" {
+		t.Errorf("values=%v want [2026 05]", pi.Values)
+	}
+	if *pi.StorageDescriptor.Location != in.LakeURI {
+		t.Errorf("location=%q want %q", *pi.StorageDescriptor.Location, in.LakeURI)
+	}
+	if *pi.StorageDescriptor.InputFormat != parquetInputFormat {
+		t.Errorf("inputFormat=%q", *pi.StorageDescriptor.InputFormat)
+	}
+	if *pi.StorageDescriptor.OutputFormat != parquetOutputFormat {
+		t.Errorf("outputFormat=%q", *pi.StorageDescriptor.OutputFormat)
+	}
+	if *pi.StorageDescriptor.SerdeInfo.SerializationLibrary != parquetSerde {
+		t.Errorf("serde=%q", *pi.StorageDescriptor.SerdeInfo.SerializationLibrary)
+	}
+}
+
+func TestGlueRegisterActivity_AlreadyExistsIsIdempotent(t *testing.T) {
+	fc := &fakeGlueClient{err: &gluetypes.AlreadyExistsException{Message: stringPtr("partition exists")}}
+	a, err := NewGlueRegisterActivity(fc, "db", "tbl")
+	if err != nil {
+		t.Fatalf("new: %v", err)
+	}
+	in := GlueRegisterInput{Year: 2026, Month: 5, LakeURI: "s3://b/k/"}
+	if err := a.Execute(context.Background(), in); err != nil {
+		t.Errorf("AlreadyExists should be swallowed; got %v", err)
+	}
+}
+
+func TestGlueRegisterActivity_OtherErrorPropagates(t *testing.T) {
+	fc := &fakeGlueClient{err: errors.New("boom")}
+	a, err := NewGlueRegisterActivity(fc, "db", "tbl")
+	if err != nil {
+		t.Fatalf("new: %v", err)
+	}
+	in := GlueRegisterInput{Year: 2026, Month: 5, LakeURI: "s3://b/k/"}
+	if err := a.Execute(context.Background(), in); err == nil {
+		t.Error("expected error to propagate")
+	}
+}
+
+func TestGlueRegisterActivity_ValidatesInput(t *testing.T) {
+	fc := &fakeGlueClient{}
+	a, _ := NewGlueRegisterActivity(fc, "db", "tbl")
+	cases := []struct {
+		name string
+		in   GlueRegisterInput
+	}{
+		{"yearLow", GlueRegisterInput{Year: 2025, Month: 5, LakeURI: "s3://b/k/"}},
+		{"yearHigh", GlueRegisterInput{Year: 2100, Month: 5, LakeURI: "s3://b/k/"}},
+		{"monthZero", GlueRegisterInput{Year: 2026, Month: 0, LakeURI: "s3://b/k/"}},
+		{"monthThirteen", GlueRegisterInput{Year: 2026, Month: 13, LakeURI: "s3://b/k/"}},
+		{"emptyURI", GlueRegisterInput{Year: 2026, Month: 5, LakeURI: ""}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := a.Execute(context.Background(), tc.in); err == nil {
+				t.Errorf("expected error for %+v", tc.in)
+			}
+		})
+	}
+	if len(fc.calls) != 0 {
+		t.Errorf("invalid inputs should not reach SDK: calls=%d", len(fc.calls))
+	}
+}
+
+func stringPtr(s string) *string { return &s }

--- a/terraform/analytics/README.md
+++ b/terraform/analytics/README.md
@@ -1,0 +1,51 @@
+# terraform/analytics — Glue Data Catalog (stub)
+
+Tracks issue #77 and ADR-018 § Query path.
+
+This directory is a **documentation stub**. The actual Terraform module is
+authored by the platform-ops team and lives in the ops infra repository.
+The files here exist so that:
+
+1. Workflow-plane developers can see, in-tree, what infrastructure
+   `plane/workflow/billing/GlueRegisterActivity` depends on.
+2. The ADR-018 query path has a code-tracked anchor for review.
+
+## Resources expected to exist
+
+| Resource | Name | Notes |
+|---|---|---|
+| `aws_glue_catalog_database` | `gitscale_analytics` | one per environment |
+| `aws_glue_catalog_table` | `usage_events` | Hive-partitioned by `year`, `month`; parquet SerDe |
+| S3 bucket | `${analytics_lake_bucket}` | also owns archive parquet objects (see plane/workflow/billing/objectstore_s3.go) |
+
+## IAM identities
+
+### Workflow worker (`spiffe://gitscale/workflow-worker`)
+
+Permissions required by `GlueRegisterActivity`:
+
+- `glue:CreatePartition`
+- `glue:GetTable`
+- `glue:GetDatabase`
+
+Scoped to the `gitscale_analytics` database + `usage_events` table.
+S3 write permissions are granted separately to the `ExportActivity`
+SPIFFE identity (already provisioned for #76).
+
+### Analyst role (`spiffe://gitscale/analyst-readonly`)
+
+Permissions required for Athena to query archived partitions:
+
+- `glue:GetDatabase`
+- `glue:GetTable`
+- `glue:GetPartition`
+- `glue:GetPartitions`
+- `s3:GetObject`, `s3:ListBucket` on `${analytics_lake_bucket}/billing/usage_events/*`
+
+## Why not a full module here
+
+ADR-008 establishes ops vs platform plane separation; cloud-account-level
+IAM and Glue resources belong to ops. The contract surface is small
+enough (database name, table name, parquet SerDe) that documenting it
+here is sufficient. If the contract grows, promote this stub into a real
+module.

--- a/terraform/analytics/main.tf
+++ b/terraform/analytics/main.tf
@@ -1,0 +1,92 @@
+# STUB — provision via ops. Tracks issue #77 + ADR-018.
+#
+# This file documents the Glue Data Catalog resources that
+# plane/workflow/billing/GlueRegisterActivity expects to exist. The full
+# Terraform module is authored separately by the platform-ops team
+# (out of scope per spec docs/superpowers/specs/2026-05-08-issue-77-...).
+#
+# When the module lands, uncomment + adapt. Until then this file serves as
+# the contract between workflow code and infrastructure.
+
+# resource "aws_glue_catalog_database" "gitscale_analytics" {
+#   name        = "gitscale_analytics"
+#   description = "GitScale archived billing partitions; queried via Athena."
+# }
+#
+# resource "aws_glue_catalog_table" "usage_events" {
+#   database_name = aws_glue_catalog_database.gitscale_analytics.name
+#   name          = "usage_events"
+#   table_type    = "EXTERNAL_TABLE"
+#
+#   partition_keys {
+#     name = "year"
+#     type = "string"
+#   }
+#   partition_keys {
+#     name = "month"
+#     type = "string"
+#   }
+#
+#   storage_descriptor {
+#     location      = "s3://${var.analytics_lake_bucket}/billing/usage_events/"
+#     input_format  = "org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat"
+#     output_format = "org.apache.hadoop.hive.ql.io.parquet.MapredParquetOutputFormat"
+#
+#     ser_de_info {
+#       serialization_library = "org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe"
+#     }
+#
+#     # Columns mirror billing.usage_events; keep in sync with the PG schema
+#     # owned by plane/data/store/billing.
+#     columns {
+#       name = "event_id"
+#       type = "string"
+#     }
+#     columns {
+#       name = "ts"
+#       type = "timestamp"
+#     }
+#     # ... org_id, repo_id, kind, quantity, etc.
+#   }
+# }
+#
+# # IAM policy attached to the workflow-worker SPIFFE identity (ADR-010).
+# # Minimum permissions for GlueRegisterActivity.
+# data "aws_iam_policy_document" "workflow_worker_glue_write" {
+#   statement {
+#     actions = [
+#       "glue:CreatePartition",
+#       "glue:GetTable",
+#       "glue:GetDatabase",
+#     ]
+#     resources = [
+#       aws_glue_catalog_database.gitscale_analytics.arn,
+#       aws_glue_catalog_table.usage_events.arn,
+#       "arn:aws:glue:${var.region}:${var.account_id}:catalog",
+#     ]
+#   }
+# }
+#
+# # IAM policy attached to analyst roles for read-only Athena access.
+# data "aws_iam_policy_document" "analyst_glue_read" {
+#   statement {
+#     actions = [
+#       "glue:GetDatabase",
+#       "glue:GetTable",
+#       "glue:GetPartition",
+#       "glue:GetPartitions",
+#     ]
+#     resources = [
+#       aws_glue_catalog_database.gitscale_analytics.arn,
+#       aws_glue_catalog_table.usage_events.arn,
+#       "arn:aws:glue:${var.region}:${var.account_id}:catalog",
+#     ]
+#   }
+#   statement {
+#     actions   = ["s3:GetObject", "s3:ListBucket"]
+#     resources = [
+#       "arn:aws:s3:::${var.analytics_lake_bucket}",
+#       "arn:aws:s3:::${var.analytics_lake_bucket}/billing/usage_events/*",
+#     ]
+#   }
+# }


### PR DESCRIPTION
## Summary

- Adds `billing.GlueRegisterActivity` calling `glue.CreatePartition` against `gitscale_analytics.usage_events`. Idempotent (`AlreadyExistsException` swallowed).
- Inserts the activity in `PartitionArchiveWorkflow` between `EmitArchiveEvent` and `DropPartition`. Order: Detach → Export → Emit → GlueRegister → Drop.
- Wires the activity in `cmd/workflow-worker/main.go` inside the env-gated archive block (#76); env-overridable database/table; localstack-friendly via `GLUE_ENDPOINT`.
- Adds localstack-Glue integration test (`//go:build integration`) asserting `GetPartition` round-trip plus idempotent re-run.
- Adds `terraform/analytics/` documentation stub recording the Glue resources + IAM identities required by ops.

Conforming to ADR-018 § Query path. ADR-008 outbox semantics preserved (Glue runs after the outbox emit, so the billing event remains the source of truth and a Glue replay is a no-op).

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` — all packages green
- [x] `go test ./plane/workflow/billing/ -run GlueRegister`
- [ ] Localstack integration: `go test -tags=integration ./plane/workflow/billing/ -run Integration_LocalstackRoundTrip` (CI tier)

## Refs

- Closes #77
- Spec: `docs/superpowers/specs/2026-05-08-issue-77-glue-data-catalog-design.md`
- Plan: `docs/superpowers/plans/2026-05-08-issue-77-glue-data-catalog-plan.md`
- ADRs: ADR-008 (outbox), ADR-018 (analytics query path)
- Wave-2 dep: #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)