### PR TITLE
[Workflow] Per-month DEK destruction workflow (post-7y retention enforcement)

### DIFF
--- a/cmd/workflow-worker/main.go
+++ b/cmd/workflow-worker/main.go
@@ -36,6 +36,7 @@ import (
 	"github.com/gitscale-platform/gitscale/plane/data/outbox"
 	"github.com/gitscale-platform/gitscale/plane/data/store"
 	billingstore "github.com/gitscale-platform/gitscale/plane/data/store/billing"
+	pgstore "github.com/gitscale-platform/gitscale/plane/data/store/postgres"
 	gswf "github.com/gitscale-platform/gitscale/plane/workflow"
 	"github.com/gitscale-platform/gitscale/plane/workflow/appclient"
 	"github.com/gitscale-platform/gitscale/plane/workflow/billing"
@@ -295,7 +296,67 @@ func run(logger *slog.Logger) error {
 			logger.Info("billing restore deps wired", "scratch_dir", scratchDir)
 		}
 
-		billing.Bundle(partActivity, archiveDeps, restoreDeps).Apply(workerRegistrar{w})
+		// DEKDestructionDeps wiring (#80, ADR-018 §Encryption + ADR-015).
+		// Only wired when archive deps are present (it depends on the same
+		// Vault + S3 + billing-service surfaces). Operator approval is
+		// stubbed with auto-approve until ADR-015 wiring lands; legal-hold
+		// uses a static-not-held checker until S3 Object Lock integration
+		// ships. Both gaps are documented in the runbook.
+		var dekDeps *billing.DEKDestructionDeps
+		if archiveDeps != nil {
+			vaultClient, err := billing.LoadVaultClientFromEnv()
+			if err != nil {
+				return fmt.Errorf("vault client (dek destroy): %w", err)
+			}
+			destroy, err := billing.NewDestroyDEKActivity(vaultClient,
+				envDefault("VAULT_TRANSIT_MOUNT", ""),
+				envDefault("VAULT_BILLING_KEY", ""),
+			)
+			if err != nil {
+				return fmt.Errorf("destroy dek activity: %w", err)
+			}
+
+			s3Ctx2, cancelS3b := context.WithTimeout(context.Background(), 10*time.Second)
+			s3client, err := buildS3ClientFromEnv(s3Ctx2)
+			cancelS3b()
+			if err != nil {
+				return fmt.Errorf("s3 client (dek destroy): %w", err)
+			}
+			dekObjStore := billing.NewS3ObjectStore(s3client, os.Getenv("S3_BUCKET"))
+			resolver, err := billing.NewManifestKEKHintResolver(dekObjStore, os.Getenv("S3_BUCKET"))
+			if err != nil {
+				return fmt.Errorf("manifest resolver: %w", err)
+			}
+			ms := pgstore.New(pool)
+			listAct, err := billing.NewListEligiblePartitionsActivity(ms, resolver)
+			if err != nil {
+				return fmt.Errorf("list eligible partitions activity: %w", err)
+			}
+			holdAct, err := billing.NewCheckLegalHoldActivity(billing.NewStaticLegalHoldChecker(false, ""))
+			if err != nil {
+				return fmt.Errorf("legal hold activity: %w", err)
+			}
+			approvalAct := billing.NewRequestOperatorApprovalActivity(billing.NewAutoApproveStub())
+
+			billingClient := appclient.NewGRPCBillingClient(billingConn)
+			emitDEK, err := billing.NewEmitDEKDestroyedActivity(billingClient)
+			if err != nil {
+				return fmt.Errorf("emit dek destroyed activity: %w", err)
+			}
+			dekDeps = &billing.DEKDestructionDeps{
+				List:      listAct,
+				LegalHold: holdAct,
+				Approval:  approvalAct,
+				Destroy:   destroy,
+				Emit:      emitDEK,
+			}
+			logger.Info("billing dek-destruction deps wired",
+				"bucket", os.Getenv("S3_BUCKET"))
+		} else {
+			logger.Info("archive deps absent; skipping DEK-destruction deps + schedule")
+		}
+
+		billing.Bundle(partActivity, archiveDeps, restoreDeps, dekDeps).Apply(workerRegistrar{w})
 
 		// Outbox TTL expirer (#45, ADR-008): one Expirer per domain, dispatched
 		// by a single fan-out workflow on the same task queue.
@@ -334,6 +395,21 @@ func run(logger *slog.Logger) error {
 			logger.Info("billing partition-archive registered",
 				"schedule_id", billing.ArchiveScheduleID,
 				"cron", billing.ArchiveCronExpression)
+		}
+
+		// Register / converge the monthly DEK destruction schedule when the
+		// DEK deps are wired (#80, ADR-018 §Encryption). Schedule targets
+		// DEKDestructionRouterWorkflow which computes the cutoff at fire time.
+		if dekDeps != nil {
+			ctxDEK, cancelDEK := context.WithTimeout(context.Background(), 10*time.Second)
+			_, err = billing.EnsureDEKDestructionSchedule(ctxDEK, c.ScheduleClient())
+			cancelDEK()
+			if err != nil {
+				return fmt.Errorf("billing.EnsureDEKDestructionSchedule: %w", err)
+			}
+			logger.Info("billing dek-destruction registered",
+				"schedule_id", billing.DEKDestructionScheduleID,
+				"cron", billing.DEKDestructionCronExpression)
 		}
 	} else {
 		logger.Info("POSTGRES_URL unset; skipping billing.Bundle + rollover schedule")

--- a/docs/runbooks/billing-dek-destruction.md
+++ b/docs/runbooks/billing-dek-destruction.md
@@ -1,0 +1,128 @@
+# Runbook: Billing DEK destruction (crypto-shred)
+
+> Issue #80, ADR-018 §Encryption, ADR-015 (operator approval).
+
+## Summary
+
+`DEKDestructionWorkflow` (workflow plane, task queue
+`billing-maintenance`) destroys per-month Vault transit key versions for
+billing partition archives that are at least **7 years + 30 days** old.
+The destruction is irreversible by design — once the key version is
+trimmed, the encrypted parquet on the analytics lake can never be
+decrypted again.
+
+The workflow runs monthly: `DEKDestructionRouterWorkflow` is the
+schedule target (cron `0 2 1 * *` UTC) and computes the cutoff at fire
+time, then spawns `DEKDestructionWorkflow` as a child.
+
+## Pre-flight
+
+Before each scheduled run:
+
+1. Confirm the legal-hold review queue is empty. Any partition under a
+   hold MUST be excluded; see [Legal-hold override](#legal-hold-override).
+2. Confirm the Vault transit key `platform-billing-master` has
+   `deletion_allowed=true` and `min_decryption_version` is monotonic
+   non-decreasing. The activity bumps `min_decryption_version` and then
+   trims; both fail if `deletion_allowed=false`.
+3. Confirm the operator-approval channel is staffed (see
+   [Operator approval](#operator-approval)).
+
+## Schedule cadence
+
+- Schedule ID: `billing-dek-destruction`
+- Cron: `0 2 1 * *` (UTC) — 1st of every month at 02:00 UTC
+- Retention: 7 years + 30 days (`DEKDestructionRetentionDays = 365*7 + 30`)
+- Task queue: `billing-maintenance`
+
+The 02:00 UTC fire time is chosen to land well after the 24th-of-month
+partition rollover (12:00 UTC) and archive (14:00 UTC) schedules so any
+prior cleanup work has settled.
+
+## Operator approval
+
+Per ADR-015, every irreversible action gates on operator approval. The
+`RequestOperatorApprovalActivity` boundary takes an `OperatorApprover`
+implementation; production wiring depends on the ADR-015 mechanism
+landing.
+
+**Current state (until ADR-015 is implemented):**
+`cmd/workflow-worker` wires `AutoApproveStub`, which auto-approves every
+request and emits a structured warning log:
+
+```text
+DEK-destruction operator-approval auto-approved (ADR-015 stub)
+  year=2027 month=1 partition_name=billing.usage_events_2027_01
+  kek_hint=platform-billing-v3
+```
+
+**Operator mitigation while the stub is in use:**
+
+- Pause the schedule before each natural fire window:
+  `temporal schedule pause --schedule-id billing-dek-destruction
+  --reason "manual review window"`
+- Review the candidate set out-of-band; resume only after sign-off:
+  `temporal schedule unpause --schedule-id billing-dek-destruction`
+- Audit emit events after each run by querying
+  `billing.billing_outbox WHERE event_type = 'billing.partition_dek_destroyed'`.
+
+**Replacement plan:** swap `AutoApproveStub` for the real ADR-015
+approver in `cmd/workflow-worker/main.go`. The boundary
+`OperatorApprover` interface stays the same; no workflow change required.
+
+## Legal-hold override
+
+`CheckLegalHoldActivity` consults a `LegalHoldChecker`. Production wiring
+is staged behind a static-not-held checker
+(`NewStaticLegalHoldChecker(false, "")`) until the S3-Object-Lock-backed
+implementation lands.
+
+**To add a partition to the hold list (delays destruction):**
+
+Until the real checker ships, hold a partition by **pausing the
+schedule** before the run. Once the real checker is wired (S3 Object
+Lock or a dedicated legal-hold metadata table), the override path is to
+flip the corresponding object's lock state at the bucket level; the
+workflow will record the hold in `Result.Skipped` as
+`<year>-<month>-<partition_name>: legal_hold:<reason>`.
+
+## Recovery
+
+**There is no recovery.** Crypto-shred is irreversible by design. Once
+`min_available_version` advances past a target version, the DEK
+material is permanently deleted from Vault. The encrypted parquet and
+its manifest remain on the analytics lake for forensic reference, but
+the ciphertext is unrecoverable.
+
+If a destruction was made in error:
+
+1. The audit event lives in `billing.billing_outbox` with payload
+   `{kek_hint, vault_key_version, destroyed_at, ...}`. Reconstruct the
+   incident timeline from there.
+2. The encrypted parquet remains at the lake URI; a future legal review
+   can reference what was held but not what it contained.
+3. File a postmortem; tighten the operator-approval gate.
+
+## Workflow result schema
+
+`DEKDestructionResult.Skipped` is a per-partition string slice. Each
+entry is `<YYYY-MM-partition_name>: <reason>`. Reasons:
+
+| Reason | Meaning |
+|---|---|
+| `missing_kek_hint` | Manifest could not be resolved or had no `kek_hint`; backfill the manifest. |
+| `legal_hold:<r>` | Partition held; skipped until the hold is lifted. |
+| `legal_hold_error:<e>` | Hold check itself errored; investigate. |
+| `approval_rejected:<r>` | Operator rejected the partition; will retry on the next run. |
+| `approval_error:<e>` | Approval boundary errored; investigate. |
+| `destroy_error:<e>` | Vault trim failed; activity will retry per `DefaultRetryPolicy`, then surface here. |
+| `emit_error:<e>` | Destruction succeeded but the audit event did not land. **`KeysDestroyed` still increments** because the irreversible side effect happened — manually replay the emit via direct gRPC call or DB insert. |
+
+## Related
+
+- ADR-018 §Encryption — crypto-shred mandate
+- ADR-015 — operator approval for irreversible actions
+- ADR-008 — outbox pattern (audit event)
+- ADR-019 — application-plane state-mutation boundary
+- Source: `plane/workflow/billing/dek_destruction_workflow.go`
+- Schedule: `plane/workflow/billing/dek_destruction_schedules.go`

--- a/docs/superpowers/plans/2026-05-08-issue-80-dek-destruction-plan.md
+++ b/docs/superpowers/plans/2026-05-08-issue-80-dek-destruction-plan.md
@@ -1,0 +1,47 @@
+# Issue #80 DEK destruction workflow — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:subagent-driven-development.
+
+**Goal:** Implement `DEKDestructionWorkflow` that destroys per-month Vault transit key versions for archives ≥ 7y + 30d old, with legal-hold + operator-approval gates, idempotent on `(year, month)`.
+
+**Spec:** `docs/superpowers/specs/2026-05-08-issue-80-dek-destruction-design.md`
+
+**Branch:** `feat/workflow-dek-destruction`
+
+---
+
+## File map
+
+### Create
+- `plane/workflow/billing/dek_destruction_workflow.go`
+- `plane/workflow/billing/dek_destruction_router_workflow.go`
+- `plane/workflow/billing/dek_destruction_workflow_test.go`
+- `plane/workflow/billing/list_eligible_partitions_activity.go`
+- `plane/workflow/billing/check_legal_hold_activity.go`
+- `plane/workflow/billing/request_operator_approval_activity.go`
+- `plane/workflow/billing/destroy_dek_activity.go`
+- `plane/workflow/billing/emit_dek_destroyed_activity.go`
+- `plane/workflow/billing/dek_destruction_schedules.go`
+- `plane/workflow/billing/dek_destruction_workflow_integration_test.go`
+- `docs/runbooks/billing-dek-destruction.md`
+
+### Modify
+- `plane/workflow/billing/bundle.go` — `DEKDestructionDeps` field; register
+- `cmd/workflow-worker/main.go` — wire deps + schedule in env-gated block (#76)
+- `plane/application/billing/events.go` — add `EventTypePartitionDEKDestroyed` constant + payload
+- `plane/application/billing/postgres_service.go` — handler for new event type (delegates to outbox write only — no source row needed; the destruction itself is the side effect)
+
+---
+
+## Tasks (compressed)
+
+1. **Schema-side payload + service:** add `partition_dek_destroyed` event type and a thin `RecordDEKDestroyed` RPC in `plane/application/billing` that writes only an outbox row (no source-row update — the destruction is recorded by absence of the key, plus the audit event).
+2. **List/check/approve activities:** unit-test each with stubs.
+3. **DestroyDEK activity:** Vault `transit/keys/<key>/<version>/destroy`. Idempotent: 404 returns nil. Unit-test against fake `vault.Client`.
+4. **EmitDEKDestroyed activity:** calls `BillingClient.RecordDEKDestroyed` (new RPC).
+5. **Workflow body:** deterministic iteration over eligible partitions; per-partition activity chain; `Result.Skipped` accumulation. Workflow testsuite verifies happy + each skip path (held / rejected / vault-error).
+6. **Router workflow + schedule:** mirrors #76's ArchiveRouter pattern.
+7. **Worker wiring:** mirror #76 env-gated block.
+8. **Integration test:** Vault testcontainer with versioned key; assert version destroyed + outbox row written.
+9. **Runbook:** docs/runbooks/billing-dek-destruction.md.
+10. **Final gates:** test sweep, skills (`gitscale-temporal-determinism`, `gitscale-go-conventions`, `gitscale-plane-boundary`, `gitscale-outbox-check`, `gitscale-adr-guard`), self-review battery, push, PR. Closes #80.

--- a/docs/superpowers/specs/2026-05-08-issue-80-dek-destruction-design.md
+++ b/docs/superpowers/specs/2026-05-08-issue-80-dek-destruction-design.md
@@ -1,0 +1,124 @@
+# Spec — Issue #80 Per-month DEK destruction workflow
+
+Date: 2026-05-08
+Issue: #80
+Plane: workflow
+Priority: p3 (Wave 2; deps #76, soft-gates on #75 KeyProvider)
+ADR-impact: conforming (ADR-018 §Encryption / crypto-shred; ADR-015 operator
+approval)
+
+## Goals
+
+1. Monthly scheduled workflow that identifies partitions ≥ 7y + 30d old
+   and destroys their per-month Vault transit key version (crypto-shred).
+2. Pre-flight legal-hold check (S3 prefix lifecycle status).
+3. Operator-approval gate (per ADR-015) before the irreversible
+   `vault transit/keys/<key>/<version>/destroy` call.
+4. Outbox event `billing.partition_dek_destroyed` for audit trail.
+5. Idempotent on `(year, month)` via Temporal workflow ID.
+
+## Non-goals
+
+- Modifying the legal-hold mechanism itself (assumes S3 Object Lock or a
+  Legal-Hold prefix is already configured at the bucket level).
+- Destroying entire transit keys (only specific versions per ADR-018).
+- Restoring a destroyed DEK (impossible by design).
+
+## Architecture
+
+### Workflow
+
+`plane/workflow/billing/dek_destruction_workflow.go`:
+
+```go
+const DEKDestructionWorkflowName = "billing.DEKDestructionWorkflow"
+
+type DEKDestructionInput struct {
+    RunTime time.Time // bound at fire time by the schedule (cmd-level)
+}
+
+type DEKDestructionResult struct {
+    PartitionsScanned int
+    KeysDestroyed     int
+    Skipped           []string // reason per skip
+}
+
+func DEKDestructionWorkflow(ctx workflow.Context, in DEKDestructionInput) (DEKDestructionResult, error)
+```
+
+Activity sequence:
+
+1. `ListEligiblePartitionsActivity(ctx, cutoff)` — scans
+   `billing.partition_archives` for rows where `archived_at < now() - 7y -
+   30d`. Returns `[]PartitionArchive`.
+2. `CheckLegalHoldActivity(ctx, lakeURI)` — calls S3 GetObjectLockConfiguration
+   on the prefix; returns the legal-hold state. Skip the partition if
+   held; record reason.
+3. `RequestOperatorApprovalActivity(ctx, partitionList)` — uses the existing
+   ADR-015 approval mechanism (or stub for now; spec D9). On reject, abort
+   the run for that partition.
+4. `DestroyDEKActivity(ctx, year, month, kekHint)` — parses the version
+   from `kekHint` (`platform-billing-v<N>`) and calls Vault transit
+   `keys/<keyName>/<version>/destroy`. Idempotent: a missing version
+   returns success.
+5. `EmitDEKDestroyedEventActivity(ctx, partition)` — writes
+   `billing.partition_dek_destroyed` to billing_outbox via the
+   `BillingClient` gRPC (per ADR-019 boundary).
+
+The workflow body iterates the partition list deterministically; one
+activity sequence per eligible partition. Errors per partition do not
+abort the whole run — they are accumulated in `Result.Skipped`.
+
+### Schedule
+
+Monthly cron via `EnsureDEKDestructionSchedule(ctx, sc)`. Uses an
+`ArchiveRouterWorkflow`-style dynamic args computation via a thin router
+workflow that calls `workflow.Now(ctx)` and spawns the actual workflow
+with `RunTime` bound — same trick as #76's `ArchiveRouterWorkflow`.
+
+### Bundle + worker wiring
+
+`Bundle.DEKDestructionDeps`; register on `QueueBillingMaintenance`. Worker
+constructs activities in the env-gated archive block.
+
+### Integration test
+
+`plane/workflow/billing/dek_destruction_workflow_integration_test.go`
+(`//go:build integration`):
+
+- Boot Vault testcontainer with a versioned `platform-billing-master`.
+- Pre-create transit key + rotate to v2.
+- Seed `billing.partition_archives` row with `archived_at < cutoff`,
+  `kek_hint = "platform-billing-v1"`.
+- Run the workflow; auto-approve via stub.
+- Assert: Vault `key_version=1` is in `archive_keys` (destroyed), and the
+  outbox row exists.
+
+### Runbook
+
+`docs/runbooks/billing-dek-destruction.md`:
+
+- Pre-flight: confirm legal-hold review queue is empty.
+- Monthly schedule cadence (1st of month at 02:00 UTC).
+- Operator-approval mechanism: how to approve / reject per partition.
+- Legal-hold override: how to add a partition to the hold list (delays
+  destruction).
+- Recovery: NONE — once destroyed, the archive is unrecoverable. This is
+  the design intent.
+
+## Acceptance checklist
+
+- [ ] Workflow + 5 activities + router on `QueueBillingMaintenance`
+- [ ] Schedule registered via `EnsureDEKDestructionSchedule`
+- [ ] Operator-approval gate present (real or ADR-015 stub)
+- [ ] Outbox event emitted on success
+- [ ] testcontainers Vault integration test asserts versioned destroy
+- [ ] Runbook documents legal-hold override
+- [ ] PR description references ADR-018 + ADR-015
+
+## References
+
+- ADR-018 §Encryption / crypto-shred (`docs/architecture.md` line ~663)
+- ADR-015 (operator approval)
+- `plane/workflow/billing/vault_keyprovider.go` (#75)
+- `plane/workflow/billing/archive_router_workflow.go` (#76 pattern)

--- a/internal/proto/gitscale/billing/v1/billing.pb.go
+++ b/internal/proto/gitscale/billing/v1/billing.pb.go
@@ -161,6 +161,134 @@ func (x *RecordPartitionArchivedResponse) GetCreated() bool {
 	return false
 }
 
+type RecordDEKDestroyedRequest struct {
+	state           protoimpl.MessageState `protogen:"open.v1"`
+	Year            int32                  `protobuf:"varint,1,opt,name=year,proto3" json:"year,omitempty"`                                                // 2026..2100
+	Month           int32                  `protobuf:"varint,2,opt,name=month,proto3" json:"month,omitempty"`                                              // 1..12
+	PartitionName   string                 `protobuf:"bytes,3,opt,name=partition_name,json=partitionName,proto3" json:"partition_name,omitempty"`          // matching billing.partition_archives row
+	KekHint         string                 `protobuf:"bytes,4,opt,name=kek_hint,json=kekHint,proto3" json:"kek_hint,omitempty"`                            // e.g. "platform-billing-v3" — destroyed Vault key version
+	VaultKeyVersion int32                  `protobuf:"varint,5,opt,name=vault_key_version,json=vaultKeyVersion,proto3" json:"vault_key_version,omitempty"` // numeric N parsed from kek_hint
+	unknownFields   protoimpl.UnknownFields
+	sizeCache       protoimpl.SizeCache
+}
+
+func (x *RecordDEKDestroyedRequest) Reset() {
+	*x = RecordDEKDestroyedRequest{}
+	mi := &file_gitscale_billing_v1_billing_proto_msgTypes[2]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RecordDEKDestroyedRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RecordDEKDestroyedRequest) ProtoMessage() {}
+
+func (x *RecordDEKDestroyedRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_gitscale_billing_v1_billing_proto_msgTypes[2]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RecordDEKDestroyedRequest.ProtoReflect.Descriptor instead.
+func (*RecordDEKDestroyedRequest) Descriptor() ([]byte, []int) {
+	return file_gitscale_billing_v1_billing_proto_rawDescGZIP(), []int{2}
+}
+
+func (x *RecordDEKDestroyedRequest) GetYear() int32 {
+	if x != nil {
+		return x.Year
+	}
+	return 0
+}
+
+func (x *RecordDEKDestroyedRequest) GetMonth() int32 {
+	if x != nil {
+		return x.Month
+	}
+	return 0
+}
+
+func (x *RecordDEKDestroyedRequest) GetPartitionName() string {
+	if x != nil {
+		return x.PartitionName
+	}
+	return ""
+}
+
+func (x *RecordDEKDestroyedRequest) GetKekHint() string {
+	if x != nil {
+		return x.KekHint
+	}
+	return ""
+}
+
+func (x *RecordDEKDestroyedRequest) GetVaultKeyVersion() int32 {
+	if x != nil {
+		return x.VaultKeyVersion
+	}
+	return 0
+}
+
+type RecordDEKDestroyedResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	EventId       string                 `protobuf:"bytes,1,opt,name=event_id,json=eventId,proto3" json:"event_id,omitempty"` // UUID of outbox event row
+	Created       bool                   `protobuf:"varint,2,opt,name=created,proto3" json:"created,omitempty"`               // false on idempotent retry (event already emitted)
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *RecordDEKDestroyedResponse) Reset() {
+	*x = RecordDEKDestroyedResponse{}
+	mi := &file_gitscale_billing_v1_billing_proto_msgTypes[3]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RecordDEKDestroyedResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RecordDEKDestroyedResponse) ProtoMessage() {}
+
+func (x *RecordDEKDestroyedResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_gitscale_billing_v1_billing_proto_msgTypes[3]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RecordDEKDestroyedResponse.ProtoReflect.Descriptor instead.
+func (*RecordDEKDestroyedResponse) Descriptor() ([]byte, []int) {
+	return file_gitscale_billing_v1_billing_proto_rawDescGZIP(), []int{3}
+}
+
+func (x *RecordDEKDestroyedResponse) GetEventId() string {
+	if x != nil {
+		return x.EventId
+	}
+	return ""
+}
+
+func (x *RecordDEKDestroyedResponse) GetCreated() bool {
+	if x != nil {
+		return x.Created
+	}
+	return false
+}
+
 var File_gitscale_billing_v1_billing_proto protoreflect.FileDescriptor
 
 const file_gitscale_billing_v1_billing_proto_rawDesc = "" +
@@ -176,9 +304,19 @@ const file_gitscale_billing_v1_billing_proto_rawDesc = "" +
 	"\x1fRecordPartitionArchivedResponse\x12\x1d\n" +
 	"\n" +
 	"archive_id\x18\x01 \x01(\tR\tarchiveId\x12\x18\n" +
-	"\acreated\x18\x02 \x01(\bR\acreated2\x97\x01\n" +
+	"\acreated\x18\x02 \x01(\bR\acreated\"\xb3\x01\n" +
+	"\x19RecordDEKDestroyedRequest\x12\x12\n" +
+	"\x04year\x18\x01 \x01(\x05R\x04year\x12\x14\n" +
+	"\x05month\x18\x02 \x01(\x05R\x05month\x12%\n" +
+	"\x0epartition_name\x18\x03 \x01(\tR\rpartitionName\x12\x19\n" +
+	"\bkek_hint\x18\x04 \x01(\tR\akekHint\x12*\n" +
+	"\x11vault_key_version\x18\x05 \x01(\x05R\x0fvaultKeyVersion\"Q\n" +
+	"\x1aRecordDEKDestroyedResponse\x12\x19\n" +
+	"\bevent_id\x18\x01 \x01(\tR\aeventId\x12\x18\n" +
+	"\acreated\x18\x02 \x01(\bR\acreated2\x8e\x02\n" +
 	"\x0eBillingService\x12\x84\x01\n" +
-	"\x17RecordPartitionArchived\x123.gitscale.billing.v1.RecordPartitionArchivedRequest\x1a4.gitscale.billing.v1.RecordPartitionArchivedResponseB\xe0\x01\n" +
+	"\x17RecordPartitionArchived\x123.gitscale.billing.v1.RecordPartitionArchivedRequest\x1a4.gitscale.billing.v1.RecordPartitionArchivedResponse\x12u\n" +
+	"\x12RecordDEKDestroyed\x12..gitscale.billing.v1.RecordDEKDestroyedRequest\x1a/.gitscale.billing.v1.RecordDEKDestroyedResponseB\xe0\x01\n" +
 	"\x17com.gitscale.billing.v1B\fBillingProtoP\x01ZIgithub.com/gitscale-platform/gitscale/internal/proto/billing/v1;billingv1\xa2\x02\x03GBX\xaa\x02\x13Gitscale.Billing.V1\xca\x02\x13Gitscale\\Billing\\V1\xe2\x02\x1fGitscale\\Billing\\V1\\GPBMetadata\xea\x02\x15Gitscale::Billing::V1b\x06proto3"
 
 var (
@@ -193,16 +331,20 @@ func file_gitscale_billing_v1_billing_proto_rawDescGZIP() []byte {
 	return file_gitscale_billing_v1_billing_proto_rawDescData
 }
 
-var file_gitscale_billing_v1_billing_proto_msgTypes = make([]protoimpl.MessageInfo, 2)
+var file_gitscale_billing_v1_billing_proto_msgTypes = make([]protoimpl.MessageInfo, 4)
 var file_gitscale_billing_v1_billing_proto_goTypes = []any{
 	(*RecordPartitionArchivedRequest)(nil),  // 0: gitscale.billing.v1.RecordPartitionArchivedRequest
 	(*RecordPartitionArchivedResponse)(nil), // 1: gitscale.billing.v1.RecordPartitionArchivedResponse
+	(*RecordDEKDestroyedRequest)(nil),       // 2: gitscale.billing.v1.RecordDEKDestroyedRequest
+	(*RecordDEKDestroyedResponse)(nil),      // 3: gitscale.billing.v1.RecordDEKDestroyedResponse
 }
 var file_gitscale_billing_v1_billing_proto_depIdxs = []int32{
 	0, // 0: gitscale.billing.v1.BillingService.RecordPartitionArchived:input_type -> gitscale.billing.v1.RecordPartitionArchivedRequest
-	1, // 1: gitscale.billing.v1.BillingService.RecordPartitionArchived:output_type -> gitscale.billing.v1.RecordPartitionArchivedResponse
-	1, // [1:2] is the sub-list for method output_type
-	0, // [0:1] is the sub-list for method input_type
+	2, // 1: gitscale.billing.v1.BillingService.RecordDEKDestroyed:input_type -> gitscale.billing.v1.RecordDEKDestroyedRequest
+	1, // 2: gitscale.billing.v1.BillingService.RecordPartitionArchived:output_type -> gitscale.billing.v1.RecordPartitionArchivedResponse
+	3, // 3: gitscale.billing.v1.BillingService.RecordDEKDestroyed:output_type -> gitscale.billing.v1.RecordDEKDestroyedResponse
+	2, // [2:4] is the sub-list for method output_type
+	0, // [0:2] is the sub-list for method input_type
 	0, // [0:0] is the sub-list for extension type_name
 	0, // [0:0] is the sub-list for extension extendee
 	0, // [0:0] is the sub-list for field type_name
@@ -219,7 +361,7 @@ func file_gitscale_billing_v1_billing_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_gitscale_billing_v1_billing_proto_rawDesc), len(file_gitscale_billing_v1_billing_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   2,
+			NumMessages:   4,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/internal/proto/gitscale/billing/v1/billing.proto
+++ b/internal/proto/gitscale/billing/v1/billing.proto
@@ -15,6 +15,16 @@ service BillingService {
   // the same Tx. Idempotent on (year, month, partition_name).
   rpc RecordPartitionArchived(RecordPartitionArchivedRequest)
       returns (RecordPartitionArchivedResponse);
+
+  // RecordDEKDestroyed emits billing.partition_dek_destroyed to the outbox
+  // for audit trail after the DEK destruction workflow (#80) successfully
+  // destroys a per-month Vault transit key version. The destruction itself
+  // is the source of truth — there is no source row to update; the outbox
+  // event is the only durable record that destruction occurred.
+  // Idempotent on (year, month, partition_name): repeated calls return the
+  // same event id and only the first call writes the outbox row.
+  rpc RecordDEKDestroyed(RecordDEKDestroyedRequest)
+      returns (RecordDEKDestroyedResponse);
 }
 
 message RecordPartitionArchivedRequest {
@@ -29,4 +39,17 @@ message RecordPartitionArchivedRequest {
 message RecordPartitionArchivedResponse {
   string archive_id = 1;  // UUID of partition_archives row (new or existing)
   bool   created    = 2;  // false on idempotent retry
+}
+
+message RecordDEKDestroyedRequest {
+  int32  year             = 1;  // 2026..2100
+  int32  month            = 2;  // 1..12
+  string partition_name   = 3;  // matching billing.partition_archives row
+  string kek_hint         = 4;  // e.g. "platform-billing-v3" — destroyed Vault key version
+  int32  vault_key_version = 5; // numeric N parsed from kek_hint
+}
+
+message RecordDEKDestroyedResponse {
+  string event_id = 1;  // UUID of outbox event row
+  bool   created  = 2;  // false on idempotent retry (event already emitted)
 }

--- a/internal/proto/gitscale/billing/v1/billing_grpc.pb.go
+++ b/internal/proto/gitscale/billing/v1/billing_grpc.pb.go
@@ -24,6 +24,7 @@ const _ = grpc.SupportPackageIsVersion9
 
 const (
 	BillingService_RecordPartitionArchived_FullMethodName = "/gitscale.billing.v1.BillingService/RecordPartitionArchived"
+	BillingService_RecordDEKDestroyed_FullMethodName      = "/gitscale.billing.v1.BillingService/RecordDEKDestroyed"
 )
 
 // BillingServiceClient is the client API for BillingService service.
@@ -37,6 +38,14 @@ type BillingServiceClient interface {
 	// monthly partition and emits billing.partition_archived to the outbox in
 	// the same Tx. Idempotent on (year, month, partition_name).
 	RecordPartitionArchived(ctx context.Context, in *RecordPartitionArchivedRequest, opts ...grpc.CallOption) (*RecordPartitionArchivedResponse, error)
+	// RecordDEKDestroyed emits billing.partition_dek_destroyed to the outbox
+	// for audit trail after the DEK destruction workflow (#80) successfully
+	// destroys a per-month Vault transit key version. The destruction itself
+	// is the source of truth — there is no source row to update; the outbox
+	// event is the only durable record that destruction occurred.
+	// Idempotent on (year, month, partition_name): repeated calls return the
+	// same event id and only the first call writes the outbox row.
+	RecordDEKDestroyed(ctx context.Context, in *RecordDEKDestroyedRequest, opts ...grpc.CallOption) (*RecordDEKDestroyedResponse, error)
 }
 
 type billingServiceClient struct {
@@ -57,6 +66,16 @@ func (c *billingServiceClient) RecordPartitionArchived(ctx context.Context, in *
 	return out, nil
 }
 
+func (c *billingServiceClient) RecordDEKDestroyed(ctx context.Context, in *RecordDEKDestroyedRequest, opts ...grpc.CallOption) (*RecordDEKDestroyedResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(RecordDEKDestroyedResponse)
+	err := c.cc.Invoke(ctx, BillingService_RecordDEKDestroyed_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // BillingServiceServer is the server API for BillingService service.
 // All implementations must embed UnimplementedBillingServiceServer
 // for forward compatibility.
@@ -68,6 +87,14 @@ type BillingServiceServer interface {
 	// monthly partition and emits billing.partition_archived to the outbox in
 	// the same Tx. Idempotent on (year, month, partition_name).
 	RecordPartitionArchived(context.Context, *RecordPartitionArchivedRequest) (*RecordPartitionArchivedResponse, error)
+	// RecordDEKDestroyed emits billing.partition_dek_destroyed to the outbox
+	// for audit trail after the DEK destruction workflow (#80) successfully
+	// destroys a per-month Vault transit key version. The destruction itself
+	// is the source of truth — there is no source row to update; the outbox
+	// event is the only durable record that destruction occurred.
+	// Idempotent on (year, month, partition_name): repeated calls return the
+	// same event id and only the first call writes the outbox row.
+	RecordDEKDestroyed(context.Context, *RecordDEKDestroyedRequest) (*RecordDEKDestroyedResponse, error)
 	mustEmbedUnimplementedBillingServiceServer()
 }
 
@@ -80,6 +107,9 @@ type UnimplementedBillingServiceServer struct{}
 
 func (UnimplementedBillingServiceServer) RecordPartitionArchived(context.Context, *RecordPartitionArchivedRequest) (*RecordPartitionArchivedResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method RecordPartitionArchived not implemented")
+}
+func (UnimplementedBillingServiceServer) RecordDEKDestroyed(context.Context, *RecordDEKDestroyedRequest) (*RecordDEKDestroyedResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method RecordDEKDestroyed not implemented")
 }
 func (UnimplementedBillingServiceServer) mustEmbedUnimplementedBillingServiceServer() {}
 func (UnimplementedBillingServiceServer) testEmbeddedByValue()                        {}
@@ -120,6 +150,24 @@ func _BillingService_RecordPartitionArchived_Handler(srv interface{}, ctx contex
 	return interceptor(ctx, in, info, handler)
 }
 
+func _BillingService_RecordDEKDestroyed_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(RecordDEKDestroyedRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(BillingServiceServer).RecordDEKDestroyed(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: BillingService_RecordDEKDestroyed_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(BillingServiceServer).RecordDEKDestroyed(ctx, req.(*RecordDEKDestroyedRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // BillingService_ServiceDesc is the grpc.ServiceDesc for BillingService service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -130,6 +178,10 @@ var BillingService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "RecordPartitionArchived",
 			Handler:    _BillingService_RecordPartitionArchived_Handler,
+		},
+		{
+			MethodName: "RecordDEKDestroyed",
+			Handler:    _BillingService_RecordDEKDestroyed_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},

--- a/plane/application/billing/events.go
+++ b/plane/application/billing/events.go
@@ -10,6 +10,11 @@ import (
 // when a usage_events partition has been successfully archived to the data lake.
 const EventTypePartitionArchived = "billing.partition_archived"
 
+// EventTypePartitionDEKDestroyed is the event_type written to billing.billing_outbox
+// after the DEK destruction workflow (#80) destroys a per-month Vault transit key
+// version. Crypto-shred is irreversible — the outbox event is the audit record.
+const EventTypePartitionDEKDestroyed = "billing.partition_dek_destroyed"
+
 // envelopeVersion is the schema version of PartitionArchivedPayload. Bump when
 // the payload shape changes in a way consumers need to disambiguate.
 const envelopeVersion = 1
@@ -26,6 +31,38 @@ type PartitionArchivedPayload struct {
 	BytesWritten    int64     `json:"bytes_written"`
 	ArchivedAt      time.Time `json:"archived_at"`
 	EnvelopeVersion int       `json:"_envelope_version"`
+}
+
+// PartitionDEKDestroyedPayload is the JSON payload written to the outbox when
+// a per-month DEK is crypto-shredded (#80). The payload pins the destroyed
+// Vault transit key version (kek_hint + numeric vault_key_version) so audit
+// consumers can correlate against the encrypted archive's manifest. The
+// destruction is the source of truth: there is no row update on
+// partition_archives — the event is the only durable record that destruction
+// occurred.
+type PartitionDEKDestroyedPayload struct {
+	Year             int       `json:"year"`
+	Month            int       `json:"month"`
+	PartitionName    string    `json:"partition_name"`
+	KEKHint          string    `json:"kek_hint"`
+	VaultKeyVersion  int       `json:"vault_key_version"`
+	DestroyedAt      time.Time `json:"destroyed_at"`
+	EnvelopeVersion  int       `json:"_envelope_version"`
+}
+
+// newPartitionDEKDestroyedPayload builds the outbox payload for a destroyed
+// per-month DEK. Only fields relevant to audit trail are included; key
+// material is never logged or persisted.
+func newPartitionDEKDestroyedPayload(in RecordDEKDestroyedInput, destroyedAt time.Time) PartitionDEKDestroyedPayload {
+	return PartitionDEKDestroyedPayload{
+		Year:            in.Year,
+		Month:           in.Month,
+		PartitionName:   in.PartitionName,
+		KEKHint:         in.KEKHint,
+		VaultKeyVersion: in.VaultKeyVersion,
+		DestroyedAt:     destroyedAt,
+		EnvelopeVersion: envelopeVersion,
+	}
 }
 
 // newPartitionArchivedPayload builds the outbox payload from the persisted

--- a/plane/application/billing/grpc_server.go
+++ b/plane/application/billing/grpc_server.go
@@ -43,6 +43,25 @@ func (s *GRPCServer) RecordPartitionArchived(ctx context.Context, req *billingv1
 	}, nil
 }
 
+// RecordDEKDestroyed translates the proto request into the service-level
+// input and maps domain errors to the documented gRPC code surface.
+func (s *GRPCServer) RecordDEKDestroyed(ctx context.Context, req *billingv1.RecordDEKDestroyedRequest) (*billingv1.RecordDEKDestroyedResponse, error) {
+	out, err := s.svc.RecordDEKDestroyed(ctx, RecordDEKDestroyedInput{
+		Year:            int(req.GetYear()),
+		Month:           int(req.GetMonth()),
+		PartitionName:   req.GetPartitionName(),
+		KEKHint:         req.GetKekHint(),
+		VaultKeyVersion: int(req.GetVaultKeyVersion()),
+	})
+	if err != nil {
+		return nil, mapErr(err)
+	}
+	return &billingv1.RecordDEKDestroyedResponse{
+		EventId: out.EventID,
+		Created: out.Created,
+	}, nil
+}
+
 // mapErr converts a billing domain error into a gRPC status. Validation
 // failures map to InvalidArgument; unknown errors are reported as Internal.
 func mapErr(err error) error {
@@ -51,7 +70,9 @@ func mapErr(err error) error {
 		errors.Is(err, ErrInvalidMonth),
 		errors.Is(err, ErrEmptyPartitionName),
 		errors.Is(err, ErrEmptyLakeURI),
-		errors.Is(err, ErrNegativeCount):
+		errors.Is(err, ErrNegativeCount),
+		errors.Is(err, ErrEmptyKEKHint),
+		errors.Is(err, ErrInvalidKeyVersion):
 		return status.Error(codes.InvalidArgument, err.Error())
 	default:
 		return status.Error(codes.Internal, err.Error())

--- a/plane/application/billing/models.go
+++ b/plane/application/billing/models.go
@@ -24,3 +24,24 @@ type RecordPartitionArchivedOutput struct {
 	ArchiveID string // UUID stringified
 	Created   bool
 }
+
+// RecordDEKDestroyedInput is the service-level input recording an irreversible
+// per-month DEK destruction (#80). KEKHint is the manifest hint
+// ("platform-billing-v<N>") and VaultKeyVersion is the parsed numeric N.
+// PartitionName mirrors billing.partition_archives.partition_name for the
+// row whose ciphertext is now unrecoverable.
+type RecordDEKDestroyedInput struct {
+	Year            int
+	Month           int
+	PartitionName   string
+	KEKHint         string
+	VaultKeyVersion int
+}
+
+// RecordDEKDestroyedOutput is the service-level output. Created is false on
+// idempotent retry (the outbox row for this (year,month,partition_name,
+// kek_hint) tuple was already emitted).
+type RecordDEKDestroyedOutput struct {
+	EventID string // UUID stringified
+	Created bool
+}

--- a/plane/application/billing/postgres_service.go
+++ b/plane/application/billing/postgres_service.go
@@ -2,6 +2,7 @@ package billing
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/gitscale-platform/gitscale/plane/data/store"
@@ -82,4 +83,55 @@ func (s *PostgresService) RecordPartitionArchived(ctx context.Context, in Record
 		return RecordPartitionArchivedOutput{}, err
 	}
 	return RecordPartitionArchivedOutput{ArchiveID: archiveID.String(), Created: created}, nil
+}
+
+// dekDestroyedNamespace anchors the deterministic UUID derivation for the
+// outbox aggregate_id of a billing.partition_dek_destroyed event. Stable
+// across versions; bump only when changing the natural-key shape.
+var dekDestroyedNamespace = uuid.MustParse("0e1d2c3b-4a59-6877-8695-a4b3c2d1e0f9")
+
+// dekDestroyedAggregateID derives a deterministic UUID v5 from the natural
+// key (year, month, partition_name, kek_hint). Same key inputs always yield
+// the same id, which lets HasOutboxEventForAggregate anchor idempotency.
+func dekDestroyedAggregateID(in RecordDEKDestroyedInput) uuid.UUID {
+	natural := fmt.Sprintf("%04d-%02d|%s|%s", in.Year, in.Month, in.PartitionName, in.KEKHint)
+	return uuid.NewSHA1(dekDestroyedNamespace, []byte(natural))
+}
+
+// RecordDEKDestroyed emits billing.partition_dek_destroyed to the outbox.
+// Validation runs before any Tx is opened. Idempotency is anchored on a
+// deterministic aggregate_id (UUIDv5 over the natural key); HasOutboxEventForAggregate
+// inside the Tx checks for an existing row before WriteOutbox writes a new one.
+// The outbox row is the only durable record — there is no source-row update
+// because the destruction itself (Vault transit trim) is the side effect.
+func (s *PostgresService) RecordDEKDestroyed(ctx context.Context, in RecordDEKDestroyedInput) (RecordDEKDestroyedOutput, error) {
+	if err := validateDEKDestroyedInput(in); err != nil {
+		return RecordDEKDestroyedOutput{}, err
+	}
+	aggregateID := dekDestroyedAggregateID(in)
+	destroyedAt := s.clock()
+	var created bool
+	err := s.store.Transact(ctx, func(tx store.Tx) error {
+		exists, err := tx.Billing().HasOutboxEventForAggregate(ctx, EventTypePartitionDEKDestroyed, aggregateID)
+		if err != nil {
+			return err
+		}
+		if exists {
+			created = false
+			return nil
+		}
+		created = true
+		return tx.WriteOutbox(
+			ctx,
+			store.DomainBilling,
+			"partition_dek",
+			aggregateID,
+			EventTypePartitionDEKDestroyed,
+			newPartitionDEKDestroyedPayload(in, destroyedAt),
+		)
+	})
+	if err != nil {
+		return RecordDEKDestroyedOutput{}, err
+	}
+	return RecordDEKDestroyedOutput{EventID: aggregateID.String(), Created: created}, nil
 }

--- a/plane/application/billing/service.go
+++ b/plane/application/billing/service.go
@@ -11,16 +11,24 @@ import (
 // reaches it through the gRPC surface (ADR-019).
 type Service interface {
 	RecordPartitionArchived(ctx context.Context, in RecordPartitionArchivedInput) (RecordPartitionArchivedOutput, error)
+
+	// RecordDEKDestroyed emits billing.partition_dek_destroyed to the outbox.
+	// The DEK destruction itself is the source of truth (Vault transit key
+	// version trim is irreversible); the outbox row is the audit record.
+	// Idempotent on the (year, month, partition_name, kek_hint) tuple.
+	RecordDEKDestroyed(ctx context.Context, in RecordDEKDestroyedInput) (RecordDEKDestroyedOutput, error)
 }
 
 // Sentinel validation errors. Wrapped with %w-friendly equality at the gRPC
 // layer where they map to InvalidArgument.
 var (
-	ErrInvalidYear        = errors.New("billing: year out of range (2026..2100)")
-	ErrInvalidMonth       = errors.New("billing: month out of range (1..12)")
-	ErrEmptyPartitionName = errors.New("billing: partition_name is empty")
-	ErrEmptyLakeURI       = errors.New("billing: lake_uri is empty")
-	ErrNegativeCount      = errors.New("billing: row_count or bytes_written is negative")
+	ErrInvalidYear         = errors.New("billing: year out of range (2026..2100)")
+	ErrInvalidMonth        = errors.New("billing: month out of range (1..12)")
+	ErrEmptyPartitionName  = errors.New("billing: partition_name is empty")
+	ErrEmptyLakeURI        = errors.New("billing: lake_uri is empty")
+	ErrNegativeCount       = errors.New("billing: row_count or bytes_written is negative")
+	ErrEmptyKEKHint        = errors.New("billing: kek_hint is empty")
+	ErrInvalidKeyVersion   = errors.New("billing: vault_key_version must be > 0")
 )
 
 // validateInput enforces the contract documented on RecordPartitionArchivedInput.
@@ -41,6 +49,28 @@ func validateInput(in RecordPartitionArchivedInput) error {
 	}
 	if in.RowCount < 0 || in.BytesWritten < 0 {
 		return ErrNegativeCount
+	}
+	return nil
+}
+
+// validateDEKDestroyedInput enforces the contract on RecordDEKDestroyedInput.
+// Validation runs before any Tx is opened so failed inputs never produce
+// outbox rows.
+func validateDEKDestroyedInput(in RecordDEKDestroyedInput) error {
+	if in.Year < 2026 || in.Year > 2100 {
+		return ErrInvalidYear
+	}
+	if in.Month < 1 || in.Month > 12 {
+		return ErrInvalidMonth
+	}
+	if in.PartitionName == "" {
+		return ErrEmptyPartitionName
+	}
+	if in.KEKHint == "" {
+		return ErrEmptyKEKHint
+	}
+	if in.VaultKeyVersion < 1 {
+		return ErrInvalidKeyVersion
 	}
 	return nil
 }

--- a/plane/application/billing/stub_service.go
+++ b/plane/application/billing/stub_service.go
@@ -14,16 +14,18 @@ import (
 // (year, month, partition_name) is unique and a duplicate insert returns the
 // existing archive id with Created=false.
 type StubService struct {
-	mu    sync.Mutex
-	rows  map[string]PartitionArchive
-	clock func() time.Time
+	mu          sync.Mutex
+	rows        map[string]PartitionArchive
+	dekEvents   map[uuid.UUID]struct{}
+	clock       func() time.Time
 }
 
 // NewStubService returns an empty StubService backed by time.Now().UTC().
 func NewStubService() *StubService {
 	return &StubService{
-		rows:  map[string]PartitionArchive{},
-		clock: func() time.Time { return time.Now().UTC() },
+		rows:      map[string]PartitionArchive{},
+		dekEvents: map[uuid.UUID]struct{}{},
+		clock:     func() time.Time { return time.Now().UTC() },
 	}
 }
 
@@ -51,4 +53,21 @@ func (s *StubService) RecordPartitionArchived(_ context.Context, in RecordPartit
 	}
 	s.rows[key] = pa
 	return RecordPartitionArchivedOutput{ArchiveID: pa.ID.String(), Created: true}, nil
+}
+
+// RecordDEKDestroyed simulates the DEK-destruction outbox emit with the same
+// idempotency contract as PostgresService — repeated calls with the same
+// natural key return Created=false.
+func (s *StubService) RecordDEKDestroyed(_ context.Context, in RecordDEKDestroyedInput) (RecordDEKDestroyedOutput, error) {
+	if err := validateDEKDestroyedInput(in); err != nil {
+		return RecordDEKDestroyedOutput{}, err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	id := dekDestroyedAggregateID(in)
+	if _, ok := s.dekEvents[id]; ok {
+		return RecordDEKDestroyedOutput{EventID: id.String(), Created: false}, nil
+	}
+	s.dekEvents[id] = struct{}{}
+	return RecordDEKDestroyedOutput{EventID: id.String(), Created: true}, nil
 }

--- a/plane/data/events/billing/partition_dek_destroyed.schema.json
+++ b/plane/data/events/billing/partition_dek_destroyed.schema.json
@@ -1,0 +1,50 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://gitscale.io/events/billing/partition_dek_destroyed.schema.json",
+  "title": "billing.partition_dek_destroyed",
+  "description": "Emitted after the DEK destruction workflow (#80) crypto-shreds a per-month Vault transit key version. ADR-018 §Encryption: irreversible. The outbox event is the only durable record — there is no source row update. Idempotent on (year, month, partition_name, kek_hint).",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "year",
+    "month",
+    "partition_name",
+    "kek_hint",
+    "vault_key_version",
+    "destroyed_at",
+    "_envelope_version"
+  ],
+  "properties": {
+    "year": {
+      "type": "integer",
+      "minimum": 2026,
+      "maximum": 2100
+    },
+    "month": {
+      "type": "integer",
+      "minimum": 1,
+      "maximum": 12
+    },
+    "partition_name": {
+      "type": "string",
+      "minLength": 1
+    },
+    "kek_hint": {
+      "type": "string",
+      "minLength": 1,
+      "pattern": "^platform-billing-v[0-9]+$"
+    },
+    "vault_key_version": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "destroyed_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "_envelope_version": {
+      "type": "integer",
+      "const": 1
+    }
+  }
+}

--- a/plane/data/events/billing/partition_dek_destroyed.testdata/basic.json
+++ b/plane/data/events/billing/partition_dek_destroyed.testdata/basic.json
@@ -1,0 +1,9 @@
+{
+  "year": 2027,
+  "month": 1,
+  "partition_name": "usage_events_2027_01",
+  "kek_hint": "platform-billing-v3",
+  "vault_key_version": 3,
+  "destroyed_at": "2034-06-01T02:00:00.000000Z",
+  "_envelope_version": 1
+}

--- a/plane/data/store/metadata.go
+++ b/plane/data/store/metadata.go
@@ -176,6 +176,18 @@ type BillingReader interface {
 	// GetPartitionArchiveByKey returns the row matching the natural key
 	// (year, month, partition_name) or (nil, nil) when no row exists.
 	GetPartitionArchiveByKey(ctx context.Context, year, month int, partitionName string) (*PartitionArchive, error)
+
+	// ListPartitionArchivesArchivedBefore returns archive rows with
+	// archived_at strictly less than cutoff, sorted by (year, month, id)
+	// for deterministic workflow iteration. Used by the DEK destruction
+	// workflow (#80) to enumerate eligible partitions.
+	ListPartitionArchivesArchivedBefore(ctx context.Context, cutoff time.Time) ([]PartitionArchive, error)
+
+	// HasOutboxEventForAggregate returns true when an outbox row already
+	// exists for (eventType, aggregateID). Used to anchor idempotency for
+	// outbox-only events (e.g. billing.partition_dek_destroyed) that have
+	// no source row to UNIQUE-key against.
+	HasOutboxEventForAggregate(ctx context.Context, eventType string, aggregateID uuid.UUID) (bool, error)
 }
 
 // BillingWriter exposes write operations against the billing domain.

--- a/plane/data/store/postgres/billing.go
+++ b/plane/data/store/postgres/billing.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/gitscale-platform/gitscale/plane/data/store"
 	"github.com/google/uuid"
@@ -34,6 +35,57 @@ func (r *billingReader) GetPartitionArchiveByKey(ctx context.Context, year, mont
 		return nil, fmt.Errorf("postgres: GetPartitionArchiveByKey: %w", err)
 	}
 	return &pa, nil
+}
+
+// ListPartitionArchivesArchivedBefore enumerates partition_archives older
+// than cutoff for the DEK destruction workflow (#80). Sorted by (year, month,
+// id) for deterministic workflow iteration.
+func (r *billingReader) ListPartitionArchivesArchivedBefore(ctx context.Context, cutoff time.Time) ([]store.PartitionArchive, error) {
+	const q = `
+		SELECT id, year, month, partition_name, lake_uri,
+		       row_count, bytes_written, archived_at
+		FROM billing.partition_archives
+		WHERE archived_at < $1
+		ORDER BY year ASC, month ASC, id ASC`
+	rows, err := r.q.Query(ctx, q, cutoff)
+	if err != nil {
+		return nil, fmt.Errorf("postgres: ListPartitionArchivesArchivedBefore: %w", err)
+	}
+	defer rows.Close()
+	var out []store.PartitionArchive
+	for rows.Next() {
+		var pa store.PartitionArchive
+		if err := rows.Scan(
+			&pa.ID, &pa.Year, &pa.Month, &pa.PartitionName, &pa.LakeURI,
+			&pa.RowCount, &pa.BytesWritten, &pa.ArchivedAt,
+		); err != nil {
+			return nil, fmt.Errorf("postgres: ListPartitionArchivesArchivedBefore scan: %w", err)
+		}
+		out = append(out, pa)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("postgres: ListPartitionArchivesArchivedBefore rows: %w", err)
+	}
+	return out, nil
+}
+
+// HasOutboxEventForAggregate consults billing.billing_outbox for an existing
+// row keyed by (event_type, aggregate_id). Used by the DEK destruction
+// workflow (#80) to make outbox writes idempotent without a source row.
+func (r *billingReader) HasOutboxEventForAggregate(ctx context.Context, eventType string, aggregateID uuid.UUID) (bool, error) {
+	const q = `
+		SELECT 1 FROM billing.billing_outbox
+		WHERE event_type = $1 AND aggregate_id = $2
+		LIMIT 1`
+	var dummy int
+	err := r.q.QueryRow(ctx, q, eventType, aggregateID).Scan(&dummy)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return false, nil
+		}
+		return false, fmt.Errorf("postgres: HasOutboxEventForAggregate: %w", err)
+	}
+	return true, nil
 }
 
 // billingWriter embeds billingReader and adds Tx-only mutations.

--- a/plane/data/store/stub/billing.go
+++ b/plane/data/store/stub/billing.go
@@ -3,6 +3,8 @@ package stub
 import (
 	"context"
 	"fmt"
+	"sort"
+	"time"
 
 	"github.com/gitscale-platform/gitscale/plane/data/store"
 	"github.com/google/uuid"
@@ -36,6 +38,43 @@ func (r *stubBillingReader) GetPartitionArchiveByKey(_ context.Context, year, mo
 	return &cp, nil
 }
 
+// ListPartitionArchivesArchivedBefore returns committed archive rows older
+// than cutoff, sorted to mirror the postgres impl's ORDER BY year, month, id.
+func (r *stubBillingReader) ListPartitionArchivesArchivedBefore(_ context.Context, cutoff time.Time) ([]store.PartitionArchive, error) {
+	r.store.mu.Lock()
+	defer r.store.mu.Unlock()
+	var out []store.PartitionArchive
+	for _, pa := range r.store.partitionArchives {
+		if pa.ArchivedAt.Before(cutoff) {
+			out = append(out, pa)
+		}
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Year != out[j].Year {
+			return out[i].Year < out[j].Year
+		}
+		if out[i].Month != out[j].Month {
+			return out[i].Month < out[j].Month
+		}
+		return out[i].ID.String() < out[j].ID.String()
+	})
+	return out, nil
+}
+
+// HasOutboxEventForAggregate consults committed outbox records. Mirrors the
+// postgres impl's WHERE event_type=$1 AND aggregate_id=$2 query. Pending
+// (uncommitted) writes are checked separately by stubBillingWriter.
+func (r *stubBillingReader) HasOutboxEventForAggregate(_ context.Context, eventType string, aggregateID uuid.UUID) (bool, error) {
+	r.store.mu.Lock()
+	defer r.store.mu.Unlock()
+	for _, ev := range r.store.outbox {
+		if ev.Domain == store.DomainBilling && ev.EventType == eventType && ev.AggregateID == aggregateID {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
 // Billing returns the billing writer scoped to this Tx. Pending writes are
 // only made visible on commit; reads consult both pending and committed maps.
 func (t *stubTx) Billing() store.BillingWriter {
@@ -51,6 +90,45 @@ func (w *stubBillingWriter) lazyInit() {
 	if w.tx.pendingPartitionArchives == nil {
 		w.tx.pendingPartitionArchives = make(map[string]store.PartitionArchive)
 	}
+}
+
+// ListPartitionArchivesArchivedBefore consults pending writes first, then
+// falls back to committed state. Sort order matches the reader's.
+func (w *stubBillingWriter) ListPartitionArchivesArchivedBefore(ctx context.Context, cutoff time.Time) ([]store.PartitionArchive, error) {
+	committed, err := w.reader.ListPartitionArchivesArchivedBefore(ctx, cutoff)
+	if err != nil {
+		return nil, err
+	}
+	if w.tx.pendingPartitionArchives == nil {
+		return committed, nil
+	}
+	merged := append([]store.PartitionArchive(nil), committed...)
+	for _, pa := range w.tx.pendingPartitionArchives {
+		if pa.ArchivedAt.Before(cutoff) {
+			merged = append(merged, pa)
+		}
+	}
+	sort.Slice(merged, func(i, j int) bool {
+		if merged[i].Year != merged[j].Year {
+			return merged[i].Year < merged[j].Year
+		}
+		if merged[i].Month != merged[j].Month {
+			return merged[i].Month < merged[j].Month
+		}
+		return merged[i].ID.String() < merged[j].ID.String()
+	})
+	return merged, nil
+}
+
+// HasOutboxEventForAggregate checks pending Tx writes first, then committed
+// outbox state. The pending check uses the same filter as the postgres impl.
+func (w *stubBillingWriter) HasOutboxEventForAggregate(ctx context.Context, eventType string, aggregateID uuid.UUID) (bool, error) {
+	for _, ev := range w.tx.pendingOutbox {
+		if ev.Domain == store.DomainBilling && ev.EventType == eventType && ev.AggregateID == aggregateID {
+			return true, nil
+		}
+	}
+	return w.reader.HasOutboxEventForAggregate(ctx, eventType, aggregateID)
 }
 
 func (w *stubBillingWriter) GetPartitionArchiveByKey(ctx context.Context, year, month int, partitionName string) (*store.PartitionArchive, error) {

--- a/plane/workflow/appclient/billing.go
+++ b/plane/workflow/appclient/billing.go
@@ -13,6 +13,22 @@ type BillingClient interface {
 	// RecordPartitionArchived emits billing.partition_archived to the outbox
 	// via the billing app-plane service.
 	RecordPartitionArchived(ctx context.Context, in PartitionArchivedInput) error
+
+	// RecordDEKDestroyed emits billing.partition_dek_destroyed to the outbox
+	// via the billing app-plane service. Idempotent on the natural key
+	// (year, month, partition_name, kek_hint).
+	RecordDEKDestroyed(ctx context.Context, in DEKDestroyedInput) error
+}
+
+// DEKDestroyedInput carries the destruction outcome to the billing service.
+// VaultKeyVersion is the parsed numeric N from "platform-billing-v<N>" and
+// must be > 0; KEKHint is preserved verbatim for audit trail.
+type DEKDestroyedInput struct {
+	Year            int
+	Month           int
+	PartitionName   string
+	KEKHint         string
+	VaultKeyVersion int
 }
 
 // PartitionArchivedInput carries the archival outcome to the billing service.
@@ -27,9 +43,11 @@ type PartitionArchivedInput struct {
 
 // StubBillingClient records calls in memory. Used by workflow unit tests.
 type StubBillingClient struct {
-	mu    sync.Mutex
-	calls []PartitionArchivedInput
-	fn    func(in PartitionArchivedInput) error
+	mu       sync.Mutex
+	calls    []PartitionArchivedInput
+	dekCalls []DEKDestroyedInput
+	fn       func(in PartitionArchivedInput) error
+	dekFn    func(in DEKDestroyedInput) error
 }
 
 // NewStubBillingClient returns a recording stub that succeeds by default.
@@ -40,6 +58,13 @@ func (s *StubBillingClient) SetFn(fn func(PartitionArchivedInput) error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.fn = fn
+}
+
+// SetDEKFn injects a fake-error path for RecordDEKDestroyed.
+func (s *StubBillingClient) SetDEKFn(fn func(DEKDestroyedInput) error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.dekFn = fn
 }
 
 // RecordPartitionArchived records the call and runs the injected fn if set.
@@ -55,9 +80,30 @@ func (s *StubBillingClient) RecordPartitionArchived(_ context.Context, in Partit
 	return nil
 }
 
-// Calls returns a snapshot of all recorded calls.
+// RecordDEKDestroyed records the DEK-destruction call and runs the injected
+// fn if set.
+func (s *StubBillingClient) RecordDEKDestroyed(_ context.Context, in DEKDestroyedInput) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.dekFn != nil {
+		if err := s.dekFn(in); err != nil {
+			return err
+		}
+	}
+	s.dekCalls = append(s.dekCalls, in)
+	return nil
+}
+
+// Calls returns a snapshot of all recorded archive calls.
 func (s *StubBillingClient) Calls() []PartitionArchivedInput {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return append([]PartitionArchivedInput(nil), s.calls...)
+}
+
+// DEKCalls returns a snapshot of all recorded DEK-destruction calls.
+func (s *StubBillingClient) DEKCalls() []DEKDestroyedInput {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]DEKDestroyedInput(nil), s.dekCalls...)
 }

--- a/plane/workflow/appclient/billing_grpc.go
+++ b/plane/workflow/appclient/billing_grpc.go
@@ -37,3 +37,18 @@ func (g *grpcBillingClient) RecordPartitionArchived(ctx context.Context, in Part
 	})
 	return err
 }
+
+// RecordDEKDestroyed calls into the billing app-plane service to emit
+// billing.partition_dek_destroyed. Idempotent retries return nil; only the
+// first call writes the outbox row (anchored on the deterministic UUIDv5
+// aggregate_id derived from the natural key).
+func (g *grpcBillingClient) RecordDEKDestroyed(ctx context.Context, in DEKDestroyedInput) error {
+	_, err := g.c.RecordDEKDestroyed(ctx, &billingv1.RecordDEKDestroyedRequest{
+		Year:            int32(in.Year),
+		Month:           int32(in.Month),
+		PartitionName:   in.PartitionName,
+		KekHint:         in.KEKHint,
+		VaultKeyVersion: int32(in.VaultKeyVersion),
+	})
+	return err
+}

--- a/plane/workflow/billing/bundle.go
+++ b/plane/workflow/billing/bundle.go
@@ -22,19 +22,32 @@ type ArchiveDeps struct {
 // ArchiveDeps so a worker pool can be sized for read-heavy restore traffic
 // without enabling archive scheduling.
 type RestoreDeps struct {
-	FetchManifest    *FetchManifestActivity
-	VerifyChecksum   *VerifyChecksumActivity
-	DownloadDecrypt  *DownloadAndDecryptActivity
-	LoadQuarantine   *LoadIntoQuarantineActivity
-	DropQuarantine   *DropQuarantineActivity
+	FetchManifest   *FetchManifestActivity
+	VerifyChecksum  *VerifyChecksumActivity
+	DownloadDecrypt *DownloadAndDecryptActivity
+	LoadQuarantine  *LoadIntoQuarantineActivity
+	DropQuarantine  *DropQuarantineActivity
+}
+
+// DEKDestructionDeps holds the dependencies injected into the DEK destruction
+// activities (#80, ADR-018 §Encryption). Constructed in cmd/workflow-worker
+// and passed to Bundle. Pass nil to skip DEK-destruction workflow + activity
+// registration. All fields must be non-nil when the struct itself is non-nil.
+type DEKDestructionDeps struct {
+	List      *ListEligiblePartitionsActivity
+	LegalHold *CheckLegalHoldActivity
+	Approval  *RequestOperatorApprovalActivity
+	Destroy   *DestroyDEKActivity
+	Emit      *EmitDEKDestroyedActivity
 }
 
 // Bundle returns the registration set for the billing-maintenance task queue.
-// Hosts the partition-rollover workflow (#18-rollover) and, when archive is
+// Hosts the partition-rollover workflow (#18-rollover); when archive is
 // non-nil, the partition-archive workflow (#69) plus its activities; when
 // restore is non-nil, the partition-restore workflow (#79) plus its
-// activities.
-func Bundle(rollover *CreatePartitionActivity, archive *ArchiveDeps, restore *RestoreDeps) gswf.Bundle {
+// activities; when dek is non-nil, the DEK-destruction workflow (#80) plus
+// its activities.
+func Bundle(rollover *CreatePartitionActivity, archive *ArchiveDeps, restore *RestoreDeps, dek *DEKDestructionDeps) gswf.Bundle {
 	wfs := []any{PartitionRolloverWorkflow}
 	acts := []any{
 		gswf.NamedActivity{Name: ActivityNameCreatePartition, Activity: rollover.Execute},
@@ -57,6 +70,16 @@ func Bundle(rollover *CreatePartitionActivity, archive *ArchiveDeps, restore *Re
 			gswf.NamedActivity{Name: ActivityNameDownloadDecrypt, Activity: restore.DownloadDecrypt.Execute},
 			gswf.NamedActivity{Name: ActivityNameLoadQuarantine, Activity: restore.LoadQuarantine.Execute},
 			gswf.NamedActivity{Name: ActivityNameDropQuarantine, Activity: restore.DropQuarantine.Execute},
+		)
+	}
+	if dek != nil {
+		wfs = append(wfs, DEKDestructionWorkflow, DEKDestructionRouterWorkflow)
+		acts = append(acts,
+			gswf.NamedActivity{Name: ActivityNameListEligiblePartitions, Activity: dek.List.Execute},
+			gswf.NamedActivity{Name: ActivityNameCheckLegalHold, Activity: dek.LegalHold.Execute},
+			gswf.NamedActivity{Name: ActivityNameRequestOperatorApproval, Activity: dek.Approval.Execute},
+			gswf.NamedActivity{Name: ActivityNameDestroyDEK, Activity: dek.Destroy.Execute},
+			gswf.NamedActivity{Name: ActivityNameEmitDEKDestroyed, Activity: dek.Emit.Execute},
 		)
 	}
 	return gswf.Bundle{

--- a/plane/workflow/billing/check_legal_hold_activity.go
+++ b/plane/workflow/billing/check_legal_hold_activity.go
@@ -1,0 +1,79 @@
+package billing
+
+import (
+	"context"
+	"errors"
+)
+
+// ActivityNameCheckLegalHold is the registered name for the
+// CheckLegalHoldActivity.Execute method.
+const ActivityNameCheckLegalHold = "billing.CheckLegalHoldForDEKDestroy"
+
+// LegalHoldCheckInput identifies the partition to check.
+type LegalHoldCheckInput struct {
+	Year          int
+	Month         int
+	PartitionName string
+	LakeURI       string
+}
+
+// LegalHoldCheckResult reports whether the partition is currently held.
+// Reason is non-empty when Held is true and is propagated as the workflow
+// skip reason for the partition.
+type LegalHoldCheckResult struct {
+	Held   bool
+	Reason string
+}
+
+// LegalHoldChecker is the workflow-plane abstraction over the underlying
+// legal-hold mechanism (S3 Object Lock GetObjectLockConfiguration, a
+// dedicated metadata table, etc.). The spec D9 deliberately leaves the
+// concrete mechanism out of scope for #80; production wires whichever
+// implementation lands first.
+type LegalHoldChecker interface {
+	IsHeld(ctx context.Context, lakeURI string) (held bool, reason string, err error)
+}
+
+// CheckLegalHoldActivity wraps a LegalHoldChecker so the workflow can call
+// the boundary as a Temporal activity (network access, etc. are confined
+// here per ADR-003).
+type CheckLegalHoldActivity struct {
+	checker LegalHoldChecker
+}
+
+// NewCheckLegalHoldActivity wraps checker.
+func NewCheckLegalHoldActivity(checker LegalHoldChecker) (*CheckLegalHoldActivity, error) {
+	if checker == nil {
+		return nil, errors.New("billing.NewCheckLegalHoldActivity: checker is nil")
+	}
+	return &CheckLegalHoldActivity{checker: checker}, nil
+}
+
+// Execute returns the legal-hold state for the partition's lake URI.
+func (a *CheckLegalHoldActivity) Execute(ctx context.Context, in LegalHoldCheckInput) (LegalHoldCheckResult, error) {
+	held, reason, err := a.checker.IsHeld(ctx, in.LakeURI)
+	if err != nil {
+		return LegalHoldCheckResult{}, err
+	}
+	return LegalHoldCheckResult{Held: held, Reason: reason}, nil
+}
+
+// staticLegalHoldChecker returns the same answer for every call. Used as a
+// safe default when no real checker is wired (production must replace it
+// with an actual S3-Object-Lock-backed implementation).
+type staticLegalHoldChecker struct {
+	held   bool
+	reason string
+}
+
+// NewStaticLegalHoldChecker returns a LegalHoldChecker that always returns
+// (held, reason). Useful for development environments before the real S3
+// integration ships and for unit tests.
+func NewStaticLegalHoldChecker(held bool, reason string) LegalHoldChecker {
+	return staticLegalHoldChecker{held: held, reason: reason}
+}
+
+// IsHeld implements LegalHoldChecker.
+func (s staticLegalHoldChecker) IsHeld(_ context.Context, _ string) (bool, string, error) {
+	return s.held, s.reason, nil
+}

--- a/plane/workflow/billing/check_legal_hold_activity_test.go
+++ b/plane/workflow/billing/check_legal_hold_activity_test.go
@@ -1,0 +1,52 @@
+package billing
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+type stubChecker struct {
+	held   bool
+	reason string
+	err    error
+}
+
+func (s stubChecker) IsHeld(_ context.Context, _ string) (bool, string, error) {
+	return s.held, s.reason, s.err
+}
+
+func TestCheckLegalHoldActivity_PropagatesVerdict(t *testing.T) {
+	a, err := NewCheckLegalHoldActivity(stubChecker{held: true, reason: "litigation"})
+	if err != nil {
+		t.Fatalf("NewCheckLegalHoldActivity: %v", err)
+	}
+	res, err := a.Execute(context.Background(), LegalHoldCheckInput{LakeURI: "s3://b/k"})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if !res.Held || res.Reason != "litigation" {
+		t.Errorf("verdict=%+v", res)
+	}
+}
+
+func TestCheckLegalHoldActivity_PropagatesError(t *testing.T) {
+	a, _ := NewCheckLegalHoldActivity(stubChecker{err: errors.New("aws: 500")})
+	if _, err := a.Execute(context.Background(), LegalHoldCheckInput{}); err == nil {
+		t.Error("expected error")
+	}
+}
+
+func TestCheckLegalHoldActivity_NilChecker(t *testing.T) {
+	if _, err := NewCheckLegalHoldActivity(nil); err == nil {
+		t.Error("expected error for nil checker")
+	}
+}
+
+func TestStaticLegalHoldChecker(t *testing.T) {
+	c := NewStaticLegalHoldChecker(false, "")
+	held, _, err := c.IsHeld(context.Background(), "s3://b/k")
+	if err != nil || held {
+		t.Errorf("static checker returned held=%v err=%v", held, err)
+	}
+}

--- a/plane/workflow/billing/dek_destruction_router_workflow.go
+++ b/plane/workflow/billing/dek_destruction_router_workflow.go
@@ -1,0 +1,41 @@
+package billing
+
+import (
+	"fmt"
+	"time"
+
+	"go.temporal.io/sdk/workflow"
+)
+
+// DEKDestructionRouterWorkflowName is the registered name for the router.
+//
+// The schedule (EnsureDEKDestructionSchedule) targets this router; the
+// router computes Cutoff at fire time via workflow.Now and starts
+// DEKDestructionWorkflow as a child. This pattern works around
+// ScheduleWorkflowAction's static-args limitation while preserving the
+// inner workflow's determinism. Mirrors ArchiveRouterWorkflow.
+const DEKDestructionRouterWorkflowName = "billing.DEKDestructionRouter"
+
+// DEKDestructionRouterWorkflow computes Cutoff := workflow.Now − 7y30d
+// and starts DEKDestructionWorkflow as a child workflow with the bound
+// Cutoff and RunTime. Determinism: workflow.Now(ctx) is the canonical
+// replay-safe clock; AddDate is pure; fmt.Sprintf is pure. No goroutines,
+// network calls, or non-deterministic map iteration.
+func DEKDestructionRouterWorkflow(ctx workflow.Context) (DEKDestructionResult, error) {
+	now := workflow.Now(ctx)
+	cutoff := now.AddDate(0, 0, -DEKDestructionRetentionDays)
+
+	cwo := workflow.ChildWorkflowOptions{
+		WorkflowID: fmt.Sprintf("billing-dek-destruction-%s", now.UTC().Format(time.RFC3339)),
+	}
+	cctx := workflow.WithChildOptions(ctx, cwo)
+
+	var result DEKDestructionResult
+	if err := workflow.ExecuteChildWorkflow(cctx, DEKDestructionWorkflow, DEKDestructionInput{
+		RunTime: now,
+		Cutoff:  cutoff,
+	}).Get(ctx, &result); err != nil {
+		return DEKDestructionResult{}, err
+	}
+	return result, nil
+}

--- a/plane/workflow/billing/dek_destruction_router_workflow_test.go
+++ b/plane/workflow/billing/dek_destruction_router_workflow_test.go
@@ -1,0 +1,62 @@
+package billing
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/mock"
+	"go.temporal.io/sdk/testsuite"
+)
+
+// TestDEKDestructionRouter_Computes7y30dCutoff fixes workflow.Now to a known
+// timestamp and asserts the child workflow is started with Cutoff = now − 7y30d.
+func TestDEKDestructionRouter_Computes7y30dCutoff(t *testing.T) {
+	cases := []struct {
+		name       string
+		fireTime   time.Time
+		wantCutoff time.Time
+	}{
+		{
+			name:       "midyear",
+			fireTime:   time.Date(2034, 6, 1, 2, 0, 0, 0, time.UTC),
+			wantCutoff: time.Date(2034, 6, 1, 2, 0, 0, 0, time.UTC).AddDate(0, 0, -DEKDestructionRetentionDays),
+		},
+		{
+			name:       "epoch-edge",
+			fireTime:   time.Date(2033, 1, 1, 0, 0, 0, 0, time.UTC),
+			wantCutoff: time.Date(2033, 1, 1, 0, 0, 0, 0, time.UTC).AddDate(0, 0, -DEKDestructionRetentionDays),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s := &testsuite.WorkflowTestSuite{}
+			env := s.NewTestWorkflowEnvironment()
+			env.SetStartTime(tc.fireTime)
+
+			env.RegisterWorkflow(DEKDestructionRouterWorkflow)
+			env.RegisterWorkflow(DEKDestructionWorkflow)
+
+			var got DEKDestructionInput
+			env.OnWorkflow(DEKDestructionWorkflow, mock.Anything, mock.MatchedBy(func(in DEKDestructionInput) bool {
+				got = in
+				return true
+			})).Return(DEKDestructionResult{}, nil).Once()
+
+			env.ExecuteWorkflow(DEKDestructionRouterWorkflow)
+
+			if !env.IsWorkflowCompleted() {
+				t.Fatal("router workflow did not complete")
+			}
+			if err := env.GetWorkflowError(); err != nil {
+				t.Fatalf("router workflow error: %v", err)
+			}
+			if !got.Cutoff.Equal(tc.wantCutoff) {
+				t.Errorf("Cutoff=%v want %v", got.Cutoff, tc.wantCutoff)
+			}
+			if !got.RunTime.Equal(tc.fireTime) {
+				t.Errorf("RunTime=%v want %v", got.RunTime, tc.fireTime)
+			}
+		})
+	}
+}

--- a/plane/workflow/billing/dek_destruction_schedules.go
+++ b/plane/workflow/billing/dek_destruction_schedules.go
@@ -1,0 +1,42 @@
+package billing
+
+import (
+	"context"
+
+	gswf "github.com/gitscale-platform/gitscale/plane/workflow"
+	"go.temporal.io/sdk/client"
+)
+
+// DEKDestructionScheduleID is the stable Temporal schedule ID for the
+// monthly DEK destruction run.
+const DEKDestructionScheduleID = "billing-dek-destruction"
+
+// DEKDestructionCronExpression fires on the 1st of every month at 02:00
+// UTC — well after the rollover (24th 12:00 UTC) and archive (24th 14:00
+// UTC) schedules so any cleanup work has settled before crypto-shred runs.
+const DEKDestructionCronExpression = "0 2 1 * *"
+
+// EnsureDEKDestructionSchedule registers (or converges) the monthly DEK
+// destruction schedule. Called by cmd/workflow-worker at boot once the
+// worker is running.
+//
+// The schedule targets DEKDestructionRouterWorkflow rather than
+// DEKDestructionWorkflow directly: ScheduleWorkflowAction.Args is statically
+// bound at schedule-create time, so the Cutoff = fireTime − 7y30d
+// computation must happen at fire time. The router performs that
+// computation deterministically via workflow.Now and starts
+// DEKDestructionWorkflow as a child. See dek_destruction_router_workflow.go.
+func EnsureDEKDestructionSchedule(ctx context.Context, sc gswf.ScheduleClient) (client.ScheduleHandle, error) {
+	return gswf.EnsureSchedule(ctx, sc, client.ScheduleOptions{
+		ID: DEKDestructionScheduleID,
+		Spec: client.ScheduleSpec{
+			CronExpressions: []string{DEKDestructionCronExpression},
+			TimeZoneName:    "UTC",
+		},
+		Action: &client.ScheduleWorkflowAction{
+			ID:        "billing-dek-destruction",
+			Workflow:  "DEKDestructionRouterWorkflow",
+			TaskQueue: gswf.QueueBillingMaintenance,
+		},
+	})
+}

--- a/plane/workflow/billing/dek_destruction_workflow.go
+++ b/plane/workflow/billing/dek_destruction_workflow.go
@@ -1,0 +1,181 @@
+package billing
+
+import (
+	"fmt"
+	"time"
+
+	gswf "github.com/gitscale-platform/gitscale/plane/workflow"
+	"go.temporal.io/sdk/workflow"
+)
+
+// DEKDestructionWorkflowName is the registered name for DEKDestructionWorkflow.
+const DEKDestructionWorkflowName = "billing.DEKDestructionWorkflow"
+
+// DEKDestructionRetentionDays is the retention floor before a partition's
+// per-month DEK becomes eligible for crypto-shred. ADR-018 §Encryption
+// fixes this at 7 years + 30 days; the +30d gives a grace window for
+// late-arriving legal holds.
+//
+// The router workflow subtracts this duration from workflow.Now to compute
+// the cutoff at fire time, preserving determinism.
+const DEKDestructionRetentionDays = 365*7 + 30
+
+// DEKDestructionInput is the input to DEKDestructionWorkflow.
+//
+// RunTime is bound at fire time by the schedule (via the router workflow);
+// it is propagated through to activity inputs that capture timestamps.
+// Cutoff is the precomputed (RunTime - 7y30d) the router passes through —
+// computing it once in the router keeps the inner workflow deterministic
+// across replays even if the constant is bumped between deploys.
+type DEKDestructionInput struct {
+	RunTime time.Time
+	Cutoff  time.Time
+}
+
+// DEKDestructionResult summarises a workflow run.
+type DEKDestructionResult struct {
+	PartitionsScanned int
+	KeysDestroyed     int
+	// Skipped is one entry per partition that was scanned but not
+	// destroyed; the value is "<year>-<month>-<partition_name>: <reason>".
+	// Reasons are: "missing_kek_hint", "legal_hold:<hold_reason>",
+	// "approval_rejected:<reason>", "destroy_error:<error>",
+	// "emit_error:<error>".
+	Skipped []string
+}
+
+// DEKDestructionWorkflow scans billing.partition_archives for partitions
+// older than (RunTime - 7y30d) and crypto-shreds their per-month Vault
+// transit key versions (ADR-018 §Encryption). Pre-flight legal-hold check
+// and ADR-015 operator-approval gate run before the irreversible Vault
+// trim. Per-partition errors do not abort the run; they are accumulated
+// in Result.Skipped.
+//
+// Determinism: workflow.Now is not called here — Cutoff is precomputed by
+// the router and embedded in the input. Iteration order is deterministic
+// because ListEligiblePartitionsActivity returns a sorted slice.
+func DEKDestructionWorkflow(ctx workflow.Context, in DEKDestructionInput) (DEKDestructionResult, error) {
+	if in.Cutoff.IsZero() {
+		return DEKDestructionResult{}, fmt.Errorf("dek destruction: cutoff is zero")
+	}
+
+	listOpts := workflow.ActivityOptions{
+		StartToCloseTimeout: 5 * time.Minute,
+		RetryPolicy:         gswf.DefaultRetryPolicy(),
+	}
+	checkOpts := workflow.ActivityOptions{
+		StartToCloseTimeout: 2 * time.Minute,
+		RetryPolicy:         gswf.DefaultRetryPolicy(),
+	}
+	// Approval may legitimately block on a human; long timeout + heartbeat-
+	// friendly retry policy. Tests inject a synchronous mock and never see
+	// this timeout.
+	approvalOpts := workflow.ActivityOptions{
+		StartToCloseTimeout: 24 * time.Hour,
+		HeartbeatTimeout:    5 * time.Minute,
+		RetryPolicy:         gswf.DefaultRetryPolicy(),
+	}
+	destroyOpts := workflow.ActivityOptions{
+		StartToCloseTimeout: 5 * time.Minute,
+		RetryPolicy:         gswf.DefaultRetryPolicy(),
+	}
+	emitOpts := workflow.ActivityOptions{
+		StartToCloseTimeout: time.Minute,
+		RetryPolicy:         gswf.DefaultRetryPolicy(),
+	}
+
+	listCtx := workflow.WithActivityOptions(ctx, listOpts)
+	var listResult ListEligibleResult
+	if err := workflow.ExecuteActivity(listCtx, ActivityNameListEligiblePartitions,
+		ListEligibleInput{Cutoff: in.Cutoff},
+	).Get(listCtx, &listResult); err != nil {
+		return DEKDestructionResult{}, fmt.Errorf("dek destruction: list: %w", err)
+	}
+
+	result := DEKDestructionResult{
+		PartitionsScanned: len(listResult.Partitions),
+	}
+
+	for _, p := range listResult.Partitions {
+		tag := fmt.Sprintf("%04d-%02d-%s", p.Year, p.Month, p.PartitionName)
+
+		if p.KEKHint == "" {
+			result.Skipped = append(result.Skipped, fmt.Sprintf("%s: missing_kek_hint", tag))
+			continue
+		}
+
+		// 1. Legal-hold gate.
+		checkCtx := workflow.WithActivityOptions(ctx, checkOpts)
+		var hold LegalHoldCheckResult
+		if err := workflow.ExecuteActivity(checkCtx, ActivityNameCheckLegalHold,
+			LegalHoldCheckInput{
+				Year:          p.Year,
+				Month:         p.Month,
+				PartitionName: p.PartitionName,
+				LakeURI:       p.LakeURI,
+			},
+		).Get(checkCtx, &hold); err != nil {
+			result.Skipped = append(result.Skipped, fmt.Sprintf("%s: legal_hold_error:%v", tag, err))
+			continue
+		}
+		if hold.Held {
+			result.Skipped = append(result.Skipped, fmt.Sprintf("%s: legal_hold:%s", tag, hold.Reason))
+			continue
+		}
+
+		// 2. Operator-approval gate (ADR-015).
+		approvalCtx := workflow.WithActivityOptions(ctx, approvalOpts)
+		var approval OperatorApprovalResult
+		if err := workflow.ExecuteActivity(approvalCtx, ActivityNameRequestOperatorApproval,
+			OperatorApprovalInput{
+				Year:          p.Year,
+				Month:         p.Month,
+				PartitionName: p.PartitionName,
+				KEKHint:       p.KEKHint,
+			},
+		).Get(approvalCtx, &approval); err != nil {
+			result.Skipped = append(result.Skipped, fmt.Sprintf("%s: approval_error:%v", tag, err))
+			continue
+		}
+		if !approval.Approved {
+			result.Skipped = append(result.Skipped, fmt.Sprintf("%s: approval_rejected:%s", tag, approval.Reason))
+			continue
+		}
+
+		// 3. Destroy DEK (irreversible).
+		destroyCtx := workflow.WithActivityOptions(ctx, destroyOpts)
+		var destroy DestroyDEKResult
+		if err := workflow.ExecuteActivity(destroyCtx, ActivityNameDestroyDEK,
+			DestroyDEKInput{Year: p.Year, Month: p.Month, KEKHint: p.KEKHint},
+		).Get(destroyCtx, &destroy); err != nil {
+			result.Skipped = append(result.Skipped, fmt.Sprintf("%s: destroy_error:%v", tag, err))
+			continue
+		}
+
+		// 4. Emit audit event. A failure after the destroy succeeded
+		// surfaces as a skip, NOT a workflow abort: the irreversible side
+		// effect already happened, so we record the gap in result rather
+		// than letting Temporal restart and double-emit on a later attempt.
+		// Operator runbook covers the manual-replay path.
+		emitCtx := workflow.WithActivityOptions(ctx, emitOpts)
+		if err := workflow.ExecuteActivity(emitCtx, ActivityNameEmitDEKDestroyed,
+			EmitDEKDestroyedInput{
+				Year:            p.Year,
+				Month:           p.Month,
+				PartitionName:   p.PartitionName,
+				KEKHint:         p.KEKHint,
+				VaultKeyVersion: destroy.VaultKeyVersion,
+			},
+		).Get(emitCtx, nil); err != nil {
+			result.Skipped = append(result.Skipped, fmt.Sprintf("%s: emit_error:%v", tag, err))
+			// Still count the destruction — the audit gap is the operator's
+			// problem, not a reason to under-report what was crypto-shredded.
+			result.KeysDestroyed++
+			continue
+		}
+
+		result.KeysDestroyed++
+	}
+
+	return result, nil
+}

--- a/plane/workflow/billing/dek_destruction_workflow_integration_test.go
+++ b/plane/workflow/billing/dek_destruction_workflow_integration_test.go
@@ -1,0 +1,232 @@
+//go:build integration
+
+package billing
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	appbilling "github.com/gitscale-platform/gitscale/plane/application/billing"
+	"github.com/gitscale-platform/gitscale/plane/data/store"
+	pgstore "github.com/gitscale-platform/gitscale/plane/data/store/postgres"
+	"github.com/gitscale-platform/gitscale/plane/workflow/appclient"
+	vault "github.com/hashicorp/vault/api"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/testcontainers/testcontainers-go"
+	pgmodule "github.com/testcontainers/testcontainers-go/modules/postgres"
+	"github.com/testcontainers/testcontainers-go/wait"
+	"go.temporal.io/sdk/activity"
+	"go.temporal.io/sdk/testsuite"
+)
+
+// setupPostgresForDEK boots a postgres container with the migrations
+// required for billing.partition_archives + billing.billing_outbox.
+func setupPostgresForDEK(t *testing.T) *pgxpool.Pool {
+	t.Helper()
+	ctx := context.Background()
+	ctr, err := pgmodule.Run(ctx,
+		"postgres:16-alpine",
+		pgmodule.WithDatabase("gitscale_test"),
+		pgmodule.WithUsername("gs"),
+		pgmodule.WithPassword("gs"),
+		testcontainers.WithWaitStrategy(
+			wait.ForLog("database system is ready to accept connections").
+				WithOccurrence(2).
+				WithStartupTimeout(60*time.Second),
+		),
+	)
+	if err != nil {
+		t.Fatalf("start postgres: %v", err)
+	}
+	t.Cleanup(func() { _ = ctr.Terminate(ctx) })
+	connStr, err := ctr.ConnectionString(ctx, "sslmode=disable")
+	if err != nil {
+		t.Fatalf("connection string: %v", err)
+	}
+	pool, err := pgxpool.New(ctx, connStr)
+	if err != nil {
+		t.Fatalf("pgxpool.New: %v", err)
+	}
+	t.Cleanup(pool.Close)
+
+	migrationsDir := filepath.Join("..", "..", "..", "plane", "data", "migrations")
+	for _, f := range []string{
+		"000_init.sql", "001_identity.sql", "002_repositories.sql",
+		"003_collaboration.sql", "004_ci.sql", "005_billing.sql",
+		"006_identity_revocation.sql",
+		"007_billing_partition_archives.sql",
+	} {
+		sql, err := os.ReadFile(filepath.Join(migrationsDir, f))
+		if err != nil {
+			t.Fatalf("read migration %s: %v", f, err)
+		}
+		if _, err := pool.Exec(ctx, string(sql)); err != nil {
+			t.Fatalf("apply migration %s: %v", f, err)
+		}
+	}
+	return pool
+}
+
+// rotateTransitKey rotates the transit key once so it has version 2,
+// leaving v1 as the version this test will destroy.
+func rotateTransitKey(t *testing.T, ctx context.Context, c *vault.Client, mount, name string) {
+	t.Helper()
+	if _, err := c.Logical().WriteWithContext(ctx,
+		mount+"/keys/"+name+"/rotate", map[string]any{}); err != nil {
+		t.Fatalf("rotate key: %v", err)
+	}
+	// Allow trim by enabling deletion_allowed.
+	if _, err := c.Logical().WriteWithContext(ctx,
+		mount+"/keys/"+name+"/config", map[string]any{
+			"deletion_allowed": true,
+		}); err != nil {
+		t.Fatalf("config deletion_allowed: %v", err)
+	}
+}
+
+// readMinAvailableVersion returns the key's min_available_version after the
+// trim has settled. We poll briefly because trim is async-ish in dev mode.
+func readMinAvailableVersion(t *testing.T, ctx context.Context, c *vault.Client, mount, name string) int {
+	t.Helper()
+	secret, err := c.Logical().ReadWithContext(ctx, mount+"/keys/"+name)
+	if err != nil {
+		t.Fatalf("read key: %v", err)
+	}
+	if secret == nil || secret.Data == nil {
+		t.Fatalf("key %s/%s not found", mount, name)
+	}
+	return readIntFromSecret(secret.Data, "min_available_version")
+}
+
+// TestDEKDestructionWorkflow_Integration_VaultTrimAndOutbox boots Vault +
+// Postgres testcontainers, seeds an eligible partition row, and asserts the
+// workflow trims Vault transit key version 1 and writes the outbox row.
+func TestDEKDestructionWorkflow_Integration_VaultTrimAndOutbox(t *testing.T) {
+	ctx := context.Background()
+	vaultClient := bootVaultForExport(t)
+	rotateTransitKey(t, ctx, vaultClient, "transit", "platform-billing-master")
+
+	pool := setupPostgresForDEK(t)
+	ms := pgstore.New(pool)
+	svc := appbilling.NewPostgresService(ms)
+	billingClient := &localBillingClient{svc: svc}
+
+	cutoff := time.Date(2034, 6, 1, 0, 0, 0, 0, time.UTC)
+	archiveTime := cutoff.AddDate(0, 0, -10) // older than cutoff
+	if err := ms.Transact(ctx, func(tx store.Tx) error {
+		_, _, err := tx.Billing().InsertPartitionArchiveIfAbsent(ctx, store.PartitionArchive{
+			Year: 2027, Month: 1, PartitionName: "billing.usage_events_2027_01",
+			LakeURI: "s3://test/2027/01.parquet", RowCount: 1, BytesWritten: 1,
+			ArchivedAt: archiveTime,
+		})
+		return err
+	}); err != nil {
+		t.Fatalf("seed archive: %v", err)
+	}
+
+	// Wire activities.
+	listAct, err := NewListEligiblePartitionsActivity(ms, &fixedKEKResolver{hint: "platform-billing-v1"})
+	if err != nil {
+		t.Fatalf("list activity: %v", err)
+	}
+	holdAct, _ := NewCheckLegalHoldActivity(NewStaticLegalHoldChecker(false, ""))
+	approvalAct := NewRequestOperatorApprovalActivity(NewAutoApproveStub())
+	destroy, err := NewDestroyDEKActivity(vaultClient, "transit", "platform-billing-master")
+	if err != nil {
+		t.Fatalf("destroy activity: %v", err)
+	}
+	emitAct, _ := NewEmitDEKDestroyedActivity(billingClient)
+
+	s := &testsuite.WorkflowTestSuite{}
+	env := s.NewTestWorkflowEnvironment()
+	env.RegisterWorkflow(DEKDestructionWorkflow)
+	env.RegisterActivityWithOptions(listAct.Execute, activity.RegisterOptions{Name: ActivityNameListEligiblePartitions})
+	env.RegisterActivityWithOptions(holdAct.Execute, activity.RegisterOptions{Name: ActivityNameCheckLegalHold})
+	env.RegisterActivityWithOptions(approvalAct.Execute, activity.RegisterOptions{Name: ActivityNameRequestOperatorApproval})
+	env.RegisterActivityWithOptions(destroy.Execute, activity.RegisterOptions{Name: ActivityNameDestroyDEK})
+	env.RegisterActivityWithOptions(emitAct.Execute, activity.RegisterOptions{Name: ActivityNameEmitDEKDestroyed})
+
+	env.ExecuteWorkflow(DEKDestructionWorkflow, DEKDestructionInput{
+		RunTime: cutoff,
+		Cutoff:  cutoff,
+	})
+	if !env.IsWorkflowCompleted() {
+		t.Fatal("workflow did not complete")
+	}
+	if err := env.GetWorkflowError(); err != nil {
+		t.Fatalf("workflow error: %v", err)
+	}
+	var result DEKDestructionResult
+	if err := env.GetWorkflowResult(&result); err != nil {
+		t.Fatalf("GetWorkflowResult: %v", err)
+	}
+	if result.KeysDestroyed != 1 {
+		t.Fatalf("KeysDestroyed=%d skipped=%v", result.KeysDestroyed, result.Skipped)
+	}
+
+	// Vault assertion: v1 trimmed → min_available_version >= 2.
+	if got := readMinAvailableVersion(t, ctx, vaultClient, "transit", "platform-billing-master"); got < 2 {
+		t.Fatalf("min_available_version=%d want >= 2", got)
+	}
+
+	// Outbox assertion: exactly one billing.partition_dek_destroyed row.
+	var outboxCount int
+	if err := pool.QueryRow(ctx,
+		`SELECT count(*) FROM billing.billing_outbox WHERE event_type = $1`,
+		appbilling.EventTypePartitionDEKDestroyed,
+	).Scan(&outboxCount); err != nil {
+		t.Fatalf("count outbox: %v", err)
+	}
+	if outboxCount != 1 {
+		t.Fatalf("outbox count=%d want 1", outboxCount)
+	}
+
+	// Payload sanity-check.
+	var rawPayload []byte
+	if err := pool.QueryRow(ctx,
+		`SELECT payload::text FROM billing.billing_outbox WHERE event_type = $1`,
+		appbilling.EventTypePartitionDEKDestroyed,
+	).Scan(&rawPayload); err != nil {
+		t.Fatalf("scan payload: %v", err)
+	}
+	var p appbilling.PartitionDEKDestroyedPayload
+	if err := json.Unmarshal(rawPayload, &p); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if p.KEKHint != "platform-billing-v1" || p.VaultKeyVersion != 1 {
+		t.Errorf("payload kek_hint=%q version=%d", p.KEKHint, p.VaultKeyVersion)
+	}
+}
+
+// fixedKEKResolver is a tiny resolver that returns the same hint for every
+// lake URI. The test path doesn't exercise real S3.
+type fixedKEKResolver struct{ hint string }
+
+func (r *fixedKEKResolver) ResolveKEKHint(_ context.Context, _ string) (string, error) {
+	return r.hint, nil
+}
+
+// localBillingClient implements appclient.BillingClient by calling the in-
+// process service directly. Avoids spinning a gRPC server for the test.
+type localBillingClient struct{ svc *appbilling.PostgresService }
+
+func (l *localBillingClient) RecordPartitionArchived(ctx context.Context, in appclient.PartitionArchivedInput) error {
+	_, err := l.svc.RecordPartitionArchived(ctx, appbilling.RecordPartitionArchivedInput{
+		Year: in.Year, Month: in.Month, PartitionName: in.PartitionName,
+		LakeURI: in.LakeURI, RowCount: in.RowCount, BytesWritten: in.BytesWritten,
+	})
+	return err
+}
+
+func (l *localBillingClient) RecordDEKDestroyed(ctx context.Context, in appclient.DEKDestroyedInput) error {
+	_, err := l.svc.RecordDEKDestroyed(ctx, appbilling.RecordDEKDestroyedInput{
+		Year: in.Year, Month: in.Month, PartitionName: in.PartitionName,
+		KEKHint: in.KEKHint, VaultKeyVersion: in.VaultKeyVersion,
+	})
+	return err
+}
+

--- a/plane/workflow/billing/dek_destruction_workflow_test.go
+++ b/plane/workflow/billing/dek_destruction_workflow_test.go
@@ -1,0 +1,258 @@
+package billing
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/mock"
+	"go.temporal.io/sdk/activity"
+	"go.temporal.io/sdk/testsuite"
+)
+
+// registerDEKActivityStubs registers no-op activity stubs under the DEK
+// destruction workflow's activity names so OnActivity(...) mocks can attach.
+// The mocks always intercept; the function bodies never run.
+func registerDEKActivityStubs(env *testsuite.TestWorkflowEnvironment) {
+	env.RegisterActivityWithOptions(
+		func(context.Context, ListEligibleInput) (ListEligibleResult, error) {
+			return ListEligibleResult{}, nil
+		},
+		activity.RegisterOptions{Name: ActivityNameListEligiblePartitions},
+	)
+	env.RegisterActivityWithOptions(
+		func(context.Context, LegalHoldCheckInput) (LegalHoldCheckResult, error) {
+			return LegalHoldCheckResult{}, nil
+		},
+		activity.RegisterOptions{Name: ActivityNameCheckLegalHold},
+	)
+	env.RegisterActivityWithOptions(
+		func(context.Context, OperatorApprovalInput) (OperatorApprovalResult, error) {
+			return OperatorApprovalResult{}, nil
+		},
+		activity.RegisterOptions{Name: ActivityNameRequestOperatorApproval},
+	)
+	env.RegisterActivityWithOptions(
+		func(context.Context, DestroyDEKInput) (DestroyDEKResult, error) {
+			return DestroyDEKResult{}, nil
+		},
+		activity.RegisterOptions{Name: ActivityNameDestroyDEK},
+	)
+	env.RegisterActivityWithOptions(
+		func(context.Context, EmitDEKDestroyedInput) error { return nil },
+		activity.RegisterOptions{Name: ActivityNameEmitDEKDestroyed},
+	)
+}
+
+func dekTestInput() DEKDestructionInput {
+	now := time.Date(2034, 6, 1, 2, 0, 0, 0, time.UTC)
+	return DEKDestructionInput{
+		RunTime: now,
+		Cutoff:  now.AddDate(0, 0, -DEKDestructionRetentionDays),
+	}
+}
+
+func TestDEKDestructionWorkflow_happyPath(t *testing.T) {
+	s := &testsuite.WorkflowTestSuite{}
+	env := s.NewTestWorkflowEnvironment()
+	env.RegisterWorkflow(DEKDestructionWorkflow)
+	registerDEKActivityStubs(env)
+
+	in := dekTestInput()
+	parts := []EligiblePartition{
+		{Year: 2027, Month: 1, PartitionName: "billing.usage_events_2027_01", LakeURI: "s3://b/k1.parquet", KEKHint: "platform-billing-v1"},
+		{Year: 2027, Month: 2, PartitionName: "billing.usage_events_2027_02", LakeURI: "s3://b/k2.parquet", KEKHint: "platform-billing-v2"},
+	}
+	env.OnActivity(ActivityNameListEligiblePartitions, mock.Anything, ListEligibleInput{Cutoff: in.Cutoff}).
+		Return(ListEligibleResult{Partitions: parts}, nil)
+	env.OnActivity(ActivityNameCheckLegalHold, mock.Anything, mock.Anything).
+		Return(LegalHoldCheckResult{Held: false}, nil)
+	env.OnActivity(ActivityNameRequestOperatorApproval, mock.Anything, mock.Anything).
+		Return(OperatorApprovalResult{Approved: true}, nil)
+	env.OnActivity(ActivityNameDestroyDEK, mock.Anything, DestroyDEKInput{Year: 2027, Month: 1, KEKHint: "platform-billing-v1"}).
+		Return(DestroyDEKResult{VaultKeyVersion: 1}, nil)
+	env.OnActivity(ActivityNameDestroyDEK, mock.Anything, DestroyDEKInput{Year: 2027, Month: 2, KEKHint: "platform-billing-v2"}).
+		Return(DestroyDEKResult{VaultKeyVersion: 2}, nil)
+	env.OnActivity(ActivityNameEmitDEKDestroyed, mock.Anything, mock.Anything).
+		Return(nil)
+
+	env.ExecuteWorkflow(DEKDestructionWorkflow, in)
+
+	if !env.IsWorkflowCompleted() {
+		t.Fatal("workflow did not complete")
+	}
+	if err := env.GetWorkflowError(); err != nil {
+		t.Fatalf("workflow error: %v", err)
+	}
+	var result DEKDestructionResult
+	if err := env.GetWorkflowResult(&result); err != nil {
+		t.Fatalf("GetWorkflowResult: %v", err)
+	}
+	if result.PartitionsScanned != 2 {
+		t.Errorf("PartitionsScanned=%d want 2", result.PartitionsScanned)
+	}
+	if result.KeysDestroyed != 2 {
+		t.Errorf("KeysDestroyed=%d want 2", result.KeysDestroyed)
+	}
+	if len(result.Skipped) != 0 {
+		t.Errorf("Skipped=%v want empty", result.Skipped)
+	}
+}
+
+func TestDEKDestructionWorkflow_skipMissingKEKHint(t *testing.T) {
+	s := &testsuite.WorkflowTestSuite{}
+	env := s.NewTestWorkflowEnvironment()
+	env.RegisterWorkflow(DEKDestructionWorkflow)
+	registerDEKActivityStubs(env)
+
+	in := dekTestInput()
+	env.OnActivity(ActivityNameListEligiblePartitions, mock.Anything, mock.Anything).
+		Return(ListEligibleResult{Partitions: []EligiblePartition{
+			{Year: 2027, Month: 1, PartitionName: "p1", LakeURI: "s3://b/k.parquet", KEKHint: ""},
+		}}, nil)
+	// No legal-hold / approval / destroy / emit invocations expected.
+
+	env.ExecuteWorkflow(DEKDestructionWorkflow, in)
+
+	var result DEKDestructionResult
+	_ = env.GetWorkflowResult(&result)
+	if result.KeysDestroyed != 0 {
+		t.Errorf("KeysDestroyed=%d want 0", result.KeysDestroyed)
+	}
+	if len(result.Skipped) != 1 || !contains(result.Skipped[0], "missing_kek_hint") {
+		t.Errorf("Skipped=%v want one missing_kek_hint entry", result.Skipped)
+	}
+}
+
+func TestDEKDestructionWorkflow_skipLegalHold(t *testing.T) {
+	s := &testsuite.WorkflowTestSuite{}
+	env := s.NewTestWorkflowEnvironment()
+	env.RegisterWorkflow(DEKDestructionWorkflow)
+	registerDEKActivityStubs(env)
+
+	env.OnActivity(ActivityNameListEligiblePartitions, mock.Anything, mock.Anything).
+		Return(ListEligibleResult{Partitions: []EligiblePartition{
+			{Year: 2027, Month: 1, PartitionName: "p1", LakeURI: "s3://b/k.parquet", KEKHint: "platform-billing-v1"},
+		}}, nil)
+	env.OnActivity(ActivityNameCheckLegalHold, mock.Anything, mock.Anything).
+		Return(LegalHoldCheckResult{Held: true, Reason: "litigation-x"}, nil)
+
+	env.ExecuteWorkflow(DEKDestructionWorkflow, dekTestInput())
+
+	var result DEKDestructionResult
+	_ = env.GetWorkflowResult(&result)
+	if result.KeysDestroyed != 0 {
+		t.Errorf("KeysDestroyed=%d want 0", result.KeysDestroyed)
+	}
+	if len(result.Skipped) != 1 || !contains(result.Skipped[0], "legal_hold:litigation-x") {
+		t.Errorf("Skipped=%v want legal_hold entry", result.Skipped)
+	}
+}
+
+func TestDEKDestructionWorkflow_skipApprovalRejected(t *testing.T) {
+	s := &testsuite.WorkflowTestSuite{}
+	env := s.NewTestWorkflowEnvironment()
+	env.RegisterWorkflow(DEKDestructionWorkflow)
+	registerDEKActivityStubs(env)
+
+	env.OnActivity(ActivityNameListEligiblePartitions, mock.Anything, mock.Anything).
+		Return(ListEligibleResult{Partitions: []EligiblePartition{
+			{Year: 2027, Month: 1, PartitionName: "p1", LakeURI: "s3://b/k.parquet", KEKHint: "platform-billing-v1"},
+		}}, nil)
+	env.OnActivity(ActivityNameCheckLegalHold, mock.Anything, mock.Anything).
+		Return(LegalHoldCheckResult{Held: false}, nil)
+	env.OnActivity(ActivityNameRequestOperatorApproval, mock.Anything, mock.Anything).
+		Return(OperatorApprovalResult{Approved: false, Reason: "needs-review"}, nil)
+
+	env.ExecuteWorkflow(DEKDestructionWorkflow, dekTestInput())
+
+	var result DEKDestructionResult
+	_ = env.GetWorkflowResult(&result)
+	if result.KeysDestroyed != 0 {
+		t.Errorf("KeysDestroyed=%d want 0", result.KeysDestroyed)
+	}
+	if len(result.Skipped) != 1 || !contains(result.Skipped[0], "approval_rejected:needs-review") {
+		t.Errorf("Skipped=%v want approval_rejected entry", result.Skipped)
+	}
+}
+
+func TestDEKDestructionWorkflow_skipDestroyError(t *testing.T) {
+	s := &testsuite.WorkflowTestSuite{}
+	env := s.NewTestWorkflowEnvironment()
+	env.RegisterWorkflow(DEKDestructionWorkflow)
+	registerDEKActivityStubs(env)
+
+	env.OnActivity(ActivityNameListEligiblePartitions, mock.Anything, mock.Anything).
+		Return(ListEligibleResult{Partitions: []EligiblePartition{
+			{Year: 2027, Month: 1, PartitionName: "p1", LakeURI: "s3://b/k.parquet", KEKHint: "platform-billing-v1"},
+		}}, nil)
+	env.OnActivity(ActivityNameCheckLegalHold, mock.Anything, mock.Anything).
+		Return(LegalHoldCheckResult{Held: false}, nil)
+	env.OnActivity(ActivityNameRequestOperatorApproval, mock.Anything, mock.Anything).
+		Return(OperatorApprovalResult{Approved: true}, nil)
+	env.OnActivity(ActivityNameDestroyDEK, mock.Anything, mock.Anything).
+		Return(DestroyDEKResult{}, errors.New("vault: 503"))
+
+	env.ExecuteWorkflow(DEKDestructionWorkflow, dekTestInput())
+
+	var result DEKDestructionResult
+	_ = env.GetWorkflowResult(&result)
+	if result.KeysDestroyed != 0 {
+		t.Errorf("KeysDestroyed=%d want 0", result.KeysDestroyed)
+	}
+	if len(result.Skipped) != 1 || !contains(result.Skipped[0], "destroy_error") {
+		t.Errorf("Skipped=%v want destroy_error entry", result.Skipped)
+	}
+}
+
+func TestDEKDestructionWorkflow_emitErrorStillCountsDestroyed(t *testing.T) {
+	s := &testsuite.WorkflowTestSuite{}
+	env := s.NewTestWorkflowEnvironment()
+	env.RegisterWorkflow(DEKDestructionWorkflow)
+	registerDEKActivityStubs(env)
+
+	env.OnActivity(ActivityNameListEligiblePartitions, mock.Anything, mock.Anything).
+		Return(ListEligibleResult{Partitions: []EligiblePartition{
+			{Year: 2027, Month: 1, PartitionName: "p1", LakeURI: "s3://b/k.parquet", KEKHint: "platform-billing-v1"},
+		}}, nil)
+	env.OnActivity(ActivityNameCheckLegalHold, mock.Anything, mock.Anything).
+		Return(LegalHoldCheckResult{Held: false}, nil)
+	env.OnActivity(ActivityNameRequestOperatorApproval, mock.Anything, mock.Anything).
+		Return(OperatorApprovalResult{Approved: true}, nil)
+	env.OnActivity(ActivityNameDestroyDEK, mock.Anything, mock.Anything).
+		Return(DestroyDEKResult{VaultKeyVersion: 1}, nil)
+	env.OnActivity(ActivityNameEmitDEKDestroyed, mock.Anything, mock.Anything).
+		Return(errors.New("billing-svc: 500"))
+
+	env.ExecuteWorkflow(DEKDestructionWorkflow, dekTestInput())
+
+	var result DEKDestructionResult
+	_ = env.GetWorkflowResult(&result)
+	if result.KeysDestroyed != 1 {
+		t.Errorf("KeysDestroyed=%d want 1 (irreversible side effect happened)", result.KeysDestroyed)
+	}
+	if len(result.Skipped) != 1 || !contains(result.Skipped[0], "emit_error") {
+		t.Errorf("Skipped=%v want emit_error entry", result.Skipped)
+	}
+}
+
+func TestDEKDestructionWorkflow_zeroCutoffRejected(t *testing.T) {
+	s := &testsuite.WorkflowTestSuite{}
+	env := s.NewTestWorkflowEnvironment()
+	env.RegisterWorkflow(DEKDestructionWorkflow)
+	env.ExecuteWorkflow(DEKDestructionWorkflow, DEKDestructionInput{})
+	if env.GetWorkflowError() == nil {
+		t.Error("expected error when cutoff is zero")
+	}
+}
+
+// contains is a tiny helper to avoid pulling strings into the test imports.
+func contains(haystack, needle string) bool {
+	for i := 0; i+len(needle) <= len(haystack); i++ {
+		if haystack[i:i+len(needle)] == needle {
+			return true
+		}
+	}
+	return false
+}

--- a/plane/workflow/billing/destroy_dek_activity.go
+++ b/plane/workflow/billing/destroy_dek_activity.go
@@ -1,0 +1,189 @@
+package billing
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+
+	vault "github.com/hashicorp/vault/api"
+)
+
+// ActivityNameDestroyDEK is the registered name for the
+// DestroyDEKActivity.Execute method.
+const ActivityNameDestroyDEK = "billing.DestroyDEK"
+
+// DestroyDEKInput identifies the per-month DEK to destroy. KEKHint is the
+// "platform-billing-v<N>" string captured at archive time. Year/Month are
+// passed for log correlation and idempotency-key derivation.
+type DestroyDEKInput struct {
+	Year    int
+	Month   int
+	KEKHint string
+}
+
+// DestroyDEKResult records the destroyed Vault transit key version. The
+// workflow propagates this into the EmitDEKDestroyed activity input so the
+// outbox payload pins the destroyed version.
+type DestroyDEKResult struct {
+	VaultKeyVersion int
+}
+
+// vaultLogicalClient is the subset of vault.Client used by DestroyDEKActivity.
+// Defined as an interface so unit tests can substitute a fake without
+// booting a Vault testcontainer.
+type vaultLogicalClient interface {
+	ReadWithContext(ctx context.Context, path string) (*vault.Secret, error)
+	WriteWithContext(ctx context.Context, path string, data map[string]any) (*vault.Secret, error)
+}
+
+// DestroyDEKActivity destroys a specific historical version of a Vault
+// transit key by raising the key's min_decryption_version above the target
+// version, then trimming. Vault transit does not expose a per-version
+// destroy endpoint (only per-key DELETE and bulk trim); this activity uses
+// the documented trim path to achieve the per-version crypto-shred ADR-018
+// §Encryption requires.
+//
+// Idempotency: the activity tolerates pre-trimmed versions. Reading the key
+// metadata first; if the target version is already absent (because
+// min_available_version > target), Execute returns nil. This makes Temporal
+// activity retry safe even after an irreversible side effect succeeded.
+//
+// Pre-conditions on the Vault key (configured at provisioning time, not
+// here):
+//   - deletion_allowed=true (allow trim)
+//   - min_decryption_version is monotonically increased per-month destroy,
+//     which aligns with the workflow's deterministic ascending iteration.
+//
+// Per-month DEKs are destroyed in ascending (year, month) order, which
+// keeps the trim semantics simple: the workflow trims to N+1 only after
+// all versions ≤N have already been logically retired by previous runs.
+type DestroyDEKActivity struct {
+	logical vaultLogicalClient
+	mount   string
+	keyName string
+}
+
+// NewDestroyDEKActivity returns a DestroyDEKActivity backed by client.
+// Empty mount or keyName default to the same constants used by the export
+// path (DefaultVaultTransitMount, DefaultVaultBillingKeyName).
+func NewDestroyDEKActivity(client *vault.Client, mount, keyName string) (*DestroyDEKActivity, error) {
+	if client == nil {
+		return nil, errors.New("billing.NewDestroyDEKActivity: client is nil")
+	}
+	if mount == "" {
+		mount = DefaultVaultTransitMount
+	}
+	if keyName == "" {
+		keyName = DefaultVaultBillingKeyName
+	}
+	return &DestroyDEKActivity{logical: client.Logical(), mount: mount, keyName: keyName}, nil
+}
+
+// newDestroyDEKActivityWithLogical is a test seam — production callers use
+// NewDestroyDEKActivity. The vaultLogicalClient interface keeps unit tests
+// off the Vault testcontainer.
+func newDestroyDEKActivityWithLogical(logical vaultLogicalClient, mount, keyName string) *DestroyDEKActivity {
+	if mount == "" {
+		mount = DefaultVaultTransitMount
+	}
+	if keyName == "" {
+		keyName = DefaultVaultBillingKeyName
+	}
+	return &DestroyDEKActivity{logical: logical, mount: mount, keyName: keyName}
+}
+
+// Execute crypto-shreds the Vault transit key version embedded in
+// in.KEKHint. Idempotent: if the target version is already trimmed (Vault
+// reports min_available_version > target or the key 404s on read), Execute
+// returns the parsed version with nil error so the workflow can proceed to
+// emit the audit event and not block on Temporal's retry loop.
+func (a *DestroyDEKActivity) Execute(ctx context.Context, in DestroyDEKInput) (DestroyDEKResult, error) {
+	version, err := parseKEKHintVersion(in.KEKHint)
+	if err != nil {
+		return DestroyDEKResult{}, err
+	}
+
+	keyPath := fmt.Sprintf("%s/keys/%s", a.mount, a.keyName)
+	configPath := fmt.Sprintf("%s/config", keyPath)
+	trimPath := fmt.Sprintf("%s/trim", keyPath)
+
+	// Idempotency probe: read the key metadata. A 404 (nil secret) means the
+	// key itself has been deleted, treated as already-destroyed.
+	secret, err := a.logical.ReadWithContext(ctx, keyPath)
+	if err != nil {
+		return DestroyDEKResult{}, fmt.Errorf("destroy dek: read %s: %w", keyPath, err)
+	}
+	if secret == nil || secret.Data == nil {
+		// 404 → already shredded. Idempotent success.
+		return DestroyDEKResult{VaultKeyVersion: version}, nil
+	}
+	minAvail := readIntFromSecret(secret.Data, "min_available_version")
+	if minAvail > version {
+		// Already trimmed past the target version.
+		return DestroyDEKResult{VaultKeyVersion: version}, nil
+	}
+
+	// Step 1: raise min_decryption_version above the target. Trim refuses to
+	// run unless min_available_version <= min_decryption_version. We bump it
+	// to version+1 so trim can advance to version+1.
+	if _, err := a.logical.WriteWithContext(ctx, configPath, map[string]any{
+		"min_decryption_version": version + 1,
+	}); err != nil {
+		return DestroyDEKResult{}, fmt.Errorf("destroy dek: config %s: %w", configPath, err)
+	}
+
+	// Step 2: trim. min_available_version=version+1 permanently deletes
+	// every version <= version. IRREVERSIBLE.
+	if _, err := a.logical.WriteWithContext(ctx, trimPath, map[string]any{
+		"min_available_version": version + 1,
+	}); err != nil {
+		return DestroyDEKResult{}, fmt.Errorf("destroy dek: trim %s: %w", trimPath, err)
+	}
+
+	return DestroyDEKResult{VaultKeyVersion: version}, nil
+}
+
+// parseKEKHintVersion extracts N from "platform-billing-v<N>" hints.
+// Mirrors VaultKeyProvider's emit format (vault_keyprovider.go).
+func parseKEKHintVersion(hint string) (int, error) {
+	if hint == "" {
+		return 0, errors.New("destroy dek: empty kek_hint")
+	}
+	idx := strings.LastIndex(hint, "-v")
+	if idx < 0 {
+		return 0, fmt.Errorf("destroy dek: malformed kek_hint %q", hint)
+	}
+	tail := hint[idx+2:]
+	v, err := strconv.Atoi(tail)
+	if err != nil || v < 1 {
+		return 0, fmt.Errorf("destroy dek: bad version in kek_hint %q: %w", hint, err)
+	}
+	return v, nil
+}
+
+// readIntFromSecret coerces a Vault response field to an int. Vault SDK
+// returns numeric fields as json.Number or float64 depending on transport;
+// both are handled here.
+func readIntFromSecret(data map[string]any, key string) int {
+	v, ok := data[key]
+	if !ok {
+		return 0
+	}
+	switch x := v.(type) {
+	case int:
+		return x
+	case int64:
+		return int(x)
+	case float64:
+		return int(x)
+	default:
+		// json.Number Stringer fallback
+		if s, ok := v.(fmt.Stringer); ok {
+			n, _ := strconv.Atoi(s.String())
+			return n
+		}
+	}
+	return 0
+}

--- a/plane/workflow/billing/destroy_dek_activity.go
+++ b/plane/workflow/billing/destroy_dek_activity.go
@@ -125,11 +125,18 @@ func (a *DestroyDEKActivity) Execute(ctx context.Context, in DestroyDEKInput) (D
 		return DestroyDEKResult{VaultKeyVersion: version}, nil
 	}
 
-	// Step 1: raise min_decryption_version above the target. Trim refuses to
-	// run unless min_available_version <= min_decryption_version. We bump it
-	// to version+1 so trim can advance to version+1.
+	// Step 1: raise min_decryption_version AND min_encryption_version above
+	// the target. Vault enforces min_available_version <= min(
+	// min_encryption_version, min_decryption_version); trim returns 400
+	// "minimum available version cannot be set when minimum encryption
+	// version is not set" if min_encryption_version is left at zero. Bumping
+	// both to version+1 is safe: the workflow iterates ascending (year,
+	// month) so older DEK versions are always destroyed before newer ones,
+	// and live encryption operations transparently use the latest key
+	// version regardless.
 	if _, err := a.logical.WriteWithContext(ctx, configPath, map[string]any{
 		"min_decryption_version": version + 1,
+		"min_encryption_version": version + 1,
 	}); err != nil {
 		return DestroyDEKResult{}, fmt.Errorf("destroy dek: config %s: %w", configPath, err)
 	}

--- a/plane/workflow/billing/destroy_dek_activity_test.go
+++ b/plane/workflow/billing/destroy_dek_activity_test.go
@@ -68,6 +68,9 @@ func TestDestroyDEKActivity_HappyPath_BumpsAndTrims(t *testing.T) {
 	if fake.writeCalls[0].data["min_decryption_version"] != 4 {
 		t.Errorf("min_decryption_version=%v want 4", fake.writeCalls[0].data["min_decryption_version"])
 	}
+	if fake.writeCalls[0].data["min_encryption_version"] != 4 {
+		t.Errorf("min_encryption_version=%v want 4", fake.writeCalls[0].data["min_encryption_version"])
+	}
 	if fake.writeCalls[1].path != "transit/keys/platform-billing-master/trim" {
 		t.Errorf("second write path=%q", fake.writeCalls[1].path)
 	}

--- a/plane/workflow/billing/destroy_dek_activity_test.go
+++ b/plane/workflow/billing/destroy_dek_activity_test.go
@@ -1,0 +1,144 @@
+package billing
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	vault "github.com/hashicorp/vault/api"
+)
+
+// fakeVaultLogical captures Read/Write calls for assertions and replays
+// scripted responses. Used by DestroyDEKActivity unit tests so the suite
+// runs without a Vault testcontainer.
+type fakeVaultLogical struct {
+	readPath string
+	readResp *vault.Secret
+	readErr  error
+
+	writeCalls []writeCall
+	writeErr   map[string]error
+}
+
+type writeCall struct {
+	path string
+	data map[string]any
+}
+
+func (f *fakeVaultLogical) ReadWithContext(_ context.Context, path string) (*vault.Secret, error) {
+	f.readPath = path
+	if f.readErr != nil {
+		return nil, f.readErr
+	}
+	return f.readResp, nil
+}
+
+func (f *fakeVaultLogical) WriteWithContext(_ context.Context, path string, data map[string]any) (*vault.Secret, error) {
+	f.writeCalls = append(f.writeCalls, writeCall{path: path, data: data})
+	if err := f.writeErr[path]; err != nil {
+		return nil, err
+	}
+	return nil, nil
+}
+
+func TestDestroyDEKActivity_HappyPath_BumpsAndTrims(t *testing.T) {
+	fake := &fakeVaultLogical{
+		readResp: &vault.Secret{Data: map[string]any{"min_available_version": float64(0)}},
+	}
+	a := newDestroyDEKActivityWithLogical(fake, "transit", "platform-billing-master")
+
+	res, err := a.Execute(context.Background(), DestroyDEKInput{
+		Year: 2027, Month: 1, KEKHint: "platform-billing-v3",
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if res.VaultKeyVersion != 3 {
+		t.Errorf("VaultKeyVersion=%d want 3", res.VaultKeyVersion)
+	}
+	if fake.readPath != "transit/keys/platform-billing-master" {
+		t.Errorf("read path=%q", fake.readPath)
+	}
+	if len(fake.writeCalls) != 2 {
+		t.Fatalf("write calls=%d want 2", len(fake.writeCalls))
+	}
+	if fake.writeCalls[0].path != "transit/keys/platform-billing-master/config" {
+		t.Errorf("first write path=%q", fake.writeCalls[0].path)
+	}
+	if fake.writeCalls[0].data["min_decryption_version"] != 4 {
+		t.Errorf("min_decryption_version=%v want 4", fake.writeCalls[0].data["min_decryption_version"])
+	}
+	if fake.writeCalls[1].path != "transit/keys/platform-billing-master/trim" {
+		t.Errorf("second write path=%q", fake.writeCalls[1].path)
+	}
+	if fake.writeCalls[1].data["min_available_version"] != 4 {
+		t.Errorf("min_available_version=%v want 4", fake.writeCalls[1].data["min_available_version"])
+	}
+}
+
+func TestDestroyDEKActivity_AlreadyTrimmed_Idempotent(t *testing.T) {
+	fake := &fakeVaultLogical{
+		readResp: &vault.Secret{Data: map[string]any{"min_available_version": float64(5)}},
+	}
+	a := newDestroyDEKActivityWithLogical(fake, "transit", "platform-billing-master")
+
+	res, err := a.Execute(context.Background(), DestroyDEKInput{
+		Year: 2027, Month: 1, KEKHint: "platform-billing-v3",
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if res.VaultKeyVersion != 3 {
+		t.Errorf("VaultKeyVersion=%d want 3", res.VaultKeyVersion)
+	}
+	if len(fake.writeCalls) != 0 {
+		t.Errorf("expected no writes when already trimmed, got %d", len(fake.writeCalls))
+	}
+}
+
+func TestDestroyDEKActivity_KeyDeleted_Idempotent(t *testing.T) {
+	// Vault 404 → nil secret. Treated as already-shredded.
+	fake := &fakeVaultLogical{readResp: nil}
+	a := newDestroyDEKActivityWithLogical(fake, "transit", "platform-billing-master")
+
+	res, err := a.Execute(context.Background(), DestroyDEKInput{
+		Year: 2027, Month: 1, KEKHint: "platform-billing-v3",
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if res.VaultKeyVersion != 3 {
+		t.Errorf("VaultKeyVersion=%d want 3", res.VaultKeyVersion)
+	}
+	if len(fake.writeCalls) != 0 {
+		t.Errorf("expected no writes when key absent, got %d", len(fake.writeCalls))
+	}
+}
+
+func TestDestroyDEKActivity_BadKEKHint(t *testing.T) {
+	fake := &fakeVaultLogical{}
+	a := newDestroyDEKActivityWithLogical(fake, "", "")
+
+	cases := []string{"", "platform-billing", "platform-billing-vXYZ", "platform-billing-v0"}
+	for _, hint := range cases {
+		_, err := a.Execute(context.Background(), DestroyDEKInput{Year: 2027, Month: 1, KEKHint: hint})
+		if err == nil {
+			t.Errorf("expected error for hint %q", hint)
+		}
+	}
+}
+
+func TestDestroyDEKActivity_TrimError_Surfaces(t *testing.T) {
+	fake := &fakeVaultLogical{
+		readResp: &vault.Secret{Data: map[string]any{"min_available_version": float64(0)}},
+		writeErr: map[string]error{
+			"transit/keys/platform-billing-master/trim": errors.New("vault: trim refused"),
+		},
+	}
+	a := newDestroyDEKActivityWithLogical(fake, "", "")
+
+	_, err := a.Execute(context.Background(), DestroyDEKInput{Year: 2027, Month: 1, KEKHint: "platform-billing-v3"})
+	if err == nil {
+		t.Fatal("expected trim error")
+	}
+}

--- a/plane/workflow/billing/emit_dek_destroyed_activity.go
+++ b/plane/workflow/billing/emit_dek_destroyed_activity.go
@@ -1,0 +1,50 @@
+package billing
+
+import (
+	"context"
+	"errors"
+
+	"github.com/gitscale-platform/gitscale/plane/workflow/appclient"
+)
+
+// ActivityNameEmitDEKDestroyed is the registered name for the
+// EmitDEKDestroyedActivity.Execute method.
+const ActivityNameEmitDEKDestroyed = "billing.EmitDEKDestroyedEvent"
+
+// EmitDEKDestroyedInput is the input to EmitDEKDestroyedActivity.Execute.
+type EmitDEKDestroyedInput struct {
+	Year            int
+	Month           int
+	PartitionName   string
+	KEKHint         string
+	VaultKeyVersion int
+}
+
+// EmitDEKDestroyedActivity calls appclient.BillingClient.RecordDEKDestroyed,
+// which routes to the billing app-plane service (ADR-019). The service
+// writes billing.partition_dek_destroyed to billing_outbox in a single
+// transaction (ADR-008). Idempotent on (year, month, partition_name,
+// kek_hint).
+type EmitDEKDestroyedActivity struct {
+	client appclient.BillingClient
+}
+
+// NewEmitDEKDestroyedActivity returns an EmitDEKDestroyedActivity. Returns
+// an error if client is nil so the worker boot path fails fast.
+func NewEmitDEKDestroyedActivity(client appclient.BillingClient) (*EmitDEKDestroyedActivity, error) {
+	if client == nil {
+		return nil, errors.New("billing.NewEmitDEKDestroyedActivity: client is nil")
+	}
+	return &EmitDEKDestroyedActivity{client: client}, nil
+}
+
+// Execute calls RecordDEKDestroyed on the billing app-plane service.
+func (a *EmitDEKDestroyedActivity) Execute(ctx context.Context, in EmitDEKDestroyedInput) error {
+	return a.client.RecordDEKDestroyed(ctx, appclient.DEKDestroyedInput{
+		Year:            in.Year,
+		Month:           in.Month,
+		PartitionName:   in.PartitionName,
+		KEKHint:         in.KEKHint,
+		VaultKeyVersion: in.VaultKeyVersion,
+	})
+}

--- a/plane/workflow/billing/emit_dek_destroyed_activity_test.go
+++ b/plane/workflow/billing/emit_dek_destroyed_activity_test.go
@@ -1,0 +1,48 @@
+package billing
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/gitscale-platform/gitscale/plane/workflow/appclient"
+)
+
+func TestEmitDEKDestroyedActivity_ForwardsToBillingClient(t *testing.T) {
+	stub := appclient.NewStubBillingClient()
+	a, err := NewEmitDEKDestroyedActivity(stub)
+	if err != nil {
+		t.Fatalf("NewEmitDEKDestroyedActivity: %v", err)
+	}
+	in := EmitDEKDestroyedInput{
+		Year: 2027, Month: 1, PartitionName: "p1",
+		KEKHint: "platform-billing-v1", VaultKeyVersion: 1,
+	}
+	if err := a.Execute(context.Background(), in); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	calls := stub.DEKCalls()
+	if len(calls) != 1 {
+		t.Fatalf("DEKCalls=%d want 1", len(calls))
+	}
+	if calls[0].KEKHint != "platform-billing-v1" || calls[0].VaultKeyVersion != 1 {
+		t.Errorf("call payload mismatch: %+v", calls[0])
+	}
+}
+
+func TestEmitDEKDestroyedActivity_NilClientRejected(t *testing.T) {
+	if _, err := NewEmitDEKDestroyedActivity(nil); err == nil {
+		t.Error("expected error for nil client")
+	}
+}
+
+func TestEmitDEKDestroyedActivity_PropagatesClientError(t *testing.T) {
+	stub := appclient.NewStubBillingClient()
+	stub.SetDEKFn(func(_ appclient.DEKDestroyedInput) error { return errors.New("rpc failed") })
+	a, _ := NewEmitDEKDestroyedActivity(stub)
+	if err := a.Execute(context.Background(), EmitDEKDestroyedInput{
+		Year: 2027, Month: 1, PartitionName: "p1", KEKHint: "platform-billing-v1", VaultKeyVersion: 1,
+	}); err == nil {
+		t.Error("expected error to propagate")
+	}
+}

--- a/plane/workflow/billing/list_eligible_partitions_activity.go
+++ b/plane/workflow/billing/list_eligible_partitions_activity.go
@@ -1,0 +1,99 @@
+package billing
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/gitscale-platform/gitscale/plane/data/store"
+)
+
+// ActivityNameListEligiblePartitions is the registered name for the
+// ListEligiblePartitionsActivity.Execute method. The DEK destruction
+// workflow dispatches by string so tests can substitute a fake.
+const ActivityNameListEligiblePartitions = "billing.ListEligiblePartitionsForDEKDestroy"
+
+// ListEligibleInput is the input to ListEligiblePartitionsActivity.Execute.
+// Cutoff is the upper bound: rows with archived_at < cutoff are returned.
+type ListEligibleInput struct {
+	Cutoff time.Time
+}
+
+// EligiblePartition is a per-partition record returned to the workflow.
+// KEKHint is the manifest hint embedded at archive time and is required for
+// DestroyDEKActivity. KEKHint may be empty for legacy archives written
+// before the DEK destruction workflow shipped — those rows are surfaced
+// here so the workflow can record a "missing_kek_hint" skip and operators
+// can backfill via the runbook.
+type EligiblePartition struct {
+	Year          int
+	Month         int
+	PartitionName string
+	LakeURI       string
+	ArchivedAt    time.Time
+	KEKHint       string
+}
+
+// ListEligibleResult is the activity's return type — a deterministic
+// slice (sorted by year, month, partition id) is propagated to the workflow.
+type ListEligibleResult struct {
+	Partitions []EligiblePartition
+}
+
+// KEKHintResolver looks up the kek_hint for a given partition archive.
+// For #80 we read it out of the manifest.json sitting in the object store
+// next to the encrypted parquet (issue #74's archiveManifest, see
+// export_activity.go). The interface keeps the activity testable without
+// a real object store.
+type KEKHintResolver interface {
+	ResolveKEKHint(ctx context.Context, lakeURI string) (string, error)
+}
+
+// ListEligiblePartitionsActivity scans billing.partition_archives for rows
+// older than the cutoff and resolves each row's kek_hint via the supplied
+// resolver. Errors resolving an individual hint do not abort the activity:
+// the row is returned with KEKHint == "" and the workflow records a skip.
+type ListEligiblePartitionsActivity struct {
+	store    store.MetadataStore
+	resolver KEKHintResolver
+}
+
+// NewListEligiblePartitionsActivity returns a ListEligiblePartitionsActivity.
+// Both deps must be non-nil so the worker boot path fails fast.
+func NewListEligiblePartitionsActivity(s store.MetadataStore, r KEKHintResolver) (*ListEligiblePartitionsActivity, error) {
+	if s == nil {
+		return nil, errors.New("billing.NewListEligiblePartitionsActivity: store is nil")
+	}
+	if r == nil {
+		return nil, errors.New("billing.NewListEligiblePartitionsActivity: resolver is nil")
+	}
+	return &ListEligiblePartitionsActivity{store: s, resolver: r}, nil
+}
+
+// Execute returns the deterministic list of eligible partitions older than
+// in.Cutoff. Errors resolving any individual kek_hint are swallowed and the
+// row is returned with KEKHint=="" so the workflow can record a skip rather
+// than aborting the run for the entire batch.
+func (a *ListEligiblePartitionsActivity) Execute(ctx context.Context, in ListEligibleInput) (ListEligibleResult, error) {
+	if in.Cutoff.IsZero() {
+		return ListEligibleResult{}, errors.New("billing.ListEligiblePartitions: cutoff is zero")
+	}
+	rows, err := a.store.Billing().ListPartitionArchivesArchivedBefore(ctx, in.Cutoff)
+	if err != nil {
+		return ListEligibleResult{}, fmt.Errorf("billing.ListEligiblePartitions: %w", err)
+	}
+	out := make([]EligiblePartition, 0, len(rows))
+	for _, pa := range rows {
+		hint, _ := a.resolver.ResolveKEKHint(ctx, pa.LakeURI) // best-effort
+		out = append(out, EligiblePartition{
+			Year:          pa.Year,
+			Month:         pa.Month,
+			PartitionName: pa.PartitionName,
+			LakeURI:       pa.LakeURI,
+			ArchivedAt:    pa.ArchivedAt,
+			KEKHint:       hint,
+		})
+	}
+	return ListEligibleResult{Partitions: out}, nil
+}

--- a/plane/workflow/billing/list_eligible_partitions_activity_test.go
+++ b/plane/workflow/billing/list_eligible_partitions_activity_test.go
@@ -1,0 +1,105 @@
+package billing
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/gitscale-platform/gitscale/plane/data/store"
+	stubstore "github.com/gitscale-platform/gitscale/plane/data/store/stub"
+	"github.com/google/uuid"
+)
+
+type fakeKEKResolver struct {
+	hints map[string]string
+	errs  map[string]error
+}
+
+func (f *fakeKEKResolver) ResolveKEKHint(_ context.Context, lakeURI string) (string, error) {
+	if err, ok := f.errs[lakeURI]; ok {
+		return "", err
+	}
+	return f.hints[lakeURI], nil
+}
+
+func TestListEligiblePartitionsActivity_FiltersByCutoff_AndResolvesHints(t *testing.T) {
+	ms := stubstore.New()
+	cutoff := time.Date(2034, 6, 1, 0, 0, 0, 0, time.UTC)
+
+	// Seed the in-memory store with 2 old + 1 new partition archive. Use
+	// the writer path to mirror production semantics.
+	old1ID, old2ID, recentID := uuid.New(), uuid.New(), uuid.New()
+	if err := ms.Transact(context.Background(), func(tx store.Tx) error {
+		_, _, err := tx.Billing().InsertPartitionArchiveIfAbsent(context.Background(), store.PartitionArchive{
+			ID: old1ID, Year: 2027, Month: 1, PartitionName: "p1",
+			LakeURI: "s3://b/p1.parquet", ArchivedAt: cutoff.AddDate(0, 0, -10),
+		})
+		if err != nil {
+			return err
+		}
+		_, _, err = tx.Billing().InsertPartitionArchiveIfAbsent(context.Background(), store.PartitionArchive{
+			ID: old2ID, Year: 2027, Month: 2, PartitionName: "p2",
+			LakeURI: "s3://b/p2.parquet", ArchivedAt: cutoff.AddDate(0, 0, -5),
+		})
+		if err != nil {
+			return err
+		}
+		_, _, err = tx.Billing().InsertPartitionArchiveIfAbsent(context.Background(), store.PartitionArchive{
+			ID: recentID, Year: 2034, Month: 5, PartitionName: "recent",
+			LakeURI: "s3://b/recent.parquet", ArchivedAt: cutoff.AddDate(0, 0, 5),
+		})
+		return err
+	}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	resolver := &fakeKEKResolver{
+		hints: map[string]string{
+			"s3://b/p1.parquet": "platform-billing-v1",
+			"s3://b/p2.parquet": "", // simulates resolution failure → empty hint, workflow skips
+		},
+		errs: map[string]error{
+			"s3://b/p2.parquet": errors.New("manifest 404"),
+		},
+	}
+
+	a, err := NewListEligiblePartitionsActivity(ms, resolver)
+	if err != nil {
+		t.Fatalf("NewListEligiblePartitionsActivity: %v", err)
+	}
+	res, err := a.Execute(context.Background(), ListEligibleInput{Cutoff: cutoff})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if len(res.Partitions) != 2 {
+		t.Fatalf("Partitions=%d want 2 (recent excluded)", len(res.Partitions))
+	}
+	if res.Partitions[0].KEKHint != "platform-billing-v1" {
+		t.Errorf("p1 KEKHint=%q want platform-billing-v1", res.Partitions[0].KEKHint)
+	}
+	if res.Partitions[1].KEKHint != "" {
+		t.Errorf("p2 KEKHint=%q want empty (resolver error → skip path)", res.Partitions[1].KEKHint)
+	}
+	if res.Partitions[0].Year != 2027 || res.Partitions[0].Month != 1 {
+		t.Errorf("ordering broken: first=%v", res.Partitions[0])
+	}
+}
+
+func TestListEligiblePartitionsActivity_ZeroCutoffRejected(t *testing.T) {
+	ms := stubstore.New()
+	a, _ := NewListEligiblePartitionsActivity(ms, &fakeKEKResolver{})
+	_, err := a.Execute(context.Background(), ListEligibleInput{})
+	if err == nil {
+		t.Error("expected error for zero cutoff")
+	}
+}
+
+func TestNewListEligiblePartitionsActivity_NilDeps(t *testing.T) {
+	if _, err := NewListEligiblePartitionsActivity(nil, &fakeKEKResolver{}); err == nil {
+		t.Error("expected error for nil store")
+	}
+	if _, err := NewListEligiblePartitionsActivity(stubstore.New(), nil); err == nil {
+		t.Error("expected error for nil resolver")
+	}
+}

--- a/plane/workflow/billing/manifest_kekhint_resolver.go
+++ b/plane/workflow/billing/manifest_kekhint_resolver.go
@@ -1,0 +1,64 @@
+package billing
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// ManifestKEKHintResolver resolves a partition's kek_hint by fetching the
+// archiveManifest JSON sibling from the object store. The manifest key is
+// derived from the lake URI by replacing ".parquet" with ".manifest.json".
+//
+// Used by ListEligiblePartitionsActivity (#80). Failures (missing manifest,
+// malformed JSON, empty kek_hint) return an error; the caller treats this
+// as a "missing_kek_hint" skip rather than aborting the run.
+type ManifestKEKHintResolver struct {
+	store  ObjectStore
+	bucket string
+}
+
+// NewManifestKEKHintResolver wraps the supplied ObjectStore. The bucket is
+// used to strip the canonical "s3://<bucket>/" prefix from the lake URI to
+// recover the object key. Both deps must be non-nil.
+func NewManifestKEKHintResolver(store ObjectStore, bucket string) (*ManifestKEKHintResolver, error) {
+	if store == nil {
+		return nil, errors.New("billing.NewManifestKEKHintResolver: store is nil")
+	}
+	if bucket == "" {
+		return nil, errors.New("billing.NewManifestKEKHintResolver: bucket is empty")
+	}
+	return &ManifestKEKHintResolver{store: store, bucket: bucket}, nil
+}
+
+// ResolveKEKHint reads the manifest.json next to the parquet at lakeURI and
+// returns the kek_hint string. lakeURI is expected to end in ".parquet"; any
+// other suffix returns an error. A missing kek_hint key in the manifest is
+// reported as an error so the workflow can skip the partition explicitly.
+func (r *ManifestKEKHintResolver) ResolveKEKHint(ctx context.Context, lakeURI string) (string, error) {
+	prefix := fmt.Sprintf("s3://%s/", r.bucket)
+	if !strings.HasPrefix(lakeURI, prefix) {
+		return "", fmt.Errorf("manifest resolver: lake_uri %q does not start with %q", lakeURI, prefix)
+	}
+	parquetKey := strings.TrimPrefix(lakeURI, prefix)
+	if !strings.HasSuffix(parquetKey, ".parquet") {
+		return "", fmt.Errorf("manifest resolver: lake_uri %q does not end in .parquet", lakeURI)
+	}
+	manifestKey := strings.TrimSuffix(parquetKey, ".parquet") + ".manifest.json"
+	data, err := r.store.GetBytes(ctx, manifestKey)
+	if err != nil {
+		return "", fmt.Errorf("manifest resolver: %w", err)
+	}
+	var m struct {
+		KEKHint string `json:"kek_hint"`
+	}
+	if err := json.Unmarshal(data, &m); err != nil {
+		return "", fmt.Errorf("manifest resolver: unmarshal %s: %w", manifestKey, err)
+	}
+	if m.KEKHint == "" {
+		return "", fmt.Errorf("manifest resolver: empty kek_hint in %s", manifestKey)
+	}
+	return m.KEKHint, nil
+}

--- a/plane/workflow/billing/manifest_kekhint_resolver_test.go
+++ b/plane/workflow/billing/manifest_kekhint_resolver_test.go
@@ -1,0 +1,78 @@
+package billing
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+)
+
+func TestManifestKEKHintResolver_ReadsKEKHintFromManifest(t *testing.T) {
+	store := newStubObjectStore("test-bucket")
+	manifest := archiveManifest{
+		SchemaVersion: 1, KEKHint: "platform-billing-v3", EncFormat: encFormatV1,
+	}
+	raw, _ := json.Marshal(manifest)
+	if err := store.PutBytes(context.Background(),
+		"billing/usage_events/year=2027/month=01/usage_events_2027_01.manifest.json", raw); err != nil {
+		t.Fatalf("PutBytes: %v", err)
+	}
+
+	r, err := NewManifestKEKHintResolver(store, "test-bucket")
+	if err != nil {
+		t.Fatalf("NewManifestKEKHintResolver: %v", err)
+	}
+	hint, err := r.ResolveKEKHint(context.Background(),
+		"s3://test-bucket/billing/usage_events/year=2027/month=01/usage_events_2027_01.parquet")
+	if err != nil {
+		t.Fatalf("ResolveKEKHint: %v", err)
+	}
+	if hint != "platform-billing-v3" {
+		t.Errorf("hint=%q want platform-billing-v3", hint)
+	}
+}
+
+func TestManifestKEKHintResolver_BadURI(t *testing.T) {
+	store := newStubObjectStore("test-bucket")
+	r, _ := NewManifestKEKHintResolver(store, "test-bucket")
+
+	cases := []string{
+		"https://example.com/x.parquet",       // wrong scheme
+		"s3://other/x.parquet",                // wrong bucket
+		"s3://test-bucket/x.txt",              // wrong suffix
+	}
+	for _, uri := range cases {
+		if _, err := r.ResolveKEKHint(context.Background(), uri); err == nil {
+			t.Errorf("expected error for %q", uri)
+		}
+	}
+}
+
+func TestManifestKEKHintResolver_MissingManifest(t *testing.T) {
+	store := newStubObjectStore("test-bucket")
+	r, _ := NewManifestKEKHintResolver(store, "test-bucket")
+	_, err := r.ResolveKEKHint(context.Background(),
+		"s3://test-bucket/no/such/object.parquet")
+	if err == nil {
+		t.Error("expected error for missing manifest")
+	}
+}
+
+func TestManifestKEKHintResolver_EmptyKEKHint(t *testing.T) {
+	store := newStubObjectStore("test-bucket")
+	raw, _ := json.Marshal(archiveManifest{SchemaVersion: 1, KEKHint: ""})
+	_ = store.PutBytes(context.Background(),
+		"x.manifest.json", raw)
+	r, _ := NewManifestKEKHintResolver(store, "test-bucket")
+	if _, err := r.ResolveKEKHint(context.Background(), "s3://test-bucket/x.parquet"); err == nil {
+		t.Error("expected error for empty kek_hint")
+	}
+}
+
+func TestNewManifestKEKHintResolver_NilDeps(t *testing.T) {
+	if _, err := NewManifestKEKHintResolver(nil, "b"); err == nil {
+		t.Error("expected error for nil store")
+	}
+	if _, err := NewManifestKEKHintResolver(newStubObjectStore("b"), ""); err == nil {
+		t.Error("expected error for empty bucket")
+	}
+}

--- a/plane/workflow/billing/objectstore.go
+++ b/plane/workflow/billing/objectstore.go
@@ -23,7 +23,8 @@ type ObjectStore interface {
 	PutBytes(ctx context.Context, key string, data []byte) error
 
 	// GetBytes reads a small object in full (manifest, checksum). Errors with
-	// ErrObjectNotFound (or wraps it) when the object is absent.
+	// ErrObjectNotFound (or wraps it) when the object is absent. Used by the
+	// restore workflow (#79) and the DEK destruction workflow (#80).
 	GetBytes(ctx context.Context, key string) ([]byte, error)
 
 	// Download returns a streaming reader over key for large blobs. The caller

--- a/plane/workflow/billing/objectstore_s3.go
+++ b/plane/workflow/billing/objectstore_s3.go
@@ -65,7 +65,8 @@ func (s *S3ObjectStore) Upload(ctx context.Context, key string, r io.Reader, siz
 }
 
 // GetBytes fetches a small object in full via GetObject, mapping NoSuchKey to
-// ErrObjectNotFound for non-retryable manifest-missing handling in restore.
+// ErrObjectNotFound for non-retryable manifest-missing handling in restore
+// (#79) and the DEK destruction workflow (#80).
 func (s *S3ObjectStore) GetBytes(ctx context.Context, key string) ([]byte, error) {
 	out, err := s.client.GetObject(ctx, &s3.GetObjectInput{
 		Bucket: aws.String(s.bucket),

--- a/plane/workflow/billing/request_operator_approval_activity.go
+++ b/plane/workflow/billing/request_operator_approval_activity.go
@@ -1,0 +1,91 @@
+package billing
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"go.temporal.io/sdk/activity"
+)
+
+// ActivityNameRequestOperatorApproval is the registered name for the
+// RequestOperatorApprovalActivity.Execute method. The DEK destruction
+// workflow gates the irreversible Vault transit trim behind this activity.
+const ActivityNameRequestOperatorApproval = "billing.RequestOperatorApprovalForDEKDestroy"
+
+// OperatorApprovalInput identifies the partition awaiting approval.
+type OperatorApprovalInput struct {
+	Year          int
+	Month         int
+	PartitionName string
+	KEKHint       string
+}
+
+// OperatorApprovalResult is the boundary's verdict.
+type OperatorApprovalResult struct {
+	Approved bool
+	// Reason is filled when Approved is false; it propagates as the
+	// workflow's skip reason for the partition.
+	Reason string
+}
+
+// OperatorApprover is the workflow-plane abstraction over the ADR-015
+// operator-approval mechanism. The mechanism itself (UI, gRPC waiting list,
+// signal-driven workflow, etc.) is not yet implemented at the time of #80;
+// production wires whichever implementation lands first.
+type OperatorApprover interface {
+	RequestApproval(ctx context.Context, in OperatorApprovalInput) (OperatorApprovalResult, error)
+}
+
+// RequestOperatorApprovalActivity wraps an OperatorApprover so the
+// workflow can call the boundary as a Temporal activity. Long-blocking
+// human-in-the-loop approvers should configure the activity with a long
+// StartToCloseTimeout and rely on heartbeats rather than expanding the
+// boundary surface here.
+type RequestOperatorApprovalActivity struct {
+	approver OperatorApprover
+}
+
+// NewRequestOperatorApprovalActivity wraps approver.
+func NewRequestOperatorApprovalActivity(approver OperatorApprover) *RequestOperatorApprovalActivity {
+	return &RequestOperatorApprovalActivity{approver: approver}
+}
+
+// Execute requests approval for in. The activity surfaces the verdict
+// rather than failing on rejection; the workflow records a skip on a non-
+// approved verdict so a single rejected partition does not abort the whole
+// run.
+func (a *RequestOperatorApprovalActivity) Execute(ctx context.Context, in OperatorApprovalInput) (OperatorApprovalResult, error) {
+	if a.approver == nil {
+		return OperatorApprovalResult{}, fmt.Errorf("billing.RequestOperatorApproval: approver is nil")
+	}
+	return a.approver.RequestApproval(ctx, in)
+}
+
+// AutoApproveStub auto-approves every request and logs the event via the
+// activity logger. Used until the real ADR-015 approval mechanism lands.
+//
+// TODO(ADR-015): replace with a signal-driven approval workflow or a thin
+// gRPC client to the operator-approval service. The runbook
+// (docs/runbooks/billing-dek-destruction.md) documents this gap and the
+// operator-side mitigation: pause the DEK destruction schedule and audit
+// recent emit events whenever the auto-approve stub is enabled.
+type AutoApproveStub struct{}
+
+// NewAutoApproveStub returns the auto-approving stub.
+func NewAutoApproveStub() AutoApproveStub { return AutoApproveStub{} }
+
+// RequestApproval logs the approval event via the Temporal activity logger
+// and returns Approved=true. Workflow tests can substitute a mock
+// OperatorApprover to exercise the rejection path without touching this
+// stub.
+func (AutoApproveStub) RequestApproval(ctx context.Context, in OperatorApprovalInput) (OperatorApprovalResult, error) {
+	logger := activity.GetLogger(ctx)
+	logger.Warn("DEK-destruction operator-approval auto-approved (ADR-015 stub)",
+		slog.Int("year", in.Year),
+		slog.Int("month", in.Month),
+		slog.String("partition_name", in.PartitionName),
+		slog.String("kek_hint", in.KEKHint),
+	)
+	return OperatorApprovalResult{Approved: true, Reason: ""}, nil
+}


### PR DESCRIPTION
## Summary

- Implements `DEKDestructionWorkflow` + `DEKDestructionRouterWorkflow` on `QueueBillingMaintenance`. Per ADR-018 §Encryption, monthly schedule (`0 2 1 * *` UTC) trims the per-month Vault transit key version for partition archives older than 7y+30d. Crypto-shred is irreversible by design.
- Adds `RecordDEKDestroyed` gRPC + service method on the billing app-plane (ADR-019). Outbox event `billing.partition_dek_destroyed` is the only durable record (ADR-008); no source row is updated. Idempotency anchored on a deterministic UUIDv5 `aggregate_id` derived from `(year, month, partition_name, kek_hint)` plus a new `HasOutboxEventForAggregate` reader.
- Five activities: `ListEligiblePartitionsActivity`, `CheckLegalHoldActivity`, `RequestOperatorApprovalActivity`, `DestroyDEKActivity`, `EmitDEKDestroyedActivity`. Workflow body iterates the deterministic partition list; per-partition errors do not abort the run — they accumulate in `Result.Skipped`.

## Caveats / TODOs

- **Operator approval (ADR-015) stub**: `AutoApproveStub` auto-approves every request and logs a structured warning. Until the real ADR-015 approver lands, the runbook (`docs/runbooks/billing-dek-destruction.md`) documents the operator mitigation: pause the schedule + audit emit events. The boundary `OperatorApprover` interface is stable; swap-in is a one-line change in `cmd/workflow-worker/main.go`.
- **Legal hold**: `NewStaticLegalHoldChecker(false, "")` is wired by default. Real S3 Object Lock integration is a follow-up.
- **`emit_error` after `destroy` succeeded**: the irreversible side effect already happened. Workflow records the destruction (`KeysDestroyed++`) and surfaces the audit gap in `Skipped` rather than letting Temporal restart and double-trim. Runbook covers manual replay.

## ADRs

ADR-018 §Encryption (crypto-shred mandate), ADR-015 (operator approval), ADR-008 (outbox), ADR-019 (workflow → app-plane boundary).

## Test plan

- [x] `go test ./...` — workflow + router unit tests cover happy path + every skip path (missing kek_hint, legal hold, approval rejected, destroy error, emit error after destroy).
- [x] `DestroyDEKActivity` unit tests against a fake Vault logical client cover happy path, already-trimmed (idempotent), key-deleted (404 idempotent), bad kek_hint, and trim error surface.
- [x] `make lint-determinism lint-events lint-md lint-proto` — clean.
- [x] `go build -tags integration ./...` — integration test compiles. `dek_destruction_workflow_integration_test.go` boots Vault + Postgres testcontainers, seeds an eligible row, runs the workflow, and asserts: (1) Vault `min_available_version >= 2` (v1 destroyed); (2) exactly one `billing.partition_dek_destroyed` row in the outbox with the right `kek_hint` and `vault_key_version`. Run locally with `go test -tags integration ./plane/workflow/billing/... -run DEKDestruction`.

Spec: `docs/superpowers/specs/2026-05-08-issue-80-dek-destruction-design.md`. Plan: `docs/superpowers/plans/2026-05-08-issue-80-dek-destruction-plan.md`.

Closes #80.

🤖 Generated with [Claude Code](https://claude.com/claude-code)