### PR TITLE
[Workflow] RestorePartitionWorkflow + chunked-frame decoder (#79)

### DIFF
--- a/cmd/workflow-worker/main.go
+++ b/cmd/workflow-worker/main.go
@@ -240,7 +240,62 @@ func run(logger *slog.Logger) error {
 			logger.Info("S3_BUCKET unset; skipping archive deps + schedule")
 		}
 
-		billing.Bundle(partActivity, archiveDeps).Apply(workerRegistrar{w})
+		// RestoreDeps wiring (#79, ADR-018 §Restore + ADR-019 amendment).
+		// Opt-in via the same S3_BUCKET gate as archive: restore needs the
+		// object store + Vault + Postgres. Quarantine writes target only
+		// billing.usage_events_restore_YYYY_MM, never the live partition tree.
+		var restoreDeps *billing.RestoreDeps
+		if archiveDeps != nil {
+			vaultClient, err := billing.LoadVaultClientFromEnv()
+			if err != nil {
+				return fmt.Errorf("vault client (restore): %w", err)
+			}
+			restoreKeys := billing.NewVaultKeyProvider(
+				vaultClient,
+				envDefault("VAULT_TRANSIT_MOUNT", ""),
+				envDefault("VAULT_BILLING_KEY", ""),
+			)
+			s3Ctx, cancelS3 := context.WithTimeout(context.Background(), 10*time.Second)
+			restoreS3, err := buildS3ClientFromEnv(s3Ctx)
+			cancelS3()
+			if err != nil {
+				return fmt.Errorf("s3 client (restore): %w", err)
+			}
+			restoreObjStore := billing.NewS3ObjectStore(restoreS3, os.Getenv("S3_BUCKET"))
+
+			restorer := billingstore.NewPostgresRestorer(pool)
+			fetchAct, err := billing.NewFetchManifestActivity(restoreObjStore)
+			if err != nil {
+				return fmt.Errorf("fetch manifest activity: %w", err)
+			}
+			verifyAct, err := billing.NewVerifyChecksumActivity(restoreObjStore)
+			if err != nil {
+				return fmt.Errorf("verify checksum activity: %w", err)
+			}
+			scratchDir := envDefault("RESTORE_SCRATCH_DIR", "")
+			decAct, err := billing.NewDownloadAndDecryptActivity(restoreObjStore, restoreKeys, scratchDir)
+			if err != nil {
+				return fmt.Errorf("download+decrypt activity: %w", err)
+			}
+			loadAct, err := billing.NewLoadIntoQuarantineActivity(restorer)
+			if err != nil {
+				return fmt.Errorf("load quarantine activity: %w", err)
+			}
+			dropQAct, err := billing.NewDropQuarantineActivity(restorer)
+			if err != nil {
+				return fmt.Errorf("drop quarantine activity: %w", err)
+			}
+			restoreDeps = &billing.RestoreDeps{
+				FetchManifest:   fetchAct,
+				VerifyChecksum:  verifyAct,
+				DownloadDecrypt: decAct,
+				LoadQuarantine:  loadAct,
+				DropQuarantine:  dropQAct,
+			}
+			logger.Info("billing restore deps wired", "scratch_dir", scratchDir)
+		}
+
+		billing.Bundle(partActivity, archiveDeps, restoreDeps).Apply(workerRegistrar{w})
 
 		// Outbox TTL expirer (#45, ADR-008): one Expirer per domain, dispatched
 		// by a single fan-out workflow on the same task queue.

--- a/docs/runbooks/billing-partition-restore.md
+++ b/docs/runbooks/billing-partition-restore.md
@@ -1,0 +1,119 @@
+# Billing partition restore
+
+**Workflow:** `billing.RestorePartitionWorkflow`
+**Task queue:** `billing-maintenance`
+**Issue:** #79
+**ADR:** ADR-018 §Restore path (read-side); ADR-019 (data-plane import permitted for read paths and quarantine-only DDL)
+
+## When to run
+
+Run this workflow to restore an archived monthly partition into a quarantine
+table for dispute investigation, audit-restore, or compliance review. The
+quarantine table is **read-only by design** — it is never re-attached to the
+live `billing.usage_events` partition tree.
+
+If you need to materially change billing state, that is a separate
+application-plane action and is **not** covered by this workflow.
+
+## Inputs
+
+```json
+{ "Year": 2026, "Month": 5 }
+```
+
+Year must be in `[2026, 2099]`. Month must be in `[1, 12]`.
+
+## Trigger
+
+```sh
+temporal workflow start \
+  --task-queue billing-maintenance \
+  --type billing.RestorePartitionWorkflow \
+  --workflow-id billing.restore-partition.2026-05 \
+  --input '{"Year": 2026, "Month": 5}'
+```
+
+The workflow ID convention `billing.restore-partition.YYYY-MM` makes re-runs
+idempotent (subsequent attempts collide with the running ID).
+
+## What it does
+
+1. **FetchManifest** — `s3://<bucket>/billing/usage_events/year=YYYY/month=MM/usage_events_YYYY_MM.manifest.json`
+   - validates `source_partition` matches the requested (year, month)
+   - validates `schema_version == 1`
+2. **VerifyChecksum** — recomputes SHA-256 over the encrypted parquet object;
+   compares to the `.checksum.sha256` sidecar.
+3. **DownloadAndDecrypt** — chunked AES-256-GCM-v1-4mib decoder with per-chunk
+   AAD `<source_partition>:<chunk_index>`. Plaintext lands on the worker's
+   scratch volume (`RESTORE_SCRATCH_DIR`, default `/tmp`).
+4. **LoadIntoQuarantine** — `CREATE TABLE billing.usage_events_restore_YYYY_MM
+   (LIKE billing.usage_events INCLUDING DEFAULTS)`, COPY rows in, then `REVOKE
+   INSERT, UPDATE, DELETE, TRUNCATE … FROM PUBLIC`.
+
+On failure after step 4 starts, the workflow runs `DropQuarantineActivity` as
+compensation so the operator does not have to clean up a half-loaded table.
+
+## Verifying success
+
+```sql
+-- Row count should equal the manifest's row_count.
+SELECT count(*) FROM billing.usage_events_restore_2026_05;
+
+-- Quarantine table is read-only:
+INSERT INTO billing.usage_events_restore_2026_05 (id) VALUES (gen_random_uuid());
+-- ERROR: permission denied for table usage_events_restore_2026_05
+```
+
+## Failure modes
+
+| Symptom | Cause | Action |
+|---|---|---|
+| `ErrObjectNotFound: …manifest.json` | Archive never ran or object lifecycled out | Verify `billing.partition_archives` row exists and the bucket lifecycle policy. Restore is impossible if the parquet object is gone. |
+| `ErrChecksumMismatch` | Encrypted parquet was tampered or corrupted in object storage | Do **not** re-run. Open an incident; the bucket's data integrity is suspect. |
+| `ErrUnsupportedEncFormat` | Manifest declares a format this worker does not implement | Deploy a worker version that supports the manifest's `enc_format`. There is no compatibility shim by design. |
+| `ErrFrameTampered` | Decrypt-time AEAD failure: bad DEK, wrong AAD, truncated chunk, or bit-flip | Almost always a **DEK version mismatch** — see "Historical key versions" below. |
+| `kek_hint mismatch — manifest=… worker=…` | Vault transit key has rotated since the archive was written | See "Historical key versions" below. |
+
+## Historical key versions (known limitation)
+
+The current `VaultKeyProvider` always derives the DEK against Vault transit's
+**latest** key version (`platform-billing-master`). After a rotation, the
+`kek_hint` recorded in older manifests (e.g. `platform-billing-v1`) will not
+match what the worker derives (e.g. `platform-billing-v3`), and
+`DownloadAndDecryptActivity` will surface a kek_hint mismatch error.
+
+Vault transit retains all prior key versions on rotation, so the data is
+recoverable. The fix is to plumb a versioned key provider — out of scope for
+this PR. Tracked as a follow-up.
+
+**Operator workaround until that lands:**
+
+1. Identify the manifest's `kek_hint`:
+
+   ```sh
+   aws s3 cp s3://$BUCKET/billing/usage_events/year=2026/month=05/usage_events_2026_05.manifest.json - \
+     | jq .kek_hint
+   ```
+
+2. Stage a temporary worker pinned to that key version by overriding
+   `VAULT_BILLING_KEY` to a Vault-side alias that points at the historical
+   version, **or** request a rotation rollback via the security on-call.
+3. Run the workflow against the staged worker.
+
+## Reverting
+
+The quarantine table is independent of the live partition tree. To remove a
+restored quarantine table:
+
+```sql
+DROP TABLE billing.usage_events_restore_2026_05;
+```
+
+This has no effect on production billing state.
+
+## References
+
+- Spec: `docs/superpowers/specs/2026-05-08-issue-79-restore-partition-design.md`
+- Plan: `docs/superpowers/plans/2026-05-08-issue-79-restore-partition-plan.md`
+- Encrypt loop (must stay inverse of decoder): `plane/workflow/billing/export_activity.go`
+- Decoder: `plane/workflow/billing/restore_decoder.go`

--- a/docs/superpowers/plans/2026-05-08-issue-79-restore-partition-plan.md
+++ b/docs/superpowers/plans/2026-05-08-issue-79-restore-partition-plan.md
@@ -1,0 +1,43 @@
+# Issue #79 RestorePartition workflow — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:subagent-driven-development.
+
+**Goal:** Implement `RestorePartitionWorkflow` (FetchManifest → VerifyChecksum → DownloadAndDecrypt → LoadIntoQuarantine), with a chunked-frame decoder that mirrors `ExportActivity`'s encrypt loop exactly. Restore writes to a quarantine table — never the live partition tree.
+
+**Spec:** `docs/superpowers/specs/2026-05-08-issue-79-restore-partition-design.md`
+
+**Branch:** `feat/workflow-restore-partition`
+
+---
+
+## File map
+
+### Create
+- `plane/workflow/billing/restore_workflow.go`
+- `plane/workflow/billing/restore_workflow_test.go`
+- `plane/workflow/billing/restore_decoder.go`
+- `plane/workflow/billing/restore_decoder_test.go`
+- `plane/workflow/billing/fetch_manifest_activity.go`
+- `plane/workflow/billing/verify_checksum_activity.go`
+- `plane/workflow/billing/download_decrypt_activity.go`
+- `plane/workflow/billing/load_quarantine_activity.go`
+- `plane/workflow/billing/restore_workflow_integration_test.go`
+- `docs/runbooks/billing-partition-restore.md`
+
+### Modify
+- `plane/workflow/billing/bundle.go` — `RestoreDeps` field; register workflow + activities
+- `cmd/workflow-worker/main.go` — wire RestoreDeps in env-gated archive block (introduced by #76)
+
+---
+
+## Tasks (compressed)
+
+1. **Decoder + tests:** unit-test the inverse of the encrypt loop. Use existing fixture from export tests (encrypt with stub key, then decode and compare plaintext).
+2. **Activities + tests:** each activity gets a unit test using stubs for `S3ObjectStore`, `KeyProvider`, and a Postgres pool stub.
+3. **Workflow + testsuite:** sequence the four activities; testsuite verifies happy + each failure mode (manifest missing, checksum mismatch, unsupported `enc_format`, COPY FROM error).
+4. **Bundle + worker wiring:** mirror #76's pattern.
+5. **Integration round-trip test:** archive then restore against PG + minio + Vault testcontainers; assert row sets match by `(id, ts)`.
+6. **Runbook:** document operator steps; flag the historical-key-version limitation explicitly.
+7. **Final gates:** test sweep, skills (`gitscale-temporal-determinism`, `gitscale-go-conventions`, `gitscale-plane-boundary`, `gitscale-adr-guard`), self-review battery, push, PR. Closes #79.
+
+(Each task in the worktree should follow TDD: failing test → minimal impl → passing test → commit. Frame decoder is the largest single piece; budget for ~half its time on round-trip validation.)

--- a/docs/superpowers/specs/2026-05-08-issue-79-restore-partition-design.md
+++ b/docs/superpowers/specs/2026-05-08-issue-79-restore-partition-design.md
@@ -1,0 +1,127 @@
+# Spec — Issue #79 RestorePartition workflow
+
+Date: 2026-05-08
+Issue: #79
+Plane: workflow
+Priority: p3 (Wave 2; deps #76)
+ADR-impact: conforming (ADR-018 §Restore path)
+
+## Goals
+
+1. Restore an archived monthly partition into a quarantine table for
+   dispute-investigation / audit-restore.
+2. Decode the `aes-256-gcm-v1-4mib` chunked frame format (inverse of
+   ExportActivity's encrypt loop) with AAD validation per chunk.
+3. Idempotent on `(year, month)` via Temporal workflow ID.
+4. Round-trip integration test: archive then restore; row sets match by
+   `(id, ts)`.
+
+## Non-goals
+
+- Re-attaching the restored partition to live `billing.usage_events`
+  (quarantine-only by design).
+- Restoring multiple months in a single workflow run.
+- Restoring archives with `enc_format != aes-256-gcm-v1-4mib` (reject and
+  log; no compatibility shim).
+
+## Architecture
+
+### Workflow
+
+`plane/workflow/billing/restore_workflow.go`:
+
+```go
+const RestorePartitionWorkflowName = "billing.RestorePartitionWorkflow"
+
+type RestoreInput struct {
+    Year  int
+    Month int
+}
+
+type RestoreResult struct {
+    QuarantineTable string
+    RowsImported    int64
+    DEKVersionUsed  int    // parsed from manifest.kek_hint
+}
+
+func RestorePartitionWorkflow(ctx workflow.Context, in RestoreInput) (RestoreResult, error)
+```
+
+Activity sequence (sequential):
+
+1. `FetchManifestActivity` — `S3ObjectStore.GetBytes(<base>.manifest.json)`
+2. `VerifyChecksumActivity` — recompute SHA-256 of `<base>.parquet`,
+   compare to `<base>.checksum.sha256`
+3. `DownloadAndDecryptActivity` — pull encrypted parquet, dispatch on
+   `manifest.enc_format`, decrypt chunked frames with AAD
+   `<source_partition>:<chunk_index>`, write plaintext parquet to scratch
+4. `LoadIntoQuarantineActivity` — `CREATE TABLE
+   billing.usage_events_restore_YYYY_MM (LIKE billing.usage_events
+   INCLUDING DEFAULTS); COPY FROM` plaintext parquet rows; mark table as
+   read-only via `REVOKE INSERT/UPDATE/DELETE`
+
+Compensation: scratch-file delete + quarantine-table-drop on workflow
+failure (registered as `defer activity.RegisterCompensation`).
+
+### Frame decoder
+
+In `plane/workflow/billing/restore_decoder.go`:
+
+```go
+type ChunkedDecoder struct {
+    DEK []byte // 32 bytes
+}
+
+// DecodeStream reads the encrypted chunked stream, validates AAD per
+// chunk against partitionName + chunk index, and writes plaintext to w.
+func (d *ChunkedDecoder) DecodeStream(r io.Reader, w io.Writer, partitionName string) error
+```
+
+Mirror exactly the encrypt loop in `export_activity.go`. Reject malformed
+chunks with `ErrFrameTampered`. Reject manifest formats other than
+`aes-256-gcm-v1-4mib` with `ErrUnsupportedEncFormat`.
+
+### KeyProvider integration
+
+`DownloadAndDecryptActivity` resolves the DEK via `KeyProvider.GetDEK(year,
+month)`. The returned `DEK.KEKHint` must equal `manifest.kek_hint`; if not,
+the worker is using a different Vault key version than was used to
+encrypt — the activity surfaces an error directing the operator to
+configure the historical key version (Vault transit retains versions on
+rotation; pass version explicitly via a future `KeyProviderVersioned`
+seam — out of scope for this PR; document in the runbook).
+
+### Bundle + worker wiring
+
+`Bundle.RestoreDeps` (new field) holds the four activities;
+`Bundle.Apply` registers `RestorePartitionWorkflow` and the four activities
+on `QueueBillingMaintenance`.
+
+`cmd/workflow-worker/main.go` constructs the deps in the same env-gated
+archive block (#76).
+
+### Integration test
+
+`plane/workflow/billing/restore_workflow_integration_test.go`
+(`//go:build integration`):
+
+- Boot PG + minio + Vault.
+- Run `PartitionArchiveWorkflow{Year:2024, Month:5}` to seed an archive.
+- Run `RestorePartitionWorkflow{Year:2024, Month:5}`.
+- Assert: `billing.usage_events_restore_2024_05` exists; row count matches
+  pre-archive seed; SELECT * ordered by `(id, ts)` from quarantine table
+  matches a snapshot taken before the archive ran.
+
+## Acceptance checklist
+
+- [ ] Workflow + 4 activities registered on QueueBillingMaintenance
+- [ ] `restore_decoder.go` is the inverse of `export_activity.go` encrypt loop
+- [ ] Round-trip integration test passes
+- [ ] Manual operator runbook in `docs/runbooks/billing-partition-restore.md`
+- [ ] PR description references ADR-018
+
+## References
+
+- ADR-018 §Restore path
+- Source format: `plane/workflow/billing/export_activity.go`
+- Spec parent: `docs/superpowers/specs/2026-05-07-issue-69-archive-workflow-design.md`

--- a/plane/data/store/billing/restorer.go
+++ b/plane/data/store/billing/restorer.go
@@ -1,0 +1,44 @@
+// plane/data/store/billing/restorer.go
+package billing
+
+import (
+	"context"
+	"fmt"
+	"io"
+)
+
+// Restorer is the data-layer interface for the partition-restore workflow.
+// All writes are confined to the billing.usage_events_restore_YYYY_MM
+// quarantine namespace — the live partition tree (billing.usage_events and
+// its attached children) is strictly read-only from the restore plane.
+//
+// ADR-019 amendment: workflow plane importing data plane is permitted for
+// read paths and quarantine-table DDL only. Live-partition writes remain
+// the application plane's responsibility.
+type Restorer interface {
+	// EnsureQuarantineTable creates billing.usage_events_restore_YYYY_MM as
+	// a standalone (non-partitioned, non-attached) clone of the
+	// billing.usage_events column set. Idempotent.
+	EnsureQuarantineTable(ctx context.Context, year, month int) (table string, err error)
+
+	// LoadParquetIntoQuarantine streams plaintext Parquet rows from r into
+	// the quarantine table created by EnsureQuarantineTable. Returns the
+	// number of rows loaded.
+	LoadParquetIntoQuarantine(ctx context.Context, year, month int, r io.Reader) (rows int64, err error)
+
+	// SealQuarantineTable revokes INSERT/UPDATE/DELETE on the table from
+	// the application role, leaving SELECT only — the table is read-only by
+	// design (audit / dispute investigation, not live billing).
+	SealQuarantineTable(ctx context.Context, year, month int) error
+
+	// DropQuarantineTable removes the quarantine table on workflow failure
+	// for cleanup. Idempotent (DROP TABLE IF EXISTS).
+	DropQuarantineTable(ctx context.Context, year, month int) error
+}
+
+// QuarantineTableName returns the canonical quarantine table identifier for
+// (year, month). Exported so callers (including activity errors and runbook
+// references) share one source of truth.
+func QuarantineTableName(year, month int) string {
+	return fmt.Sprintf("billing.usage_events_restore_%04d_%02d", year, month)
+}

--- a/plane/data/store/billing/restorer_postgres.go
+++ b/plane/data/store/billing/restorer_postgres.go
@@ -1,0 +1,144 @@
+// plane/data/store/billing/restorer_postgres.go
+package billing
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/parquet-go/parquet-go"
+)
+
+// PostgresRestorer is the production Restorer backed by pgxpool. It only ever
+// touches the quarantine namespace (billing.usage_events_restore_YYYY_MM);
+// live-partition writes are out of scope by ADR-019.
+type PostgresRestorer struct {
+	pool *pgxpool.Pool
+}
+
+// NewPostgresRestorer returns a PostgresRestorer. The pool is not owned by
+// this struct; the caller is responsible for closing it.
+func NewPostgresRestorer(pool *pgxpool.Pool) *PostgresRestorer {
+	return &PostgresRestorer{pool: pool}
+}
+
+// EnsureQuarantineTable creates billing.usage_events_restore_YYYY_MM if it
+// does not already exist, cloning the column set + defaults from
+// billing.usage_events. The table is intentionally not attached as a
+// partition — it lives outside the partition tree.
+func (r *PostgresRestorer) EnsureQuarantineTable(ctx context.Context, year, month int) (string, error) {
+	if year < 2026 || year > 2099 {
+		return "", fmt.Errorf("restorer: year %d out of range", year)
+	}
+	if month < 1 || month > 12 {
+		return "", fmt.Errorf("restorer: month %d out of range", month)
+	}
+	table := fmt.Sprintf("usage_events_restore_%04d_%02d", year, month)
+	ddl := fmt.Sprintf(
+		"CREATE TABLE IF NOT EXISTS billing.%s "+
+			"(LIKE billing.usage_events INCLUDING DEFAULTS)",
+		table,
+	)
+	if _, err := r.pool.Exec(ctx, ddl); err != nil {
+		return "", fmt.Errorf("restorer: create quarantine %s: %w", table, err)
+	}
+	return "billing." + table, nil
+}
+
+// LoadParquetIntoQuarantine reads plaintext Parquet rows from src and inserts
+// them into the quarantine table via pgx CopyFrom. Returns the total row
+// count. The workflow seals the quarantine table after this completes.
+//
+// Implementation note: parquet-go requires io.ReaderAt + size, so the
+// plaintext is buffered to memory. Monthly partitions land in the GB-low-tens
+// range at most; activity heap budget is sized to absorb that. If a future
+// month exceeds the budget, switch to a temp file (the activity scratch dir
+// is ephemeral per worker).
+func (r *PostgresRestorer) LoadParquetIntoQuarantine(ctx context.Context, year, month int, src io.Reader) (int64, error) {
+	table := fmt.Sprintf("usage_events_restore_%04d_%02d", year, month)
+
+	plaintext, err := io.ReadAll(src)
+	if err != nil {
+		return 0, fmt.Errorf("restorer: read parquet: %w", err)
+	}
+
+	pr := parquet.NewGenericReader[UsageEventRow](bytes.NewReader(plaintext))
+	defer func() { _ = pr.Close() }()
+
+	var rows []UsageEventRow
+	batch := make([]UsageEventRow, 1024)
+	for {
+		n, err := pr.Read(batch)
+		if n > 0 {
+			rows = append(rows, batch[:n]...)
+		}
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return 0, fmt.Errorf("restorer: parquet read: %w", err)
+		}
+	}
+
+	copyCount, err := r.pool.CopyFrom(ctx,
+		pgx.Identifier{"billing", table},
+		[]string{
+			"id", "account_id", "principal_id", "principal_type",
+			"surface", "cost_vector", "value", "repo_id",
+			"event_source", "external_event_id", "ts", "created_at",
+		},
+		&pgxCopyFromSource{rows: rows},
+	)
+	if err != nil {
+		return 0, fmt.Errorf("restorer: copy into %s: %w", table, err)
+	}
+	return copyCount, nil
+}
+
+// SealQuarantineTable revokes write privileges so the table is SELECT-only.
+// Spec: dispute / audit-restore consumers read; nobody writes after load.
+func (r *PostgresRestorer) SealQuarantineTable(ctx context.Context, year, month int) error {
+	table := fmt.Sprintf("usage_events_restore_%04d_%02d", year, month)
+	stmt := fmt.Sprintf(
+		"REVOKE INSERT, UPDATE, DELETE, TRUNCATE ON billing.%s FROM PUBLIC",
+		table,
+	)
+	if _, err := r.pool.Exec(ctx, stmt); err != nil {
+		return fmt.Errorf("restorer: seal %s: %w", table, err)
+	}
+	return nil
+}
+
+// DropQuarantineTable removes the quarantine table — used as compensation
+// when the workflow fails after EnsureQuarantineTable succeeded.
+func (r *PostgresRestorer) DropQuarantineTable(ctx context.Context, year, month int) error {
+	table := fmt.Sprintf("usage_events_restore_%04d_%02d", year, month)
+	stmt := fmt.Sprintf("DROP TABLE IF EXISTS billing.%s", table)
+	if _, err := r.pool.Exec(ctx, stmt); err != nil {
+		return fmt.Errorf("restorer: drop %s: %w", table, err)
+	}
+	return nil
+}
+
+// pgxCopyFromSource adapts a UsageEventRow slice to pgx.CopyFromSource.
+// Column order must mirror the list passed to CopyFrom in
+// LoadParquetIntoQuarantine.
+type pgxCopyFromSource struct {
+	rows []UsageEventRow
+	pos  int
+}
+
+func (c *pgxCopyFromSource) Next() bool { return c.pos < len(c.rows) }
+func (c *pgxCopyFromSource) Values() ([]any, error) {
+	r := c.rows[c.pos]
+	c.pos++
+	return []any{
+		r.ID, r.AccountID, r.PrincipalID, r.PrincipalType,
+		r.Surface, r.CostVector, r.Value, r.RepoID,
+		r.EventSource, r.ExternalEventID, r.Ts, r.CreatedAt,
+	}, nil
+}
+func (c *pgxCopyFromSource) Err() error { return nil }

--- a/plane/data/store/billing/restorer_stub.go
+++ b/plane/data/store/billing/restorer_stub.go
@@ -1,0 +1,131 @@
+// plane/data/store/billing/restorer_stub.go
+package billing
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"sync"
+)
+
+// StubRestorer is an in-memory Restorer for activity unit tests. It records
+// each call so tests can assert order without touching Postgres.
+type StubRestorer struct {
+	mu             sync.Mutex
+	created        map[string]bool
+	sealed         map[string]bool
+	dropped        map[string]bool
+	loadedRows     map[string]int64
+	rowReader      func(year, month int, r io.Reader) (int64, error)
+	EnsureFn       func(year, month int) error
+	LoadFn         func(year, month int, r io.Reader) (int64, error)
+	SealFn         func(year, month int) error
+	DropFn         func(year, month int) error
+}
+
+// NewStubRestorer returns a StubRestorer with empty state.
+func NewStubRestorer() *StubRestorer {
+	return &StubRestorer{
+		created:    map[string]bool{},
+		sealed:     map[string]bool{},
+		dropped:    map[string]bool{},
+		loadedRows: map[string]int64{},
+	}
+}
+
+// SetRowReader installs a function that reads `r` and reports rowcount.
+// Tests use this to verify decoded plaintext (e.g. assert known length).
+func (s *StubRestorer) SetRowReader(fn func(year, month int, r io.Reader) (int64, error)) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.rowReader = fn
+}
+
+func (s *StubRestorer) EnsureQuarantineTable(_ context.Context, year, month int) (string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.EnsureFn != nil {
+		if err := s.EnsureFn(year, month); err != nil {
+			return "", err
+		}
+	}
+	s.created[partitionKey(year, month)] = true
+	return QuarantineTableName(year, month), nil
+}
+
+func (s *StubRestorer) LoadParquetIntoQuarantine(_ context.Context, year, month int, r io.Reader) (int64, error) {
+	if s.LoadFn != nil {
+		return s.LoadFn(year, month, r)
+	}
+	s.mu.Lock()
+	rowReader := s.rowReader
+	s.mu.Unlock()
+	if rowReader != nil {
+		n, err := rowReader(year, month, r)
+		if err != nil {
+			return 0, err
+		}
+		s.mu.Lock()
+		s.loadedRows[partitionKey(year, month)] = n
+		s.mu.Unlock()
+		return n, nil
+	}
+	// Default: drain and count zero rows.
+	if _, err := io.Copy(io.Discard, r); err != nil {
+		return 0, fmt.Errorf("stub restorer: drain: %w", err)
+	}
+	return 0, nil
+}
+
+func (s *StubRestorer) SealQuarantineTable(_ context.Context, year, month int) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.SealFn != nil {
+		if err := s.SealFn(year, month); err != nil {
+			return err
+		}
+	}
+	s.sealed[partitionKey(year, month)] = true
+	return nil
+}
+
+func (s *StubRestorer) DropQuarantineTable(_ context.Context, year, month int) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.DropFn != nil {
+		if err := s.DropFn(year, month); err != nil {
+			return err
+		}
+	}
+	s.dropped[partitionKey(year, month)] = true
+	return nil
+}
+
+// IsCreated reports whether EnsureQuarantineTable was called.
+func (s *StubRestorer) IsCreated(year, month int) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.created[partitionKey(year, month)]
+}
+
+// IsSealed reports whether SealQuarantineTable was called.
+func (s *StubRestorer) IsSealed(year, month int) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.sealed[partitionKey(year, month)]
+}
+
+// IsDropped reports whether DropQuarantineTable was called.
+func (s *StubRestorer) IsDropped(year, month int) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.dropped[partitionKey(year, month)]
+}
+
+// LoadedRows returns the row count recorded for (year, month) after
+// LoadParquetIntoQuarantine.
+func (s *StubRestorer) LoadedRows(year, month int) int64 {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.loadedRows[partitionKey(year, month)]
+}

--- a/plane/workflow/billing/bundle.go
+++ b/plane/workflow/billing/bundle.go
@@ -16,10 +16,25 @@ type ArchiveDeps struct {
 	Drop         *DropPartitionActivity
 }
 
+// RestoreDeps holds the dependencies injected into the restore activities.
+// Constructed in cmd/workflow-worker and passed to Bundle. Pass nil to skip
+// restore workflow + activity registration. Restore deps are independent of
+// ArchiveDeps so a worker pool can be sized for read-heavy restore traffic
+// without enabling archive scheduling.
+type RestoreDeps struct {
+	FetchManifest    *FetchManifestActivity
+	VerifyChecksum   *VerifyChecksumActivity
+	DownloadDecrypt  *DownloadAndDecryptActivity
+	LoadQuarantine   *LoadIntoQuarantineActivity
+	DropQuarantine   *DropQuarantineActivity
+}
+
 // Bundle returns the registration set for the billing-maintenance task queue.
 // Hosts the partition-rollover workflow (#18-rollover) and, when archive is
-// non-nil, the partition-archive workflow (#69) plus its activities.
-func Bundle(rollover *CreatePartitionActivity, archive *ArchiveDeps) gswf.Bundle {
+// non-nil, the partition-archive workflow (#69) plus its activities; when
+// restore is non-nil, the partition-restore workflow (#79) plus its
+// activities.
+func Bundle(rollover *CreatePartitionActivity, archive *ArchiveDeps, restore *RestoreDeps) gswf.Bundle {
 	wfs := []any{PartitionRolloverWorkflow}
 	acts := []any{
 		gswf.NamedActivity{Name: ActivityNameCreatePartition, Activity: rollover.Execute},
@@ -32,6 +47,16 @@ func Bundle(rollover *CreatePartitionActivity, archive *ArchiveDeps) gswf.Bundle
 			gswf.NamedActivity{Name: ActivityNameEmitArchiveEvent, Activity: archive.Emit.Execute},
 			gswf.NamedActivity{Name: ActivityNameGlueRegister, Activity: archive.GlueRegister.Execute},
 			gswf.NamedActivity{Name: ActivityNameDropPartition, Activity: archive.Drop.Execute},
+		)
+	}
+	if restore != nil {
+		wfs = append(wfs, RestorePartitionWorkflow)
+		acts = append(acts,
+			gswf.NamedActivity{Name: ActivityNameFetchManifest, Activity: restore.FetchManifest.Execute},
+			gswf.NamedActivity{Name: ActivityNameVerifyChecksum, Activity: restore.VerifyChecksum.Execute},
+			gswf.NamedActivity{Name: ActivityNameDownloadDecrypt, Activity: restore.DownloadDecrypt.Execute},
+			gswf.NamedActivity{Name: ActivityNameLoadQuarantine, Activity: restore.LoadQuarantine.Execute},
+			gswf.NamedActivity{Name: ActivityNameDropQuarantine, Activity: restore.DropQuarantine.Execute},
 		)
 	}
 	return gswf.Bundle{

--- a/plane/workflow/billing/download_decrypt_activity.go
+++ b/plane/workflow/billing/download_decrypt_activity.go
@@ -1,0 +1,155 @@
+package billing
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"go.temporal.io/sdk/activity"
+	"go.temporal.io/sdk/temporal"
+)
+
+// ActivityNameDownloadDecrypt is the registered name for DownloadAndDecryptActivity.
+const ActivityNameDownloadDecrypt = "billing.DownloadAndDecrypt"
+
+// DownloadDecryptInput is the input to DownloadAndDecryptActivity.Execute.
+type DownloadDecryptInput struct {
+	Year            int
+	Month           int
+	ParquetKey      string
+	SourcePartition string // mirrors manifest.source_partition (used as AAD prefix)
+	EncFormat       string // mirrors manifest.enc_format — must equal encFormatV1
+	KEKHint         string // mirrors manifest.kek_hint — must equal DEK.KEKHint
+}
+
+// DownloadDecryptResult points the next activity at the plaintext parquet on
+// the worker's scratch volume. The path is intentionally per-attempt: the
+// activity is registered with a non-zero start-to-close timeout and the
+// caller is responsible for cleanup on workflow failure.
+type DownloadDecryptResult struct {
+	PlaintextPath string
+}
+
+// DownloadAndDecryptActivity streams the encrypted parquet through the
+// chunked-frame decoder under the DEK derived for (year, month), writing
+// plaintext to a worker-local scratch file. The same activity-host runs the
+// LoadIntoQuarantine activity that consumes the file (Temporal task-queue
+// affinity holds inside a single workflow run for this stage; if affinity is
+// later relaxed, switch the artifact to an object-store handoff).
+type DownloadAndDecryptActivity struct {
+	store      ObjectStore
+	keys       KeyProvider
+	scratchDir string
+}
+
+// NewDownloadAndDecryptActivity returns a DownloadAndDecryptActivity.
+// scratchDir defaults to os.TempDir() when empty.
+func NewDownloadAndDecryptActivity(store ObjectStore, keys KeyProvider, scratchDir string) (*DownloadAndDecryptActivity, error) {
+	if store == nil {
+		return nil, errors.New("billing.NewDownloadAndDecryptActivity: store is nil")
+	}
+	if keys == nil {
+		return nil, errors.New("billing.NewDownloadAndDecryptActivity: keys is nil")
+	}
+	if scratchDir == "" {
+		scratchDir = os.TempDir()
+	}
+	return &DownloadAndDecryptActivity{store: store, keys: keys, scratchDir: scratchDir}, nil
+}
+
+// Execute resolves the DEK, validates the manifest's enc_format + kek_hint,
+// streams the encrypted parquet through ChunkedDecoder, and writes the
+// plaintext to a scratch file. Returns the scratch path so LoadIntoQuarantine
+// can stream from it.
+func (a *DownloadAndDecryptActivity) Execute(ctx context.Context, in DownloadDecryptInput) (DownloadDecryptResult, error) {
+	if in.EncFormat != encFormatV1 {
+		return DownloadDecryptResult{}, temporal.NewNonRetryableApplicationError(
+			fmt.Sprintf("%v: %q (worker only reads %q)", ErrUnsupportedEncFormat, in.EncFormat, encFormatV1),
+			"ErrUnsupportedEncFormat",
+			ErrUnsupportedEncFormat,
+		)
+	}
+
+	dek, err := a.keys.GetDEK(ctx, in.Year, in.Month)
+	if err != nil {
+		return DownloadDecryptResult{}, fmt.Errorf("download+decrypt: get dek: %w", err)
+	}
+	defer func() {
+		for i := range dek.Bytes {
+			dek.Bytes[i] = 0
+		}
+	}()
+	if dek.KEKHint != in.KEKHint {
+		return DownloadDecryptResult{}, fmt.Errorf(
+			"download+decrypt: kek_hint mismatch — manifest=%q worker=%q "+
+				"(operator must pin the historical key version; see runbook)",
+			in.KEKHint, dek.KEKHint,
+		)
+	}
+
+	body, err := a.store.Download(ctx, in.ParquetKey)
+	if err != nil {
+		return DownloadDecryptResult{}, fmt.Errorf("download+decrypt: download: %w", err)
+	}
+	defer func() { _ = body.Close() }()
+
+	plaintextName := fmt.Sprintf("usage_events_%04d_%02d_restore.parquet", in.Year, in.Month)
+	plaintextPath := filepath.Join(a.scratchDir, plaintextName)
+	out, err := os.Create(plaintextPath)
+	if err != nil {
+		return DownloadDecryptResult{}, fmt.Errorf("download+decrypt: open scratch %s: %w", plaintextPath, err)
+	}
+	closeErr := out.Close
+	defer func() {
+		if closeErr != nil {
+			_ = closeErr()
+		}
+	}()
+
+	hb := &heartbeatWriter{ctx: ctx, dst: out, every: 4 << 20}
+	dec := &ChunkedDecoder{DEK: dek.Bytes}
+	if err := dec.DecodeStream(body, hb, in.SourcePartition); err != nil {
+		_ = out.Close()
+		closeErr = nil
+		_ = os.Remove(plaintextPath)
+		if errors.Is(err, ErrFrameTampered) {
+			return DownloadDecryptResult{}, temporal.NewNonRetryableApplicationError(
+				fmt.Sprintf("download+decrypt: decode: %v", err),
+				"ErrFrameTampered", err,
+			)
+		}
+		return DownloadDecryptResult{}, fmt.Errorf("download+decrypt: decode: %w", err)
+	}
+	if err := out.Close(); err != nil {
+		closeErr = nil
+		_ = os.Remove(plaintextPath)
+		return DownloadDecryptResult{}, fmt.Errorf("download+decrypt: close scratch: %w", err)
+	}
+	closeErr = nil
+	return DownloadDecryptResult{PlaintextPath: plaintextPath}, nil
+}
+
+// heartbeatWriter wraps an io.Writer and emits a Temporal heartbeat every
+// `every` bytes written. Restore parquet streams are bounded by ExportActivity
+// output (≈GB-scale max), so a 4 MiB cadence keeps the worker responsive
+// without hammering the heartbeat path.
+type heartbeatWriter struct {
+	ctx     context.Context
+	dst     interface{ Write(p []byte) (int, error) }
+	every   int64
+	written int64
+	since   int64
+}
+
+func (h *heartbeatWriter) Write(p []byte) (int, error) {
+	n, err := h.dst.Write(p)
+	h.written += int64(n)
+	h.since += int64(n)
+	if h.since >= h.every {
+		activity.RecordHeartbeat(h.ctx, h.written)
+		h.since = 0
+	}
+	return n, err
+}

--- a/plane/workflow/billing/fetch_manifest_activity.go
+++ b/plane/workflow/billing/fetch_manifest_activity.go
@@ -1,0 +1,115 @@
+package billing
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"go.temporal.io/sdk/temporal"
+)
+
+// ActivityNameFetchManifest is the registered name for FetchManifestActivity.
+const ActivityNameFetchManifest = "billing.FetchManifest"
+
+// FetchManifestInput is the input to FetchManifestActivity.Execute.
+type FetchManifestInput struct {
+	Year  int
+	Month int
+}
+
+// FetchManifestResult exposes the parsed manifest fields the workflow needs to
+// validate and dispatch the rest of the restore pipeline. The full archived
+// manifest type stays internal — this is the workflow's view of it.
+type FetchManifestResult struct {
+	SourcePartition string
+	RowCount        int64
+	BytesWritten    int64
+	KEKHint         string
+	EncFormat       string
+	ChecksumAlg     string
+	ParquetKey      string
+	ChecksumKey     string
+}
+
+// FetchManifestActivity reads the .manifest.json sidecar for the archived
+// (year, month) partition and parses it. Manifest absence surfaces as a
+// non-retryable ErrObjectNotFound — operators must verify the archive exists
+// before re-running the workflow.
+type FetchManifestActivity struct {
+	store ObjectStore
+}
+
+// NewFetchManifestActivity returns a FetchManifestActivity.
+func NewFetchManifestActivity(store ObjectStore) (*FetchManifestActivity, error) {
+	if store == nil {
+		return nil, errors.New("billing.NewFetchManifestActivity: store is nil")
+	}
+	return &FetchManifestActivity{store: store}, nil
+}
+
+// Execute fetches and parses the manifest. Format dispatch (rejecting unknown
+// enc_format) is the workflow's responsibility — keep this activity focused
+// on I/O so it can be retried on transient S3 errors.
+func (a *FetchManifestActivity) Execute(ctx context.Context, in FetchManifestInput) (FetchManifestResult, error) {
+	parquetKey := archivedParquetKey(in.Year, in.Month)
+	manifestKey := archivedSidecarKey(in.Year, in.Month, ".manifest.json")
+	checksumKey := archivedSidecarKey(in.Year, in.Month, ".checksum.sha256")
+
+	raw, err := a.store.GetBytes(ctx, manifestKey)
+	if err != nil {
+		if errors.Is(err, ErrObjectNotFound) {
+			return FetchManifestResult{}, temporal.NewNonRetryableApplicationError(
+				fmt.Sprintf("fetch manifest: %v", err),
+				"ErrObjectNotFound", err,
+			)
+		}
+		return FetchManifestResult{}, fmt.Errorf("fetch manifest: %w", err)
+	}
+	var m archiveManifest
+	if err := json.Unmarshal(raw, &m); err != nil {
+		return FetchManifestResult{}, fmt.Errorf("fetch manifest: parse %s: %w", manifestKey, err)
+	}
+	expected := fmt.Sprintf("billing.usage_events_%04d_%02d", in.Year, in.Month)
+	if m.SourcePartition != expected {
+		return FetchManifestResult{}, fmt.Errorf(
+			"fetch manifest: source_partition=%q want %q (manifest does not match requested partition)",
+			m.SourcePartition, expected,
+		)
+	}
+	if m.SchemaVersion != 1 {
+		return FetchManifestResult{}, fmt.Errorf(
+			"fetch manifest: schema_version=%d unsupported (this worker reads only v1)",
+			m.SchemaVersion,
+		)
+	}
+	return FetchManifestResult{
+		SourcePartition: m.SourcePartition,
+		RowCount:        m.RowCount,
+		BytesWritten:    m.BytesWritten,
+		KEKHint:         m.KEKHint,
+		EncFormat:       m.EncFormat,
+		ChecksumAlg:     m.ChecksumAlg,
+		ParquetKey:      parquetKey,
+		ChecksumKey:     checksumKey,
+	}, nil
+}
+
+// archivedParquetKey is the canonical encrypted parquet key for (year, month).
+// Mirror of the layout in export_activity.go — keeping a single helper avoids
+// drift between encode and decode sides.
+func archivedParquetKey(year, month int) string {
+	return fmt.Sprintf(
+		"billing/usage_events/year=%04d/month=%02d/usage_events_%04d_%02d.parquet",
+		year, month, year, month,
+	)
+}
+
+// archivedSidecarKey returns the sidecar key (manifest, checksum) alongside
+// the parquet object.
+func archivedSidecarKey(year, month int, suffix string) string {
+	return fmt.Sprintf(
+		"billing/usage_events/year=%04d/month=%02d/usage_events_%04d_%02d%s",
+		year, month, year, month, suffix,
+	)
+}

--- a/plane/workflow/billing/load_quarantine_activity.go
+++ b/plane/workflow/billing/load_quarantine_activity.go
@@ -1,0 +1,99 @@
+package billing
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+
+	billingstore "github.com/gitscale-platform/gitscale/plane/data/store/billing"
+)
+
+// ActivityNameLoadQuarantine is the registered name for LoadIntoQuarantineActivity.
+const ActivityNameLoadQuarantine = "billing.LoadIntoQuarantine"
+
+// LoadQuarantineInput is the input to LoadIntoQuarantineActivity.Execute.
+type LoadQuarantineInput struct {
+	Year          int
+	Month         int
+	PlaintextPath string
+}
+
+// LoadQuarantineResult records the table name and row count loaded.
+type LoadQuarantineResult struct {
+	QuarantineTable string
+	RowsImported    int64
+}
+
+// LoadIntoQuarantineActivity creates the quarantine table, COPYs plaintext
+// rows in, then revokes write privileges. The activity also removes the
+// scratch file on success — on failure the workflow's drop-quarantine
+// compensation handles cleanup.
+type LoadIntoQuarantineActivity struct {
+	restorer billingstore.Restorer
+}
+
+// NewLoadIntoQuarantineActivity returns a LoadIntoQuarantineActivity.
+func NewLoadIntoQuarantineActivity(restorer billingstore.Restorer) (*LoadIntoQuarantineActivity, error) {
+	if restorer == nil {
+		return nil, errors.New("billing.NewLoadIntoQuarantineActivity: restorer is nil")
+	}
+	return &LoadIntoQuarantineActivity{restorer: restorer}, nil
+}
+
+// Execute runs Ensure → Load → Seal in sequence. Any error before Seal leaves
+// the workflow to invoke a drop-quarantine compensation activity.
+func (a *LoadIntoQuarantineActivity) Execute(ctx context.Context, in LoadQuarantineInput) (LoadQuarantineResult, error) {
+	table, err := a.restorer.EnsureQuarantineTable(ctx, in.Year, in.Month)
+	if err != nil {
+		return LoadQuarantineResult{}, fmt.Errorf("load quarantine: ensure: %w", err)
+	}
+
+	f, err := os.Open(in.PlaintextPath)
+	if err != nil {
+		return LoadQuarantineResult{}, fmt.Errorf("load quarantine: open scratch %s: %w", in.PlaintextPath, err)
+	}
+	rows, copyErr := a.restorer.LoadParquetIntoQuarantine(ctx, in.Year, in.Month, f)
+	_ = f.Close()
+	if copyErr != nil {
+		return LoadQuarantineResult{}, fmt.Errorf("load quarantine: copy: %w", copyErr)
+	}
+
+	if err := a.restorer.SealQuarantineTable(ctx, in.Year, in.Month); err != nil {
+		return LoadQuarantineResult{}, fmt.Errorf("load quarantine: seal: %w", err)
+	}
+
+	// Best-effort scratch cleanup. A leftover file is harmless for correctness.
+	_ = os.Remove(in.PlaintextPath)
+
+	return LoadQuarantineResult{QuarantineTable: table, RowsImported: rows}, nil
+}
+
+// ActivityNameDropQuarantine is the registered name for the compensation
+// activity invoked by the workflow on failure.
+const ActivityNameDropQuarantine = "billing.DropQuarantine"
+
+// DropQuarantineInput identifies the quarantine table to drop.
+type DropQuarantineInput struct {
+	Year  int
+	Month int
+}
+
+// DropQuarantineActivity removes the quarantine table on workflow failure.
+// Idempotent (DROP TABLE IF EXISTS).
+type DropQuarantineActivity struct {
+	restorer billingstore.Restorer
+}
+
+// NewDropQuarantineActivity returns a DropQuarantineActivity.
+func NewDropQuarantineActivity(restorer billingstore.Restorer) (*DropQuarantineActivity, error) {
+	if restorer == nil {
+		return nil, errors.New("billing.NewDropQuarantineActivity: restorer is nil")
+	}
+	return &DropQuarantineActivity{restorer: restorer}, nil
+}
+
+// Execute drops the quarantine table.
+func (a *DropQuarantineActivity) Execute(ctx context.Context, in DropQuarantineInput) error {
+	return a.restorer.DropQuarantineTable(ctx, in.Year, in.Month)
+}

--- a/plane/workflow/billing/objectstore.go
+++ b/plane/workflow/billing/objectstore.go
@@ -1,15 +1,18 @@
 package billing
 
 import (
+	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"sync"
 )
 
-// ObjectStore is a provider-agnostic interface for writing archive objects.
-// Implementations cover AWS S3, minio, Cloudflare R2, and GCS S3-interop mode
-// by pointing the S3-compatible client at the appropriate endpoint.
+// ObjectStore is a provider-agnostic interface for reading and writing archive
+// objects. Implementations cover AWS S3, minio, Cloudflare R2, and GCS
+// S3-interop mode by pointing the S3-compatible client at the appropriate
+// endpoint.
 type ObjectStore interface {
 	// Upload streams r to key. The implementation handles multipart upload
 	// internally for large objects. sizeHint is -1 when unknown.
@@ -18,7 +21,20 @@ type ObjectStore interface {
 
 	// PutBytes writes a small object (manifest JSON, checksum file).
 	PutBytes(ctx context.Context, key string, data []byte) error
+
+	// GetBytes reads a small object in full (manifest, checksum). Errors with
+	// ErrObjectNotFound (or wraps it) when the object is absent.
+	GetBytes(ctx context.Context, key string) ([]byte, error)
+
+	// Download returns a streaming reader over key for large blobs. The caller
+	// must Close the returned reader.
+	Download(ctx context.Context, key string) (io.ReadCloser, error)
 }
+
+// ErrObjectNotFound is returned (or wrapped) by ObjectStore.GetBytes /
+// Download when the requested key is absent. Restore activities surface this
+// as a non-retryable manifest-missing error.
+var ErrObjectNotFound = errors.New("object store: not found")
 
 // stubObjectStore captures uploaded objects in memory. Used by activity unit tests.
 type stubObjectStore struct {
@@ -70,4 +86,32 @@ func (s *stubObjectStore) Get(key string) []byte {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return s.objects[key]
+}
+
+// Set seeds the stub with bytes at key (used to drive restore-activity unit
+// tests without first running a full export).
+func (s *stubObjectStore) Set(key string, data []byte) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.objects[key] = append([]byte(nil), data...)
+}
+
+func (s *stubObjectStore) GetBytes(_ context.Context, key string) ([]byte, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	data, ok := s.objects[key]
+	if !ok {
+		return nil, fmt.Errorf("%w: %s", ErrObjectNotFound, key)
+	}
+	return append([]byte(nil), data...), nil
+}
+
+func (s *stubObjectStore) Download(_ context.Context, key string) (io.ReadCloser, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	data, ok := s.objects[key]
+	if !ok {
+		return nil, fmt.Errorf("%w: %s", ErrObjectNotFound, key)
+	}
+	return io.NopCloser(bytes.NewReader(append([]byte(nil), data...))), nil
 }

--- a/plane/workflow/billing/objectstore_s3.go
+++ b/plane/workflow/billing/objectstore_s3.go
@@ -3,12 +3,14 @@ package billing
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/feature/s3/transfermanager"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
+	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
 )
 
 // s3UploadPartSize is the multipart part size used by the transfermanager
@@ -60,6 +62,46 @@ func (s *S3ObjectStore) Upload(ctx context.Context, key string, r io.Reader, siz
 		return "", fmt.Errorf("s3: upload %s: %w", key, err)
 	}
 	return fmt.Sprintf("s3://%s/%s", s.bucket, key), nil
+}
+
+// GetBytes fetches a small object in full via GetObject, mapping NoSuchKey to
+// ErrObjectNotFound for non-retryable manifest-missing handling in restore.
+func (s *S3ObjectStore) GetBytes(ctx context.Context, key string) ([]byte, error) {
+	out, err := s.client.GetObject(ctx, &s3.GetObjectInput{
+		Bucket: aws.String(s.bucket),
+		Key:    aws.String(key),
+	})
+	if err != nil {
+		var nsk *s3types.NoSuchKey
+		if errors.As(err, &nsk) {
+			return nil, fmt.Errorf("%w: %s", ErrObjectNotFound, key)
+		}
+		return nil, fmt.Errorf("s3: get %s: %w", key, err)
+	}
+	defer func() { _ = out.Body.Close() }()
+	data, err := io.ReadAll(out.Body)
+	if err != nil {
+		return nil, fmt.Errorf("s3: read %s: %w", key, err)
+	}
+	return data, nil
+}
+
+// Download streams an object via GetObject. The caller is responsible for
+// closing the returned reader; large encrypted parquet streams are consumed
+// chunk-by-chunk by the chunked-frame decoder.
+func (s *S3ObjectStore) Download(ctx context.Context, key string) (io.ReadCloser, error) {
+	out, err := s.client.GetObject(ctx, &s3.GetObjectInput{
+		Bucket: aws.String(s.bucket),
+		Key:    aws.String(key),
+	})
+	if err != nil {
+		var nsk *s3types.NoSuchKey
+		if errors.As(err, &nsk) {
+			return nil, fmt.Errorf("%w: %s", ErrObjectNotFound, key)
+		}
+		return nil, fmt.Errorf("s3: get %s: %w", key, err)
+	}
+	return out.Body, nil
 }
 
 // PutBytes writes a small, in-memory object (manifest JSON, checksum file)

--- a/plane/workflow/billing/restore_activities_test.go
+++ b/plane/workflow/billing/restore_activities_test.go
@@ -1,0 +1,279 @@
+package billing
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	billingstore "github.com/gitscale-platform/gitscale/plane/data/store/billing"
+)
+
+// fixedKeyProvider is a KeyProvider that returns a constant DEK + KEK hint —
+// used by the restore-side unit tests to drive the kek_hint mismatch path.
+type fixedKeyProvider struct {
+	dek     []byte
+	kekHint string
+	err     error
+}
+
+func (f fixedKeyProvider) GetDEK(_ context.Context, _, _ int) (DEK, error) {
+	if f.err != nil {
+		return DEK{}, f.err
+	}
+	return DEK{Bytes: append([]byte(nil), f.dek...), KEKHint: f.kekHint}, nil
+}
+
+func TestFetchManifestActivity_happyPath(t *testing.T) {
+	store := newStubObjectStore("b")
+	m := archiveManifest{
+		SchemaVersion:   1,
+		SourcePartition: "billing.usage_events_2026_05",
+		RowCount:        7,
+		BytesWritten:    1024,
+		KEKHint:         "platform-billing-v1",
+		EncFormat:       encFormatV1,
+		ChecksumAlg:     "sha256",
+	}
+	store.Set(archivedSidecarKey(2026, 5, ".manifest.json"), jsonMarshalManifest(m))
+
+	act, err := NewFetchManifestActivity(store)
+	if err != nil {
+		t.Fatal(err)
+	}
+	out, err := act.Execute(context.Background(), FetchManifestInput{Year: 2026, Month: 5})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if out.SourcePartition != m.SourcePartition || out.RowCount != 7 || out.EncFormat != encFormatV1 {
+		t.Errorf("unexpected result %+v", out)
+	}
+	if out.ParquetKey == "" || out.ChecksumKey == "" {
+		t.Error("missing key fields")
+	}
+}
+
+func TestFetchManifestActivity_rejectsWrongSourcePartition(t *testing.T) {
+	store := newStubObjectStore("b")
+	m := archiveManifest{
+		SchemaVersion:   1,
+		SourcePartition: "billing.usage_events_2026_06",
+		EncFormat:       encFormatV1,
+	}
+	store.Set(archivedSidecarKey(2026, 5, ".manifest.json"), jsonMarshalManifest(m))
+
+	act, _ := NewFetchManifestActivity(store)
+	_, err := act.Execute(context.Background(), FetchManifestInput{Year: 2026, Month: 5})
+	if err == nil || !strings.Contains(err.Error(), "source_partition") {
+		t.Errorf("err=%v want source_partition mismatch", err)
+	}
+}
+
+func TestFetchManifestActivity_missingManifestNonRetryable(t *testing.T) {
+	store := newStubObjectStore("b")
+	act, _ := NewFetchManifestActivity(store)
+	_, err := act.Execute(context.Background(), FetchManifestInput{Year: 2026, Month: 5})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Errorf("err=%v want not-found", err)
+	}
+}
+
+func TestVerifyChecksumActivity_happyPath(t *testing.T) {
+	store := newStubObjectStore("b")
+	parquetBytes := []byte("encrypted-parquet-bytes")
+	store.Set("p.parquet", parquetBytes)
+	h := sha256.Sum256(parquetBytes)
+	store.Set("p.checksum", []byte(fmt.Sprintf("%x", h[:])))
+
+	act, _ := NewVerifyChecksumActivity(store)
+	if err := act.Execute(context.Background(), VerifyChecksumInput{
+		ParquetKey: "p.parquet", ChecksumKey: "p.checksum",
+	}); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+}
+
+func TestVerifyChecksumActivity_mismatch(t *testing.T) {
+	store := newStubObjectStore("b")
+	store.Set("p.parquet", []byte("real"))
+	store.Set("p.checksum", []byte(strings.Repeat("0", 64)))
+	act, _ := NewVerifyChecksumActivity(store)
+	err := act.Execute(context.Background(), VerifyChecksumInput{ParquetKey: "p.parquet", ChecksumKey: "p.checksum"})
+	if err == nil || !strings.Contains(err.Error(), "checksum mismatch") {
+		t.Errorf("err=%v want checksum mismatch", err)
+	}
+}
+
+func TestDownloadAndDecryptActivity_unsupportedEncFormatRejected(t *testing.T) {
+	store := newStubObjectStore("b")
+	keys := fixedKeyProvider{dek: deriveTestDEK(t, 2026, 5), kekHint: "platform-billing-v1"}
+	tmp := t.TempDir()
+	act, err := NewDownloadAndDecryptActivity(store, keys, tmp)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = act.Execute(context.Background(), DownloadDecryptInput{
+		Year: 2026, Month: 5, EncFormat: "future-format-v9",
+	})
+	if !errors.Is(err, ErrUnsupportedEncFormat) {
+		t.Errorf("err=%v want ErrUnsupportedEncFormat", err)
+	}
+}
+
+func TestDownloadAndDecryptActivity_kekHintMismatch(t *testing.T) {
+	store := newStubObjectStore("b")
+	keys := fixedKeyProvider{dek: deriveTestDEK(t, 2026, 5), kekHint: "platform-billing-v3"}
+	tmp := t.TempDir()
+	act, _ := NewDownloadAndDecryptActivity(store, keys, tmp)
+	_, err := act.Execute(context.Background(), DownloadDecryptInput{
+		Year: 2026, Month: 5, EncFormat: encFormatV1, KEKHint: "platform-billing-v1",
+	})
+	if err == nil || !strings.Contains(err.Error(), "kek_hint mismatch") {
+		t.Errorf("err=%v want kek_hint mismatch", err)
+	}
+}
+
+func TestDownloadAndDecryptActivity_roundTrip(t *testing.T) {
+	store := newStubObjectStore("b")
+	dek := deriveTestDEK(t, 2026, 5)
+	plaintext := bytes.Repeat([]byte("xyz "), 1024)
+	partition := "billing.usage_events_2026_05"
+	enc := encodeChunked(t, dek, plaintext, partition)
+	parquetKey := archivedParquetKey(2026, 5)
+	store.Set(parquetKey, enc)
+
+	keys := fixedKeyProvider{dek: dek, kekHint: "platform-billing-v1"}
+	tmp := t.TempDir()
+	act, _ := NewDownloadAndDecryptActivity(store, keys, tmp)
+
+	out, err := act.Execute(context.Background(), DownloadDecryptInput{
+		Year: 2026, Month: 5,
+		ParquetKey:      parquetKey,
+		SourcePartition: partition,
+		EncFormat:       encFormatV1,
+		KEKHint:         "platform-billing-v1",
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	got, err := os.ReadFile(out.PlaintextPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, plaintext) {
+		t.Errorf("plaintext mismatch")
+	}
+	// scratch file landed under the configured scratch dir
+	if filepath.Dir(out.PlaintextPath) != tmp {
+		t.Errorf("scratch dir=%q want under %q", out.PlaintextPath, tmp)
+	}
+}
+
+func TestDownloadAndDecryptActivity_tamperedScratchCleanedUp(t *testing.T) {
+	store := newStubObjectStore("b")
+	dek := deriveTestDEK(t, 2026, 5)
+	enc := encodeChunked(t, dek, []byte("hello"), "p")
+	// flip a byte in the ciphertext payload region (after the 4-byte length + 12-byte nonce)
+	tampered := append([]byte(nil), enc...)
+	tampered[20] ^= 0xff
+	parquetKey := archivedParquetKey(2026, 5)
+	store.Set(parquetKey, tampered)
+
+	keys := fixedKeyProvider{dek: dek, kekHint: "h"}
+	tmp := t.TempDir()
+	act, _ := NewDownloadAndDecryptActivity(store, keys, tmp)
+	_, err := act.Execute(context.Background(), DownloadDecryptInput{
+		Year: 2026, Month: 5,
+		ParquetKey:      parquetKey,
+		SourcePartition: "p",
+		EncFormat:       encFormatV1,
+		KEKHint:         "h",
+	})
+	if err == nil {
+		t.Fatal("expected tampered error")
+	}
+	files, _ := os.ReadDir(tmp)
+	if len(files) != 0 {
+		t.Errorf("scratch dir not cleaned: %d files left", len(files))
+	}
+}
+
+func TestLoadIntoQuarantineActivity_orchestratesEnsureLoadSeal(t *testing.T) {
+	restorer := billingstore.NewStubRestorer()
+	restorer.SetRowReader(func(_, _ int, r io.Reader) (int64, error) {
+		_, _ = io.Copy(io.Discard, r)
+		return 42, nil
+	})
+	tmp := t.TempDir()
+	scratch := filepath.Join(tmp, "p.parquet")
+	if err := os.WriteFile(scratch, []byte("payload"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	act, err := NewLoadIntoQuarantineActivity(restorer)
+	if err != nil {
+		t.Fatal(err)
+	}
+	out, err := act.Execute(context.Background(), LoadQuarantineInput{
+		Year: 2026, Month: 5, PlaintextPath: scratch,
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if out.RowsImported != 42 {
+		t.Errorf("RowsImported=%d want 42", out.RowsImported)
+	}
+	if !restorer.IsCreated(2026, 5) {
+		t.Error("EnsureQuarantineTable not called")
+	}
+	if !restorer.IsSealed(2026, 5) {
+		t.Error("SealQuarantineTable not called")
+	}
+	if _, statErr := os.Stat(scratch); !os.IsNotExist(statErr) {
+		t.Errorf("scratch %s not cleaned: %v", scratch, statErr)
+	}
+}
+
+func TestDropQuarantineActivity_invokesRestorer(t *testing.T) {
+	restorer := billingstore.NewStubRestorer()
+	act, err := NewDropQuarantineActivity(restorer)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := act.Execute(context.Background(), DropQuarantineInput{Year: 2026, Month: 5}); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if !restorer.IsDropped(2026, 5) {
+		t.Error("DropQuarantineTable not called")
+	}
+}
+
+func TestRestoreActivities_nilDepsRejected(t *testing.T) {
+	if _, err := NewFetchManifestActivity(nil); err == nil {
+		t.Error("nil store: expected error")
+	}
+	if _, err := NewVerifyChecksumActivity(nil); err == nil {
+		t.Error("nil store: expected error")
+	}
+	if _, err := NewDownloadAndDecryptActivity(nil, fixedKeyProvider{}, ""); err == nil {
+		t.Error("nil store: expected error")
+	}
+	if _, err := NewDownloadAndDecryptActivity(newStubObjectStore("b"), nil, ""); err == nil {
+		t.Error("nil keys: expected error")
+	}
+	if _, err := NewLoadIntoQuarantineActivity(nil); err == nil {
+		t.Error("nil restorer: expected error")
+	}
+	if _, err := NewDropQuarantineActivity(nil); err == nil {
+		t.Error("nil restorer: expected error")
+	}
+}

--- a/plane/workflow/billing/restore_decoder.go
+++ b/plane/workflow/billing/restore_decoder.go
@@ -1,0 +1,111 @@
+package billing
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+)
+
+// ErrFrameTampered is returned by ChunkedDecoder.DecodeStream when a frame
+// fails AEAD verification (wrong DEK, wrong AAD, truncated chunk, or
+// out-of-order chunk index). All four collapse to "tampered" because GCM tag
+// verification is the integrity oracle.
+var ErrFrameTampered = errors.New("billing/restore: frame tampered or DEK mismatch")
+
+// ErrUnsupportedEncFormat is returned when a manifest's enc_format is not
+// encFormatV1. Restore intentionally has no compatibility shim: a future
+// version (e.g. ChaCha20-Poly1305 or different chunk size) requires a new
+// decoder, not graceful fallback.
+var ErrUnsupportedEncFormat = errors.New("billing/restore: unsupported enc_format")
+
+// maxFramePayloadBytes caps the payload portion of a single frame at the
+// plaintext chunk size + nonce + GCM tag + 1 KiB headroom. The encrypt loop
+// in export_activity.go uses 4 MiB plaintext chunks; legitimate frames are
+// always at most 4 MiB + 12 (nonce) + 16 (tag) = 4 MiB + 28 bytes. The
+// extra slack absorbs format-version drift without exposing the worker to
+// unbounded allocation from a maliciously crafted length prefix.
+const maxFramePayloadBytes = (4 << 20) + 1024
+
+// ChunkedDecoder is the inverse of the encrypt loop in export_activity.go.
+// It expects a stream of frames in the format
+//
+//	[4-byte BE payload_len][12-byte nonce][GCM ciphertext+tag]
+//
+// where AAD per chunk is "<partitionName>:<chunkIndex>" with chunkIndex
+// starting at 0 and incrementing per frame. The decoder verifies AEAD on
+// every chunk; any deviation surfaces as ErrFrameTampered.
+type ChunkedDecoder struct {
+	DEK []byte // 32 bytes (AES-256)
+}
+
+// DecodeStream reads encrypted frames from r, decrypts each chunk under the
+// DEK with AAD "<partitionName>:<chunkIndex>", and writes plaintext chunks
+// to w in order. EOF on a frame boundary is normal termination; EOF mid-frame
+// surfaces as ErrFrameTampered.
+func (d *ChunkedDecoder) DecodeStream(r io.Reader, w io.Writer, partitionName string) error {
+	if len(d.DEK) != 32 {
+		return fmt.Errorf("billing/restore: DEK must be 32 bytes, got %d", len(d.DEK))
+	}
+	block, err := aes.NewCipher(d.DEK)
+	if err != nil {
+		return fmt.Errorf("billing/restore: new cipher: %w", err)
+	}
+	aead, err := cipher.NewGCM(block)
+	if err != nil {
+		return fmt.Errorf("billing/restore: new gcm: %w", err)
+	}
+	nonceSize := aead.NonceSize()
+	overhead := aead.Overhead()
+
+	var lenBuf [4]byte
+	var chunkIndex uint64
+	for {
+		// Read the 4-byte BE payload length. EOF here = clean stream end.
+		_, err := io.ReadFull(r, lenBuf[:])
+		if errors.Is(err, io.EOF) {
+			return nil
+		}
+		if err != nil {
+			// io.ErrUnexpectedEOF on the length prefix means the producer
+			// truncated mid-header; treat as tampered.
+			if errors.Is(err, io.ErrUnexpectedEOF) {
+				return fmt.Errorf("%w: truncated length prefix at chunk %d", ErrFrameTampered, chunkIndex)
+			}
+			return fmt.Errorf("billing/restore: read length at chunk %d: %w", chunkIndex, err)
+		}
+		payloadLen := binary.BigEndian.Uint32(lenBuf[:])
+		if int(payloadLen) < nonceSize+overhead {
+			return fmt.Errorf("%w: payload_len %d < nonce+tag at chunk %d",
+				ErrFrameTampered, payloadLen, chunkIndex)
+		}
+		if int(payloadLen) > maxFramePayloadBytes {
+			return fmt.Errorf("%w: payload_len %d exceeds cap at chunk %d",
+				ErrFrameTampered, payloadLen, chunkIndex)
+		}
+
+		payload := make([]byte, payloadLen)
+		if _, err := io.ReadFull(r, payload); err != nil {
+			if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
+				return fmt.Errorf("%w: truncated payload at chunk %d", ErrFrameTampered, chunkIndex)
+			}
+			return fmt.Errorf("billing/restore: read payload at chunk %d: %w", chunkIndex, err)
+		}
+		nonce := payload[:nonceSize]
+		ct := payload[nonceSize:]
+
+		aad := []byte(fmt.Sprintf("%s:%d", partitionName, chunkIndex))
+		pt, err := aead.Open(nil, nonce, ct, aad)
+		if err != nil {
+			// AEAD failure is the canonical "tampered" oracle: includes wrong
+			// DEK, wrong partition name, out-of-order index, bit-flip in ct.
+			return fmt.Errorf("%w: chunk %d open: %v", ErrFrameTampered, chunkIndex, err)
+		}
+		if _, werr := w.Write(pt); werr != nil {
+			return fmt.Errorf("billing/restore: write plaintext at chunk %d: %w", chunkIndex, werr)
+		}
+		chunkIndex++
+	}
+}

--- a/plane/workflow/billing/restore_decoder_test.go
+++ b/plane/workflow/billing/restore_decoder_test.go
@@ -1,0 +1,204 @@
+package billing
+
+import (
+	"bytes"
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"testing"
+)
+
+// encodeChunked replicates the encrypt loop in export_activity.go. Mirroring
+// it inside the test (rather than calling ExportActivity) keeps the decoder
+// test focused on the wire format and avoids pulling in parquet / archiver
+// machinery — and any future drift between encode and decode is caught by
+// the round-trip integration test.
+func encodeChunked(t *testing.T, dek []byte, plaintext []byte, partitionName string) []byte {
+	t.Helper()
+	block, err := aes.NewCipher(dek)
+	if err != nil {
+		t.Fatalf("aes: %v", err)
+	}
+	aead, err := cipher.NewGCM(block)
+	if err != nil {
+		t.Fatalf("gcm: %v", err)
+	}
+	const chunkSize = 4 << 20
+	var out bytes.Buffer
+	var chunkIndex uint64
+	r := bytes.NewReader(plaintext)
+	buf := make([]byte, chunkSize)
+	for {
+		n, readErr := io.ReadFull(r, buf)
+		if n > 0 {
+			nonce := make([]byte, aead.NonceSize())
+			if _, rerr := rand.Read(nonce); rerr != nil {
+				t.Fatalf("nonce: %v", rerr)
+			}
+			aad := []byte(fmt.Sprintf("%s:%d", partitionName, chunkIndex))
+			ct := aead.Seal(nil, nonce, buf[:n], aad)
+			chunkIndex++
+
+			payloadLen := uint32(len(nonce) + len(ct))
+			frame := make([]byte, 4+int(payloadLen))
+			binary.BigEndian.PutUint32(frame[:4], payloadLen)
+			copy(frame[4:], nonce)
+			copy(frame[4+len(nonce):], ct)
+			out.Write(frame)
+		}
+		if errors.Is(readErr, io.EOF) || errors.Is(readErr, io.ErrUnexpectedEOF) {
+			return out.Bytes()
+		}
+		if readErr != nil {
+			t.Fatalf("read: %v", readErr)
+		}
+	}
+}
+
+func deriveTestDEK(t *testing.T, year, month int) []byte {
+	t.Helper()
+	h := sha256.New()
+	var buf [8]byte
+	binary.BigEndian.PutUint32(buf[:4], uint32(year))
+	binary.BigEndian.PutUint32(buf[4:], uint32(month))
+	h.Write(buf[:])
+	return h.Sum(nil)
+}
+
+func TestChunkedDecoder_roundTripSingleChunk(t *testing.T) {
+	dek := deriveTestDEK(t, 2026, 5)
+	plaintext := []byte("hello world — single sub-chunk plaintext")
+	partition := "billing.usage_events_2026_05"
+
+	enc := encodeChunked(t, dek, plaintext, partition)
+	dec := &ChunkedDecoder{DEK: dek}
+
+	var out bytes.Buffer
+	if err := dec.DecodeStream(bytes.NewReader(enc), &out, partition); err != nil {
+		t.Fatalf("DecodeStream: %v", err)
+	}
+	if !bytes.Equal(out.Bytes(), plaintext) {
+		t.Errorf("plaintext mismatch")
+	}
+}
+
+func TestChunkedDecoder_roundTripMultipleChunks(t *testing.T) {
+	dek := deriveTestDEK(t, 2026, 5)
+	// 10 MiB → 3 chunks (4 + 4 + 2)
+	plaintext := bytes.Repeat([]byte("ABCD"), (10<<20)/4)
+	partition := "billing.usage_events_2026_05"
+
+	enc := encodeChunked(t, dek, plaintext, partition)
+	dec := &ChunkedDecoder{DEK: dek}
+
+	var out bytes.Buffer
+	if err := dec.DecodeStream(bytes.NewReader(enc), &out, partition); err != nil {
+		t.Fatalf("DecodeStream: %v", err)
+	}
+	if !bytes.Equal(out.Bytes(), plaintext) {
+		t.Errorf("plaintext mismatch len=%d want=%d", out.Len(), len(plaintext))
+	}
+}
+
+func TestChunkedDecoder_wrongPartitionAAD(t *testing.T) {
+	dek := deriveTestDEK(t, 2026, 5)
+	plaintext := []byte("abcdef")
+	enc := encodeChunked(t, dek, plaintext, "billing.usage_events_2026_05")
+
+	dec := &ChunkedDecoder{DEK: dek}
+	var out bytes.Buffer
+	err := dec.DecodeStream(bytes.NewReader(enc), &out, "billing.usage_events_2026_06")
+	if !errors.Is(err, ErrFrameTampered) {
+		t.Errorf("err=%v want ErrFrameTampered", err)
+	}
+}
+
+func TestChunkedDecoder_wrongDEK(t *testing.T) {
+	good := deriveTestDEK(t, 2026, 5)
+	bad := deriveTestDEK(t, 2026, 6)
+	enc := encodeChunked(t, good, []byte("abc"), "p")
+
+	dec := &ChunkedDecoder{DEK: bad}
+	var out bytes.Buffer
+	err := dec.DecodeStream(bytes.NewReader(enc), &out, "p")
+	if !errors.Is(err, ErrFrameTampered) {
+		t.Errorf("err=%v want ErrFrameTampered", err)
+	}
+}
+
+func TestChunkedDecoder_truncatedPayload(t *testing.T) {
+	dek := deriveTestDEK(t, 2026, 5)
+	enc := encodeChunked(t, dek, []byte("abcdefghij"), "p")
+	// Truncate by 5 bytes off the tail (mid-payload).
+	truncated := enc[:len(enc)-5]
+
+	dec := &ChunkedDecoder{DEK: dek}
+	var out bytes.Buffer
+	err := dec.DecodeStream(bytes.NewReader(truncated), &out, "p")
+	if !errors.Is(err, ErrFrameTampered) {
+		t.Errorf("err=%v want ErrFrameTampered", err)
+	}
+}
+
+func TestChunkedDecoder_truncatedLengthPrefix(t *testing.T) {
+	dek := deriveTestDEK(t, 2026, 5)
+	enc := encodeChunked(t, dek, []byte("abcdefghij"), "p")
+	// Append 2 extra bytes — a partial length prefix of the next "frame".
+	tampered := append(append([]byte(nil), enc...), 0x00, 0x01)
+
+	dec := &ChunkedDecoder{DEK: dek}
+	var out bytes.Buffer
+	err := dec.DecodeStream(bytes.NewReader(tampered), &out, "p")
+	if !errors.Is(err, ErrFrameTampered) {
+		t.Errorf("err=%v want ErrFrameTampered", err)
+	}
+}
+
+func TestChunkedDecoder_payloadLenTooSmall(t *testing.T) {
+	dek := deriveTestDEK(t, 2026, 5)
+	// payload_len = 0 — smaller than nonce+tag.
+	frame := make([]byte, 4)
+	binary.BigEndian.PutUint32(frame[:4], 0)
+	dec := &ChunkedDecoder{DEK: dek}
+	var out bytes.Buffer
+	err := dec.DecodeStream(bytes.NewReader(frame), &out, "p")
+	if !errors.Is(err, ErrFrameTampered) {
+		t.Errorf("err=%v want ErrFrameTampered", err)
+	}
+}
+
+func TestChunkedDecoder_payloadLenExceedsCap(t *testing.T) {
+	dek := deriveTestDEK(t, 2026, 5)
+	frame := make([]byte, 4)
+	binary.BigEndian.PutUint32(frame[:4], maxFramePayloadBytes+1)
+	dec := &ChunkedDecoder{DEK: dek}
+	var out bytes.Buffer
+	err := dec.DecodeStream(bytes.NewReader(frame), &out, "p")
+	if !errors.Is(err, ErrFrameTampered) {
+		t.Errorf("err=%v want ErrFrameTampered", err)
+	}
+}
+
+func TestChunkedDecoder_emptyStream(t *testing.T) {
+	dec := &ChunkedDecoder{DEK: deriveTestDEK(t, 2026, 5)}
+	var out bytes.Buffer
+	if err := dec.DecodeStream(bytes.NewReader(nil), &out, "p"); err != nil {
+		t.Errorf("empty stream should be clean EOF, got %v", err)
+	}
+	if out.Len() != 0 {
+		t.Errorf("plaintext should be empty")
+	}
+}
+
+func TestChunkedDecoder_invalidDEKLength(t *testing.T) {
+	dec := &ChunkedDecoder{DEK: []byte{1, 2, 3}}
+	var out bytes.Buffer
+	if err := dec.DecodeStream(bytes.NewReader(nil), &out, "p"); err == nil {
+		t.Error("expected error for short DEK")
+	}
+}

--- a/plane/workflow/billing/restore_workflow.go
+++ b/plane/workflow/billing/restore_workflow.go
@@ -1,0 +1,160 @@
+package billing
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	gswf "github.com/gitscale-platform/gitscale/plane/workflow"
+	"go.temporal.io/sdk/workflow"
+)
+
+// RestorePartitionWorkflowName is the registered name for the restore
+// workflow. The workflow ID convention is
+// "billing.restore-partition.YYYY-MM" so re-runs for the same (year, month)
+// are idempotent under Temporal's existing-workflow handling.
+const RestorePartitionWorkflowName = "billing.RestorePartitionWorkflow"
+
+// RestoreInput is the input to RestorePartitionWorkflow.
+type RestoreInput struct {
+	Year  int
+	Month int
+}
+
+// RestoreResult is returned by RestorePartitionWorkflow on success.
+type RestoreResult struct {
+	QuarantineTable string
+	RowsImported    int64
+	DEKVersionUsed  int // parsed from manifest.kek_hint ("platform-billing-v<N>")
+}
+
+// nonRetryableRestoreErrors collects error types we never want Temporal to
+// retry: format/integrity mismatches that will fail the same way every time.
+var nonRetryableRestoreErrors = []string{
+	"ErrUnsupportedEncFormat",
+	"ErrChecksumMismatch",
+	"ErrFrameTampered",
+	"ErrObjectNotFound",
+}
+
+// RestorePartitionWorkflow restores an archived monthly partition to a
+// quarantine table for dispute investigation / audit-restore.
+//
+// Activity sequence (sequential):
+//  1. FetchManifest        — read .manifest.json, validate source_partition + schema
+//  2. VerifyChecksum       — recompute SHA-256 over the encrypted parquet
+//  3. DownloadAndDecrypt   — stream + AES-256-GCM-v1-4mib decode → scratch file
+//  4. LoadIntoQuarantine   — CREATE quarantine table, COPY plaintext rows, REVOKE writes
+//
+// Workflow body is purely deterministic — no time/random/IO. Retry policy is
+// the platform default; non-retryable errors (ErrUnsupportedEncFormat,
+// ErrChecksumMismatch, ErrFrameTampered, ErrObjectNotFound) are wrapped with
+// temporal.NewNonRetryableApplicationError at the activity boundary so they
+// short-circuit the policy.
+func RestorePartitionWorkflow(ctx workflow.Context, in RestoreInput) (RestoreResult, error) {
+	if in.Year < 2026 || in.Year > 2099 {
+		return RestoreResult{}, fmt.Errorf("restore: year %d out of supported range [2026, 2099]", in.Year)
+	}
+	if in.Month < 1 || in.Month > 12 {
+		return RestoreResult{}, fmt.Errorf("restore: month %d out of range [1, 12]", in.Month)
+	}
+
+	rp := gswf.DefaultRetryPolicy()
+	rp.NonRetryableErrorTypes = nonRetryableRestoreErrors
+
+	shortOpts := workflow.ActivityOptions{
+		StartToCloseTimeout: 5 * time.Minute,
+		RetryPolicy:         rp,
+	}
+	longOpts := workflow.ActivityOptions{
+		StartToCloseTimeout: 4 * time.Hour,
+		HeartbeatTimeout:    5 * time.Minute,
+		RetryPolicy:         rp,
+	}
+
+	// 1. FetchManifest
+	fetchCtx := workflow.WithActivityOptions(ctx, shortOpts)
+	var manifest FetchManifestResult
+	if err := workflow.ExecuteActivity(fetchCtx, ActivityNameFetchManifest,
+		FetchManifestInput{Year: in.Year, Month: in.Month},
+	).Get(fetchCtx, &manifest); err != nil {
+		return RestoreResult{}, fmt.Errorf("restore: fetch manifest: %w", err)
+	}
+
+	// Workflow-side enc_format gate. We also enforce inside the activity, but
+	// rejecting here saves a checksum re-hash for the unsupported case.
+	if manifest.EncFormat != encFormatV1 {
+		return RestoreResult{}, fmt.Errorf(
+			"restore: unsupported enc_format %q in manifest (worker reads only %q)",
+			manifest.EncFormat, encFormatV1,
+		)
+	}
+
+	// 2. VerifyChecksum
+	verifyCtx := workflow.WithActivityOptions(ctx, longOpts)
+	if err := workflow.ExecuteActivity(verifyCtx, ActivityNameVerifyChecksum,
+		VerifyChecksumInput{ParquetKey: manifest.ParquetKey, ChecksumKey: manifest.ChecksumKey},
+	).Get(verifyCtx, nil); err != nil {
+		return RestoreResult{}, fmt.Errorf("restore: verify checksum: %w", err)
+	}
+
+	// 3. DownloadAndDecrypt
+	decCtx := workflow.WithActivityOptions(ctx, longOpts)
+	var decResult DownloadDecryptResult
+	if err := workflow.ExecuteActivity(decCtx, ActivityNameDownloadDecrypt,
+		DownloadDecryptInput{
+			Year:            in.Year,
+			Month:           in.Month,
+			ParquetKey:      manifest.ParquetKey,
+			SourcePartition: manifest.SourcePartition,
+			EncFormat:       manifest.EncFormat,
+			KEKHint:         manifest.KEKHint,
+		},
+	).Get(decCtx, &decResult); err != nil {
+		return RestoreResult{}, fmt.Errorf("restore: decrypt: %w", err)
+	}
+
+	// 4. LoadIntoQuarantine — drop quarantine on failure (compensation).
+	loadCtx := workflow.WithActivityOptions(ctx, longOpts)
+	var loadResult LoadQuarantineResult
+	loadErr := workflow.ExecuteActivity(loadCtx, ActivityNameLoadQuarantine,
+		LoadQuarantineInput{Year: in.Year, Month: in.Month, PlaintextPath: decResult.PlaintextPath},
+	).Get(loadCtx, &loadResult)
+	if loadErr != nil {
+		// Compensation: drop the partially-loaded quarantine table. We don't
+		// surface a compensation error — it would mask the root cause.
+		dropCtx := workflow.WithActivityOptions(ctx, shortOpts)
+		_ = workflow.ExecuteActivity(dropCtx, ActivityNameDropQuarantine,
+			DropQuarantineInput{Year: in.Year, Month: in.Month},
+		).Get(dropCtx, nil)
+		return RestoreResult{}, fmt.Errorf("restore: load quarantine: %w", loadErr)
+	}
+
+	return RestoreResult{
+		QuarantineTable: loadResult.QuarantineTable,
+		RowsImported:    loadResult.RowsImported,
+		DEKVersionUsed:  parseKEKVersion(manifest.KEKHint),
+	}, nil
+}
+
+// parseKEKVersion extracts <N> from a KEK hint of the form
+// "platform-billing-v<N>". Returns 0 for the stub provider's hint or any
+// unparseable form — the operator-facing surface is informational, not load-
+// bearing.
+func parseKEKVersion(hint string) int {
+	const prefix = "platform-billing-v"
+	if !strings.HasPrefix(hint, prefix) {
+		return 0
+	}
+	n, err := strconv.Atoi(strings.TrimPrefix(hint, prefix))
+	if err != nil {
+		return 0
+	}
+	return n
+}
+
+// ErrRestoreInputInvalid is exposed for callers that want to distinguish input
+// validation errors from activity failures.
+var ErrRestoreInputInvalid = errors.New("billing/restore: invalid input")

--- a/plane/workflow/billing/restore_workflow.go
+++ b/plane/workflow/billing/restore_workflow.go
@@ -78,7 +78,7 @@ func RestorePartitionWorkflow(ctx workflow.Context, in RestoreInput) (RestoreRes
 	fetchCtx := workflow.WithActivityOptions(ctx, shortOpts)
 	var manifest FetchManifestResult
 	if err := workflow.ExecuteActivity(fetchCtx, ActivityNameFetchManifest,
-		FetchManifestInput{Year: in.Year, Month: in.Month},
+		FetchManifestInput(in),
 	).Get(fetchCtx, &manifest); err != nil {
 		return RestoreResult{}, fmt.Errorf("restore: fetch manifest: %w", err)
 	}
@@ -127,7 +127,7 @@ func RestorePartitionWorkflow(ctx workflow.Context, in RestoreInput) (RestoreRes
 		// surface a compensation error — it would mask the root cause.
 		dropCtx := workflow.WithActivityOptions(ctx, shortOpts)
 		_ = workflow.ExecuteActivity(dropCtx, ActivityNameDropQuarantine,
-			DropQuarantineInput{Year: in.Year, Month: in.Month},
+			DropQuarantineInput(in),
 		).Get(dropCtx, nil)
 		return RestoreResult{}, fmt.Errorf("restore: load quarantine: %w", loadErr)
 	}

--- a/plane/workflow/billing/restore_workflow_integration_test.go
+++ b/plane/workflow/billing/restore_workflow_integration_test.go
@@ -1,0 +1,241 @@
+//go:build integration
+
+package billing
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+	"time"
+
+	billingstore "github.com/gitscale-platform/gitscale/plane/data/store/billing"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/testcontainers/testcontainers-go"
+	pgmodule "github.com/testcontainers/testcontainers-go/modules/postgres"
+	"github.com/testcontainers/testcontainers-go/wait"
+)
+
+// TestRestorePartition_archiveRestoreRoundTrip seeds rows into the live
+// partition, runs ExportActivity to produce an encrypted parquet on a stub
+// object store, then runs the four restore activities in order and asserts
+// the quarantine table holds the exact same (id, ts) row set.
+//
+// Vault is real (testcontainer) — DEK derivation must round-trip end-to-end,
+// otherwise drift between encode and decode is silent. The object store is
+// the in-process stub so the test does not require minio.
+func TestRestorePartition_archiveRestoreRoundTrip(t *testing.T) {
+	ctx := context.Background()
+
+	pool := bootRestorePostgres(t)
+	vaultClient := bootVaultForExport(t)
+	keys := NewVaultKeyProvider(vaultClient, "", "")
+
+	year, month := 2026, 5
+
+	// Create the live partition + seed rows.
+	partitioner := billingstore.NewPostgresPartitioner(pool)
+	if _, err := partitioner.CreateUsageEventsPartition(ctx, year, month); err != nil {
+		t.Fatalf("create partition: %v", err)
+	}
+	seeded := seedUsageEvents(t, pool, year, month, 50)
+
+	// Export: detach + stream to stub object store.
+	archiver := billingstore.NewPostgresArchiver(pool)
+	if err := archiver.DetachUsageEventsPartition(ctx, year, month); err != nil {
+		t.Fatalf("detach: %v", err)
+	}
+	store := newStubObjectStore("test-bucket")
+	exportAct, err := NewExportActivity(archiver, store, keys, "test-bucket")
+	if err != nil {
+		t.Fatal(err)
+	}
+	exportRes, err := exportAct.Execute(ctx, ExportInput{Year: year, Month: month})
+	if err != nil {
+		t.Fatalf("export: %v", err)
+	}
+	if exportRes.RowCount != int64(len(seeded)) {
+		t.Fatalf("export RowCount=%d want %d", exportRes.RowCount, len(seeded))
+	}
+
+	// Restore: run each activity in workflow order against the same store.
+	fetchAct, _ := NewFetchManifestActivity(store)
+	manifest, err := fetchAct.Execute(ctx, FetchManifestInput{Year: year, Month: month})
+	if err != nil {
+		t.Fatalf("fetch manifest: %v", err)
+	}
+	if manifest.EncFormat != encFormatV1 {
+		t.Fatalf("manifest enc_format=%q", manifest.EncFormat)
+	}
+
+	verifyAct, _ := NewVerifyChecksumActivity(store)
+	if err := verifyAct.Execute(ctx, VerifyChecksumInput{
+		ParquetKey: manifest.ParquetKey, ChecksumKey: manifest.ChecksumKey,
+	}); err != nil {
+		t.Fatalf("verify checksum: %v", err)
+	}
+
+	scratch := t.TempDir()
+	decAct, _ := NewDownloadAndDecryptActivity(store, keys, scratch)
+	decRes, err := decAct.Execute(ctx, DownloadDecryptInput{
+		Year:            year,
+		Month:           month,
+		ParquetKey:      manifest.ParquetKey,
+		SourcePartition: manifest.SourcePartition,
+		EncFormat:       manifest.EncFormat,
+		KEKHint:         manifest.KEKHint,
+	})
+	if err != nil {
+		t.Fatalf("download+decrypt: %v", err)
+	}
+
+	restorer := billingstore.NewPostgresRestorer(pool)
+	loadAct, _ := NewLoadIntoQuarantineActivity(restorer)
+	loadRes, err := loadAct.Execute(ctx, LoadQuarantineInput{
+		Year: year, Month: month, PlaintextPath: decRes.PlaintextPath,
+	})
+	if err != nil {
+		t.Fatalf("load quarantine: %v", err)
+	}
+	if loadRes.RowsImported != int64(len(seeded)) {
+		t.Fatalf("RowsImported=%d want %d", loadRes.RowsImported, len(seeded))
+	}
+
+	// Assert quarantine table holds the same (id, ts) row set.
+	got := readQuarantine(t, pool, year, month)
+	sort.Slice(got, func(i, j int) bool { return got[i].id < got[j].id })
+	want := append([]idTs(nil), seeded...)
+	sort.Slice(want, func(i, j int) bool { return want[i].id < want[j].id })
+	if len(got) != len(want) {
+		t.Fatalf("row count got=%d want=%d", len(got), len(want))
+	}
+	for i := range got {
+		if got[i].id != want[i].id || !got[i].ts.Equal(want[i].ts) {
+			t.Errorf("row %d: got=(%s, %s) want=(%s, %s)",
+				i, got[i].id, got[i].ts, want[i].id, want[i].ts)
+		}
+	}
+
+	// Quarantine table must be sealed read-only.
+	if !quarantineIsSealed(t, pool, year, month) {
+		t.Error("quarantine table is not sealed read-only after restore")
+	}
+}
+
+type idTs struct {
+	id string
+	ts time.Time
+}
+
+func seedUsageEvents(t *testing.T, pool *pgxpool.Pool, year, month, n int) []idTs {
+	t.Helper()
+	ctx := context.Background()
+	rows := make([]idTs, 0, n)
+	base := time.Date(year, time.Month(month), 5, 12, 0, 0, 0, time.UTC)
+	for i := 0; i < n; i++ {
+		id := fmt.Sprintf("00000000-0000-0000-0000-%012d", i+1)
+		ts := base.Add(time.Duration(i) * time.Minute)
+		_, err := pool.Exec(ctx, `
+			INSERT INTO billing.usage_events
+			  (id, account_id, principal_id, principal_type, surface, cost_vector, value, event_source, ts, created_at)
+			VALUES
+			  ($1::uuid, $2::uuid, $3::uuid, 'agent', 'tokens', '{}'::jsonb, 1000, 'api', $4, $4)`,
+			id,
+			"00000000-0000-0000-0000-000000000001",
+			"00000000-0000-0000-0000-000000000002",
+			ts,
+		)
+		if err != nil {
+			t.Fatalf("seed row %d: %v", i, err)
+		}
+		rows = append(rows, idTs{id: id, ts: ts})
+	}
+	return rows
+}
+
+func readQuarantine(t *testing.T, pool *pgxpool.Pool, year, month int) []idTs {
+	t.Helper()
+	ctx := context.Background()
+	q := fmt.Sprintf(
+		"SELECT id::text, ts FROM billing.usage_events_restore_%04d_%02d ORDER BY ts, id",
+		year, month,
+	)
+	rows, err := pool.Query(ctx, q)
+	if err != nil {
+		t.Fatalf("read quarantine: %v", err)
+	}
+	defer rows.Close()
+	var out []idTs
+	for rows.Next() {
+		var r idTs
+		if err := rows.Scan(&r.id, &r.ts); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		out = append(out, r)
+	}
+	return out
+}
+
+func quarantineIsSealed(t *testing.T, pool *pgxpool.Pool, year, month int) bool {
+	t.Helper()
+	ctx := context.Background()
+	tableName := fmt.Sprintf("usage_events_restore_%04d_%02d", year, month)
+	// has_table_privilege returns true if PUBLIC has INSERT on the table.
+	var canInsert bool
+	if err := pool.QueryRow(ctx,
+		`SELECT has_table_privilege('public', $1::regclass, 'INSERT')`,
+		"billing."+tableName,
+	).Scan(&canInsert); err != nil {
+		t.Fatalf("probe privilege: %v", err)
+	}
+	return !canInsert
+}
+
+func bootRestorePostgres(t *testing.T) *pgxpool.Pool {
+	t.Helper()
+	ctx := context.Background()
+	ctr, err := pgmodule.Run(ctx,
+		"postgres:16-alpine",
+		pgmodule.WithDatabase("gitscale_test"),
+		pgmodule.WithUsername("gs"),
+		pgmodule.WithPassword("gs"),
+		testcontainers.WithWaitStrategy(
+			wait.ForLog("database system is ready to accept connections").
+				WithOccurrence(2).
+				WithStartupTimeout(60*time.Second),
+		),
+	)
+	if err != nil {
+		t.Fatalf("start postgres: %v", err)
+	}
+	t.Cleanup(func() { _ = ctr.Terminate(ctx) })
+
+	connStr, err := ctr.ConnectionString(ctx, "sslmode=disable")
+	if err != nil {
+		t.Fatalf("connection string: %v", err)
+	}
+	pool, err := pgxpool.New(ctx, connStr)
+	if err != nil {
+		t.Fatalf("pgxpool.New: %v", err)
+	}
+	t.Cleanup(pool.Close)
+
+	migrationsDir := filepath.Join("..", "..", "..", "plane", "data", "migrations")
+	for _, f := range []string{
+		"000_init.sql", "001_identity.sql", "002_repositories.sql",
+		"003_collaboration.sql", "004_ci.sql", "005_billing.sql",
+		"006_identity_revocation.sql", "007_billing_partition_archives.sql",
+		"008_updated_at_triggers.sql", "009_identity_temporal_columns.sql",
+	} {
+		sql, err := os.ReadFile(filepath.Join(migrationsDir, f))
+		if err != nil {
+			t.Fatalf("read %s: %v", f, err)
+		}
+		if _, err := pool.Exec(ctx, string(sql)); err != nil {
+			t.Fatalf("apply %s: %v", f, err)
+		}
+	}
+	return pool
+}

--- a/plane/workflow/billing/restore_workflow_test.go
+++ b/plane/workflow/billing/restore_workflow_test.go
@@ -1,0 +1,235 @@
+package billing
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/mock"
+	"go.temporal.io/sdk/activity"
+	"go.temporal.io/sdk/temporal"
+	"go.temporal.io/sdk/testsuite"
+)
+
+func registerRestoreActivityStubs(env *testsuite.TestWorkflowEnvironment) {
+	env.RegisterActivityWithOptions(
+		func(context.Context, FetchManifestInput) (FetchManifestResult, error) { return FetchManifestResult{}, nil },
+		activity.RegisterOptions{Name: ActivityNameFetchManifest},
+	)
+	env.RegisterActivityWithOptions(
+		func(context.Context, VerifyChecksumInput) error { return nil },
+		activity.RegisterOptions{Name: ActivityNameVerifyChecksum},
+	)
+	env.RegisterActivityWithOptions(
+		func(context.Context, DownloadDecryptInput) (DownloadDecryptResult, error) { return DownloadDecryptResult{}, nil },
+		activity.RegisterOptions{Name: ActivityNameDownloadDecrypt},
+	)
+	env.RegisterActivityWithOptions(
+		func(context.Context, LoadQuarantineInput) (LoadQuarantineResult, error) {
+			return LoadQuarantineResult{}, nil
+		},
+		activity.RegisterOptions{Name: ActivityNameLoadQuarantine},
+	)
+	env.RegisterActivityWithOptions(
+		func(context.Context, DropQuarantineInput) error { return nil },
+		activity.RegisterOptions{Name: ActivityNameDropQuarantine},
+	)
+}
+
+func happyManifest() FetchManifestResult {
+	return FetchManifestResult{
+		SourcePartition: "billing.usage_events_2026_05",
+		RowCount:        2,
+		BytesWritten:    4096,
+		KEKHint:         "platform-billing-v3",
+		EncFormat:       encFormatV1,
+		ChecksumAlg:     "sha256",
+		ParquetKey:      "billing/usage_events/year=2026/month=05/usage_events_2026_05.parquet",
+		ChecksumKey:     "billing/usage_events/year=2026/month=05/usage_events_2026_05.checksum.sha256",
+	}
+}
+
+func TestRestorePartitionWorkflow_happyPath(t *testing.T) {
+	s := &testsuite.WorkflowTestSuite{}
+	env := s.NewTestWorkflowEnvironment()
+	env.RegisterWorkflow(RestorePartitionWorkflow)
+	registerRestoreActivityStubs(env)
+
+	manifest := happyManifest()
+	env.OnActivity(ActivityNameFetchManifest, mock.Anything, FetchManifestInput{Year: 2026, Month: 5}).
+		Return(manifest, nil)
+	env.OnActivity(ActivityNameVerifyChecksum, mock.Anything,
+		VerifyChecksumInput{ParquetKey: manifest.ParquetKey, ChecksumKey: manifest.ChecksumKey}).
+		Return(nil)
+	env.OnActivity(ActivityNameDownloadDecrypt, mock.Anything, DownloadDecryptInput{
+		Year:            2026,
+		Month:           5,
+		ParquetKey:      manifest.ParquetKey,
+		SourcePartition: manifest.SourcePartition,
+		EncFormat:       manifest.EncFormat,
+		KEKHint:         manifest.KEKHint,
+	}).Return(DownloadDecryptResult{PlaintextPath: "/tmp/p.parquet"}, nil)
+	env.OnActivity(ActivityNameLoadQuarantine, mock.Anything,
+		LoadQuarantineInput{Year: 2026, Month: 5, PlaintextPath: "/tmp/p.parquet"}).
+		Return(LoadQuarantineResult{
+			QuarantineTable: "billing.usage_events_restore_2026_05",
+			RowsImported:    2,
+		}, nil)
+
+	env.ExecuteWorkflow(RestorePartitionWorkflow, RestoreInput{Year: 2026, Month: 5})
+
+	if !env.IsWorkflowCompleted() {
+		t.Fatal("workflow did not complete")
+	}
+	if err := env.GetWorkflowError(); err != nil {
+		t.Fatalf("workflow error: %v", err)
+	}
+	var result RestoreResult
+	if err := env.GetWorkflowResult(&result); err != nil {
+		t.Fatalf("GetWorkflowResult: %v", err)
+	}
+	if result.QuarantineTable != "billing.usage_events_restore_2026_05" {
+		t.Errorf("QuarantineTable=%q", result.QuarantineTable)
+	}
+	if result.RowsImported != 2 {
+		t.Errorf("RowsImported=%d want 2", result.RowsImported)
+	}
+	if result.DEKVersionUsed != 3 {
+		t.Errorf("DEKVersionUsed=%d want 3", result.DEKVersionUsed)
+	}
+}
+
+func TestRestorePartitionWorkflow_rejectsUnsupportedEncFormat(t *testing.T) {
+	s := &testsuite.WorkflowTestSuite{}
+	env := s.NewTestWorkflowEnvironment()
+	env.RegisterWorkflow(RestorePartitionWorkflow)
+	registerRestoreActivityStubs(env)
+
+	manifest := happyManifest()
+	manifest.EncFormat = "aes-256-gcm-v2-1mib" // hypothetical future format
+	env.OnActivity(ActivityNameFetchManifest, mock.Anything, mock.Anything).Return(manifest, nil)
+
+	env.ExecuteWorkflow(RestorePartitionWorkflow, RestoreInput{Year: 2026, Month: 5})
+
+	err := env.GetWorkflowError()
+	if err == nil {
+		t.Fatal("expected error for unsupported enc_format")
+	}
+	if !strings.Contains(err.Error(), "unsupported enc_format") {
+		t.Errorf("err=%v missing 'unsupported enc_format'", err)
+	}
+}
+
+func TestRestorePartitionWorkflow_manifestMissingNonRetryable(t *testing.T) {
+	s := &testsuite.WorkflowTestSuite{}
+	env := s.NewTestWorkflowEnvironment()
+	env.RegisterWorkflow(RestorePartitionWorkflow)
+	registerRestoreActivityStubs(env)
+
+	missing := temporal.NewNonRetryableApplicationError(
+		"fetch manifest: object store: not found", "ErrObjectNotFound", errors.New("not found"))
+	env.OnActivity(ActivityNameFetchManifest, mock.Anything, mock.Anything).
+		Return(FetchManifestResult{}, missing)
+
+	env.ExecuteWorkflow(RestorePartitionWorkflow, RestoreInput{Year: 2026, Month: 5})
+
+	if env.GetWorkflowError() == nil {
+		t.Fatal("expected workflow error, got nil")
+	}
+}
+
+func TestRestorePartitionWorkflow_checksumMismatchSurfaces(t *testing.T) {
+	s := &testsuite.WorkflowTestSuite{}
+	env := s.NewTestWorkflowEnvironment()
+	env.RegisterWorkflow(RestorePartitionWorkflow)
+	registerRestoreActivityStubs(env)
+
+	env.OnActivity(ActivityNameFetchManifest, mock.Anything, mock.Anything).Return(happyManifest(), nil)
+	env.OnActivity(ActivityNameVerifyChecksum, mock.Anything, mock.Anything).
+		Return(temporal.NewNonRetryableApplicationError(
+			"verify checksum: parquet checksum mismatch", "ErrChecksumMismatch", ErrChecksumMismatch))
+
+	env.ExecuteWorkflow(RestorePartitionWorkflow, RestoreInput{Year: 2026, Month: 5})
+
+	if env.GetWorkflowError() == nil {
+		t.Fatal("expected workflow error from checksum mismatch")
+	}
+}
+
+func TestRestorePartitionWorkflow_loadFailureTriggersDropCompensation(t *testing.T) {
+	s := &testsuite.WorkflowTestSuite{}
+	env := s.NewTestWorkflowEnvironment()
+	env.RegisterWorkflow(RestorePartitionWorkflow)
+	registerRestoreActivityStubs(env)
+
+	env.OnActivity(ActivityNameFetchManifest, mock.Anything, mock.Anything).Return(happyManifest(), nil)
+	env.OnActivity(ActivityNameVerifyChecksum, mock.Anything, mock.Anything).Return(nil)
+	env.OnActivity(ActivityNameDownloadDecrypt, mock.Anything, mock.Anything).
+		Return(DownloadDecryptResult{PlaintextPath: "/tmp/p.parquet"}, nil)
+
+	loadErr := temporal.NewNonRetryableApplicationError(
+		"load quarantine: copy: pg: out of disk", "PgError", errors.New("disk full"))
+	env.OnActivity(ActivityNameLoadQuarantine, mock.Anything, mock.Anything).
+		Return(LoadQuarantineResult{}, loadErr)
+	dropCalls := 0
+	env.OnActivity(ActivityNameDropQuarantine, mock.Anything,
+		DropQuarantineInput{Year: 2026, Month: 5}).
+		Run(func(args mock.Arguments) { dropCalls++ }).Return(nil)
+
+	env.ExecuteWorkflow(RestorePartitionWorkflow, RestoreInput{Year: 2026, Month: 5})
+
+	if env.GetWorkflowError() == nil {
+		t.Fatal("expected workflow error from load failure")
+	}
+	if dropCalls != 1 {
+		t.Errorf("DropQuarantine calls=%d want 1 (compensation)", dropCalls)
+	}
+}
+
+func TestRestorePartitionWorkflow_invalidInputRejected(t *testing.T) {
+	cases := []struct {
+		name string
+		in   RestoreInput
+	}{
+		{"zero", RestoreInput{}},
+		{"yearTooLow", RestoreInput{Year: 2025, Month: 5}},
+		{"yearTooHigh", RestoreInput{Year: 2100, Month: 5}},
+		{"monthZero", RestoreInput{Year: 2026, Month: 0}},
+		{"monthThirteen", RestoreInput{Year: 2026, Month: 13}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s := &testsuite.WorkflowTestSuite{}
+			env := s.NewTestWorkflowEnvironment()
+			env.RegisterWorkflow(RestorePartitionWorkflow)
+			env.ExecuteWorkflow(RestorePartitionWorkflow, tc.in)
+			if env.GetWorkflowError() == nil {
+				t.Errorf("expected error for invalid input %+v", tc.in)
+			}
+		})
+	}
+}
+
+func TestParseKEKVersion(t *testing.T) {
+	cases := map[string]int{
+		"platform-billing-v1":  1,
+		"platform-billing-v42": 42,
+		"stub-v0":              0,
+		"":                     0,
+		"platform-billing-vXX": 0,
+	}
+	for in, want := range cases {
+		if got := parseKEKVersion(in); got != want {
+			t.Errorf("parseKEKVersion(%q)=%d want %d", in, got, want)
+		}
+	}
+}
+
+// jsonMarshalManifest is a helper so the activity tests can seed a stub
+// object store with a realistic manifest payload.
+func jsonMarshalManifest(m archiveManifest) []byte {
+	b, _ := json.Marshal(m)
+	return b
+}

--- a/plane/workflow/billing/verify_checksum_activity.go
+++ b/plane/workflow/billing/verify_checksum_activity.go
@@ -1,0 +1,74 @@
+package billing
+
+import (
+	"context"
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+
+	"go.temporal.io/sdk/temporal"
+)
+
+// ActivityNameVerifyChecksum is the registered name for VerifyChecksumActivity.
+const ActivityNameVerifyChecksum = "billing.VerifyChecksum"
+
+// VerifyChecksumInput identifies the parquet + checksum sidecar pair to verify.
+type VerifyChecksumInput struct {
+	ParquetKey  string
+	ChecksumKey string
+}
+
+// VerifyChecksumActivity recomputes SHA-256 over the encrypted parquet object
+// and compares it to the sidecar checksum file. The hash is computed on the
+// encrypted bytes — the same way ExportActivity wrote it (h.Write(frame))
+// inside its encrypt loop. Verifying the encrypted bytes keeps the integrity
+// proof independent of the DEK; tampering surfaces here, before any decrypt
+// runs.
+type VerifyChecksumActivity struct {
+	store ObjectStore
+}
+
+// NewVerifyChecksumActivity returns a VerifyChecksumActivity.
+func NewVerifyChecksumActivity(store ObjectStore) (*VerifyChecksumActivity, error) {
+	if store == nil {
+		return nil, errors.New("billing.NewVerifyChecksumActivity: store is nil")
+	}
+	return &VerifyChecksumActivity{store: store}, nil
+}
+
+// ErrChecksumMismatch is returned when the recomputed SHA-256 does not match
+// the sidecar value. Surfaces as a non-retryable workflow error.
+var ErrChecksumMismatch = errors.New("billing/restore: parquet checksum mismatch")
+
+// Execute streams the encrypted parquet through SHA-256 and compares it to
+// the hex-encoded sidecar value.
+func (a *VerifyChecksumActivity) Execute(ctx context.Context, in VerifyChecksumInput) error {
+	expectedRaw, err := a.store.GetBytes(ctx, in.ChecksumKey)
+	if err != nil {
+		return fmt.Errorf("verify checksum: fetch sidecar: %w", err)
+	}
+	expected := strings.TrimSpace(string(expectedRaw))
+
+	body, err := a.store.Download(ctx, in.ParquetKey)
+	if err != nil {
+		return fmt.Errorf("verify checksum: download parquet: %w", err)
+	}
+	defer func() { _ = body.Close() }()
+
+	h := sha256.New()
+	if _, err := io.Copy(h, body); err != nil {
+		return fmt.Errorf("verify checksum: hash stream: %w", err)
+	}
+	actual := fmt.Sprintf("%x", h.Sum(nil))
+	if actual != expected {
+		return temporal.NewNonRetryableApplicationError(
+			fmt.Sprintf("%v: expected=%s actual=%s key=%s",
+				ErrChecksumMismatch, expected, actual, in.ParquetKey),
+			"ErrChecksumMismatch",
+			ErrChecksumMismatch,
+		)
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary

- New `RestorePartitionWorkflow` on `QueueBillingMaintenance`: FetchManifest → VerifyChecksum → DownloadAndDecrypt → LoadIntoQuarantine, with `DropQuarantineActivity` compensation on load failure.
- New chunked-frame decoder (`restore_decoder.go`) — exact inverse of `ExportActivity`'s encrypt loop: `[4-byte BE payload_len][12-byte nonce][GCM ciphertext+tag]`, AAD `<source_partition>:<chunk_index>`, format-pinned to `aes-256-gcm-v1-4mib`.
- Restore writes only to `billing.usage_events_restore_YYYY_MM` (quarantine namespace outside the live partition tree) and seals the table read-only after load (ADR-018 §Restore, ADR-019 amendment).
- Spec: `docs/superpowers/specs/2026-05-08-issue-79-restore-partition-design.md`
- Plan: `docs/superpowers/plans/2026-05-08-issue-79-restore-partition-plan.md`
- Runbook: `docs/runbooks/billing-partition-restore.md` (documents Vault key-version pinning limitation as a follow-up)

## ADRs

- ADR-018 §Restore path (encrypted parquet, manifest, sidecar checksum, quarantine table)
- ADR-019 amendment (workflow plane importing data plane is permitted for read paths and quarantine-only DDL)
- ADR-003 (workflow body is purely deterministic; all I/O in activities; non-retryable errors short-circuit retry policy)

## Test plan

- [x] Decoder unit tests: round-trip single + multi-chunk, wrong AAD, wrong DEK, truncated payload, truncated length prefix, length-prefix bounds, empty stream
- [x] Per-activity unit tests using stub `ObjectStore` + `StubRestorer` (kek_hint mismatch, scratch cleanup on tamper, ensure→load→seal ordering)
- [x] Workflow testsuite: happy path, unsupported `enc_format`, manifest missing (non-retryable), checksum mismatch, load failure triggers drop compensation, input validation
- [x] Integration round-trip test (`//go:build integration`): Postgres + Vault testcontainers, archive → restore, assert quarantine row set matches seeded rows by `(id, ts)` and table is sealed read-only
- [x] `go test ./...` clean
- [x] `bash plane/workflow/lint/lint-determinism.sh` clean
- [x] `make lint-md` clean

Closes #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)