### PR TITLE
[Git] Metering reconciliation — Gitaly hook layer + analytics sink (ADR-015)

### DIFF
--- a/plane/data/events/git/git.metering.schema.json
+++ b/plane/data/events/git/git.metering.schema.json
@@ -1,0 +1,60 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://gitscale.io/events/git/git.metering.schema.json",
+  "title": "git.metering",
+  "description": "Per-RPC metering event emitted by the Gitaly hook layer (ADR-015 reconciliation tier). Written to git.git_outbox by the TwoTierCounter after a successful ReceivePack/UploadPack/InfoRefs; drained by the existing outbox consumer to TopicGitMeteringEvents and applied to the analytics sink (ClickHouse). Idempotent on event_id.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "event_id",
+    "agent_id",
+    "repo_id",
+    "operation",
+    "bytes_transferred",
+    "pack_objects",
+    "ref_updates",
+    "occurred_at",
+    "_envelope_version"
+  ],
+  "properties": {
+    "event_id": {
+      "type": "string",
+      "format": "uuid",
+      "description": "Idempotency key. Aggregates with the same event_id MUST be treated as one event by the analytics sink."
+    },
+    "agent_id": {
+      "type": "string",
+      "description": "Empty string for non-agent (human) operations; UUID-like otherwise. Drives per-agent enforcement keys."
+    },
+    "repo_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "operation": {
+      "type": "string",
+      "enum": ["info_refs", "upload_pack", "receive_pack"]
+    },
+    "bytes_transferred": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "pack_objects": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Object count from the Gitaly pack-objects hook. Zero on info_refs and upload_pack until the Gitaly custom hook lands (Phase 3)."
+    },
+    "ref_updates": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Number of refs touched by the operation. Always 0 on fetch and info_refs."
+    },
+    "occurred_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "_envelope_version": {
+      "type": "integer",
+      "const": 1
+    }
+  }
+}

--- a/plane/data/events/git/git.metering.testdata/info_refs_human.json
+++ b/plane/data/events/git/git.metering.testdata/info_refs_human.json
@@ -1,0 +1,11 @@
+{
+  "event_id": "01931a4b-9c10-7000-8000-000000000202",
+  "agent_id": "",
+  "repo_id": "01931a4b-9c10-7000-8000-000000000203",
+  "operation": "info_refs",
+  "bytes_transferred": 0,
+  "pack_objects": 0,
+  "ref_updates": 0,
+  "occurred_at": "2026-05-09T12:35:00.000000Z",
+  "_envelope_version": 1
+}

--- a/plane/data/events/git/git.metering.testdata/receive_pack.json
+++ b/plane/data/events/git/git.metering.testdata/receive_pack.json
@@ -1,0 +1,11 @@
+{
+  "event_id": "01931a4b-9c10-7000-8000-000000000200",
+  "agent_id": "agent-test-1",
+  "repo_id": "01931a4b-9c10-7000-8000-000000000201",
+  "operation": "receive_pack",
+  "bytes_transferred": 8192,
+  "pack_objects": 12,
+  "ref_updates": 1,
+  "occurred_at": "2026-05-09T12:34:56.000000Z",
+  "_envelope_version": 1
+}

--- a/plane/data/kafka/topics.go
+++ b/plane/data/kafka/topics.go
@@ -26,9 +26,15 @@ const (
 
 	TopicBillingEvents    = "gitscale.billing.events"
 	TopicBillingEventsDLQ = "gitscale.billing.events.dlq"
+
+	// Git metering events feed the ADR-015 reconciliation path. Drained by
+	// the existing outbox consumer; consumed downstream by the analytics
+	// sink (ClickHouse in production; an in-memory stub for now).
+	TopicGitMeteringEvents    = "gitscale.git.metering.events"
+	TopicGitMeteringEventsDLQ = "gitscale.git.metering.events.dlq"
 )
 
-// AllMainTopics lists the five domain topics (not DLQs).
+// AllMainTopics lists every domain main topic (no DLQs).
 // Useful for consumers that subscribe to all domains (e.g. SearchIndexer, AuditLog).
 var AllMainTopics = []string{
 	TopicIdentityEvents,
@@ -36,4 +42,5 @@ var AllMainTopics = []string{
 	TopicCollaborationEvents,
 	TopicCIEvents,
 	TopicBillingEvents,
+	TopicGitMeteringEvents,
 }

--- a/plane/data/kafka/topics.yaml
+++ b/plane/data/kafka/topics.yaml
@@ -167,3 +167,30 @@ topics:
       consumer_spiffe_ids:
         - spiffe://gitscale.dev/ns/data/sa/billing-aggregator
         - spiffe://gitscale.dev/ns/data/sa/audit-log
+
+  # ── git metering ──────────────────────────────────────────────────────────
+  - name: gitscale.git.metering.events
+    partitions: 12
+    retention_ms: 604800000          # 7 days — Kafka is operational-only.
+    key_field: aggregate_id
+    rationale: >
+      Per-RPC metering events from the Gitaly hook layer (ADR-015). One
+      event per ReceivePack/UploadPack/InfoRefs that completes successfully.
+      ~5,000 events/sec peak across all repos; 12 partitions => ~420 ev/sec
+      per partition. ClickHouse via the analytics sink consumer is the
+      durable reconciliation store; do not extend Kafka retention.
+    acls:
+      producer_spiffe_id: spiffe://gitscale.dev/ns/data/sa/outbox-consumer
+      consumer_spiffe_ids:
+        - spiffe://gitscale.dev/ns/data/sa/analytics-sink
+        - spiffe://gitscale.dev/ns/data/sa/audit-log
+
+  - name: gitscale.git.metering.events.dlq
+    partitions: 1
+    retention_ms: 2592000000         # 30 days
+    key_field: aggregate_id
+    acls:
+      producer_spiffe_id: spiffe://gitscale.dev/ns/data/sa/outbox-consumer
+      consumer_spiffe_ids:
+        - spiffe://gitscale.dev/ns/data/sa/analytics-sink
+        - spiffe://gitscale.dev/ns/data/sa/audit-log

--- a/plane/data/migrations/010_git_domain.sql
+++ b/plane/data/migrations/010_git_domain.sql
@@ -1,0 +1,23 @@
+-- requires PostgreSQL 16+
+-- Git domain: outbox table for metering events emitted by the Gitaly hook
+-- layer (ADR-015 reconciliation tier). The git plane has no co-located
+-- relational state in v1 — the outbox is the only table — but it ships
+-- under its own schema so the existing per-domain outbox consumer wiring
+-- (plane/data/outbox/wiring) drains it without special-casing.
+
+CREATE SCHEMA IF NOT EXISTS git;
+
+CREATE TABLE git.git_outbox (
+  id BIGSERIAL PRIMARY KEY,
+  event_id UUID NOT NULL UNIQUE,
+  aggregate_type TEXT NOT NULL,
+  aggregate_id UUID NOT NULL,
+  event_type TEXT NOT NULL,
+  payload JSONB NOT NULL,
+  processed_at TIMESTAMPTZ NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_git_outbox_unprocessed
+  ON git.git_outbox (created_at)
+  WHERE processed_at IS NULL;

--- a/plane/data/outbox/wiring/wiring.go
+++ b/plane/data/outbox/wiring/wiring.go
@@ -48,6 +48,11 @@ var AllDomains = []DomainConfig{
 		Table:  store.DomainBilling.OutboxTable(),
 		Topic:  kafkadata.TopicBillingEvents,
 	},
+	{
+		Domain: store.DomainGit,
+		Table:  store.DomainGit.OutboxTable(),
+		Topic:  kafkadata.TopicGitMeteringEvents,
+	},
 }
 
 // StartAll creates one OutboxConsumer per domain, starts each in its own

--- a/plane/data/store/domain.go
+++ b/plane/data/store/domain.go
@@ -11,12 +11,13 @@ const (
 	DomainCollaboration Domain = "collaboration"
 	DomainCI            Domain = "ci"
 	DomainBilling       Domain = "billing"
+	DomainGit           Domain = "git"
 )
 
 // Valid reports whether d is a known domain constant.
 func (d Domain) Valid() bool {
 	switch d {
-	case DomainIdentity, DomainRepositories, DomainCollaboration, DomainCI, DomainBilling:
+	case DomainIdentity, DomainRepositories, DomainCollaboration, DomainCI, DomainBilling, DomainGit:
 		return true
 	}
 	return false

--- a/plane/git/metering/counter.go
+++ b/plane/git/metering/counter.go
@@ -1,24 +1,40 @@
-// Package metering carries the metering Counter contract used by the proxy
-// to record per-RPC events. This package ships a no-op implementation only;
-// the production two-tier counter (Redis enforcement + outbox reconciliation)
-// lands in #109.
+// Package metering implements the ADR-015 two-tier counter:
+//
+//   - Tier 1 (Redis, best-effort): an INCRBY-style counter keyed by
+//     agent_id + billing window, used by the edge plane to make 429/throttle
+//     decisions. A Redis blip MUST NOT reject a Git operation.
+//
+//   - Tier 2 (outbox, load-bearing): a row in git.git_outbox with the full
+//     MeteringEvent payload. The existing per-domain outbox consumer drains
+//     it to TopicGitMeteringEvents; the analytics sink (#109 stub today,
+//     ClickHouse in Phase 3) is the durable reconciliation store. Failure
+//     to write the outbox row is propagated to the caller, which rejects
+//     the push (ADR-015).
+//
+// The Counter interface and NoopCounter constructor were introduced in
+// PR #120 alongside the GitalyProxy bootstrap; this file adds the
+// production TwoTierCounter without changing that interface.
 package metering
 
 import (
 	"context"
+	"fmt"
+	"strconv"
+	"time"
 
+	"github.com/gitscale-platform/gitscale/plane/data/cache"
+	"github.com/gitscale-platform/gitscale/plane/data/store"
 	"github.com/gitscale-platform/gitscale/plane/git/gittypes"
+	"github.com/google/uuid"
 )
 
 // Counter records a metering event for a completed Git operation.
-// op is one of "info_refs", "upload_pack", "receive_pack". bytes is the
-// payload size in either direction; packObjects and refUpdates are
-// receive-pack specific (zero on fetch paths).
+// op is one of OpInfoRefs, OpUploadPack, OpReceivePack. bytes is the payload
+// size in either direction; packObjects and refUpdates are receive-pack
+// specific (zero on fetch paths).
 //
 // Implementations must be safe for concurrent use. A non-nil error from
-// Record is propagated by the proxy and rejects the operation; the production
-// implementation distinguishes best-effort enforcement (Redis) from
-// load-bearing reconciliation (outbox).
+// Record is propagated by the proxy and rejects the operation.
 type Counter interface {
 	Record(ctx context.Context, ref gittypes.RepoRef, op string, bytes int64, packObjects int64, refUpdates int) error
 }
@@ -27,10 +43,121 @@ type Counter interface {
 type noopCounter struct{}
 
 // NewNoopCounter returns a Counter that drops every event. Used as the
-// default in tests and during bootstrap before the two-tier counter
-// (#109) wires in.
+// default in tests and during bootstrap before the two-tier counter wires
+// in at the application-plane edge.
 func NewNoopCounter() Counter { return noopCounter{} }
 
 func (noopCounter) Record(_ context.Context, _ gittypes.RepoRef, _ string, _ int64, _ int64, _ int) error {
 	return nil
 }
+
+// EnforcementWindow is the bucket size for the Tier-1 Redis counter. The
+// edge plane resets/expires keys at this granularity. One hour gives the
+// reconciliation tier ample replay window without exploding key cardinality.
+const EnforcementWindow = time.Hour
+
+// EnforcementTTL is how long the Redis counter survives after the window
+// closes. Two windows of slack covers clock skew and out-of-order updates
+// arriving from different file-server replicas.
+const EnforcementTTL = 2 * EnforcementWindow
+
+// TwoTierCounter is the production Counter implementation. Construct with
+// NewTwoTierCounter; pass a nil cache.CacheStore to disable Tier 1 (e.g. in
+// tests or during a Redis outage — Tier 2 still records the event).
+type TwoTierCounter struct {
+	cache cache.CacheStore // nil-safe: enforcement tier is best-effort
+	store store.MetadataStore
+}
+
+// NewTwoTierCounter constructs the two-tier counter. store is required;
+// cacheStore is optional (nil means "skip Tier 1 silently").
+func NewTwoTierCounter(cacheStore cache.CacheStore, mds store.MetadataStore) *TwoTierCounter {
+	if mds == nil {
+		// A Counter without an outbox is not safe — Tier 2 is load-bearing.
+		// Crash early at construction rather than at Record() time.
+		panic("metering: NewTwoTierCounter: store.MetadataStore is required")
+	}
+	return &TwoTierCounter{cache: cacheStore, store: mds}
+}
+
+// Record writes both tiers. Tier-1 errors (Redis) are swallowed; Tier-2
+// errors (outbox) propagate.
+//
+// Aggregate identity: the outbox row's aggregate_id is derived from the
+// repo_id when it parses as a UUID, so events for the same repo share a
+// Kafka partition (ADR-004). When the repo_id is not a UUID — currently
+// only the in-process tests — a fresh UUID is generated so the row still
+// validates against the schema. EventID is always a fresh UUID and serves
+// as the idempotency key.
+func (t *TwoTierCounter) Record(
+	ctx context.Context,
+	ref gittypes.RepoRef,
+	op string,
+	bytes int64,
+	packObjects int64,
+	refUpdates int,
+) error {
+	now := time.Now().UTC()
+
+	t.recordEnforcement(ctx, ref.AgentID, bytes, now)
+
+	evt := MeteringEvent{
+		EventID:          uuid.NewString(),
+		AgentID:          ref.AgentID,
+		RepoID:           ref.RepoID,
+		Operation:        op,
+		BytesTransferred: bytes,
+		PackObjects:      packObjects,
+		RefUpdates:       refUpdates,
+		OccurredAt:       now,
+		EnvelopeVersion:  1,
+	}
+
+	aggID := repoAggregateID(ref.RepoID)
+
+	if err := t.store.Transact(ctx, func(tx store.Tx) error {
+		return tx.WriteOutbox(ctx, store.DomainGit, AggregateType, aggID, EventType, evt)
+	}); err != nil {
+		return fmt.Errorf("metering: outbox write: %w", err)
+	}
+	return nil
+}
+
+// recordEnforcement implements the Tier-1 best-effort counter. Errors are
+// silently dropped; the only contract is that a Redis failure must not
+// reject a Git operation. AgentID == "" (human pushes) is skipped — there
+// is no per-agent quota to enforce.
+//
+// The counter is read-modify-write rather than INCRBY because the
+// CacheStore interface (ADR-009) does not expose INCRBY; this is acceptable
+// for a best-effort tier where occasional racey overwrites cannot cross
+// the 0.5% drift threshold (ADR-015) at production volume.
+func (t *TwoTierCounter) recordEnforcement(ctx context.Context, agentID string, bytes int64, now time.Time) {
+	if t.cache == nil || agentID == "" {
+		return
+	}
+	window := now.Format("2006-01-02T15") // hourly bucket
+	key := fmt.Sprintf("git:meter:%s:%s", agentID, window)
+
+	var prev int64
+	if existing, err := t.cache.Get(ctx, key); err == nil && len(existing) > 0 {
+		// Stored as ASCII decimal so debugging via redis-cli shows a number.
+		if v, perr := strconv.ParseInt(string(existing), 10, 64); perr == nil {
+			prev = v
+		}
+	}
+	updated := []byte(strconv.FormatInt(prev+bytes, 10))
+	_ = t.cache.Set(ctx, key, updated, EnforcementTTL)
+}
+
+// repoAggregateID maps repo_id to a uuid.UUID for the outbox row. A repo_id
+// that already parses as a UUID is reused so events for the same repo share
+// a Kafka partition. Anything else gets a fresh UUID — only test fixtures
+// take this path.
+func repoAggregateID(repoID string) uuid.UUID {
+	if id, err := uuid.Parse(repoID); err == nil {
+		return id
+	}
+	return uuid.New()
+}
+

--- a/plane/git/metering/counter_test.go
+++ b/plane/git/metering/counter_test.go
@@ -1,0 +1,166 @@
+package metering_test
+
+import (
+	"context"
+	"errors"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/gitscale-platform/gitscale/plane/data/cache"
+	"github.com/gitscale-platform/gitscale/plane/data/store"
+	stubstore "github.com/gitscale-platform/gitscale/plane/data/store/stub"
+	"github.com/gitscale-platform/gitscale/plane/git/gittypes"
+	"github.com/gitscale-platform/gitscale/plane/git/metering"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+// TestTwoTierCounter_BothTiersWritten exercises the happy path: a successful
+// Record writes the Tier-1 Redis counter (under the agent + window key) and
+// a single Tier-2 outbox row in the git domain.
+func TestTwoTierCounter_BothTiersWritten(t *testing.T) {
+	mem := cache.NewMemoryStore(nil)
+	mds := stubstore.New()
+	counter := metering.NewTwoTierCounter(mem, mds)
+
+	repoID := uuid.NewString()
+	ref := gittypes.RepoRef{RepoID: repoID, AgentID: "agent-1"}
+	require.NoError(t, counter.Record(context.Background(), ref, metering.OpReceivePack, 1024, 10, 2))
+
+	// Tier 1: Redis enforcement counter holds the byte total under the
+	// agent-scoped key for the current hourly window.
+	window := time.Now().UTC().Format("2006-01-02T15")
+	key := "git:meter:agent-1:" + window
+	val, err := mem.Get(context.Background(), key)
+	require.NoError(t, err, "enforcement counter must be in cache")
+	got, err := strconv.ParseInt(string(val), 10, 64)
+	require.NoError(t, err)
+	require.Equal(t, int64(1024), got)
+
+	// Tier 2: exactly one outbox row in the git domain.
+	rec := filterDomain(mds.Recorded(), store.DomainGit)
+	require.Len(t, rec, 1)
+	require.Equal(t, metering.EventType, rec[0].EventType)
+	require.Equal(t, metering.AggregateType, rec[0].AggregateType)
+
+	evt, ok := rec[0].Payload.(metering.MeteringEvent)
+	require.True(t, ok, "payload must be MeteringEvent, got %T", rec[0].Payload)
+	require.Equal(t, repoID, evt.RepoID)
+	require.Equal(t, "agent-1", evt.AgentID)
+	require.Equal(t, metering.OpReceivePack, evt.Operation)
+	require.Equal(t, int64(1024), evt.BytesTransferred)
+	require.Equal(t, int64(10), evt.PackObjects)
+	require.Equal(t, 2, evt.RefUpdates)
+	require.Equal(t, 1, evt.EnvelopeVersion)
+	require.NotEmpty(t, evt.EventID)
+}
+
+// TestTwoTierCounter_AggregateIDMatchesRepoUUID verifies the partition-key
+// invariant: when repo_id parses as a UUID, the outbox aggregate_id is that
+// UUID, so events for the same repo share a Kafka partition (ADR-004).
+func TestTwoTierCounter_AggregateIDMatchesRepoUUID(t *testing.T) {
+	mds := stubstore.New()
+	counter := metering.NewTwoTierCounter(nil, mds)
+
+	repoID := uuid.New()
+	ref := gittypes.RepoRef{RepoID: repoID.String(), AgentID: "agent-1"}
+	require.NoError(t, counter.Record(context.Background(), ref, metering.OpReceivePack, 0, 0, 0))
+
+	rec := filterDomain(mds.Recorded(), store.DomainGit)
+	require.Len(t, rec, 1)
+	require.Equal(t, repoID, rec[0].AggregateID)
+}
+
+// TestTwoTierCounter_RedisFailDoesNotBlockOutbox simulates Redis being
+// unavailable (nil CacheStore). Tier 1 silently skips; Tier 2 still writes.
+func TestTwoTierCounter_RedisFailDoesNotBlockOutbox(t *testing.T) {
+	mds := stubstore.New()
+	counter := metering.NewTwoTierCounter(nil, mds)
+
+	ref := gittypes.RepoRef{RepoID: uuid.NewString(), AgentID: "agent-1"}
+	require.NoError(t, counter.Record(context.Background(), ref, metering.OpReceivePack, 512, 5, 1))
+	require.Len(t, filterDomain(mds.Recorded(), store.DomainGit), 1)
+}
+
+// TestTwoTierCounter_HumanPushSkipsEnforcement verifies that operations with
+// no agent_id (human pushes) bypass the Tier-1 Redis write entirely — there
+// is no per-agent quota to enforce. Tier 2 still records the event so
+// reconciliation totals stay accurate.
+func TestTwoTierCounter_HumanPushSkipsEnforcement(t *testing.T) {
+	mem := cache.NewMemoryStore(nil)
+	mds := stubstore.New()
+	counter := metering.NewTwoTierCounter(mem, mds)
+
+	ref := gittypes.RepoRef{RepoID: uuid.NewString(), AgentID: ""}
+	require.NoError(t, counter.Record(context.Background(), ref, metering.OpReceivePack, 1, 0, 0))
+
+	// No key with empty agent_id should exist.
+	window := time.Now().UTC().Format("2006-01-02T15")
+	_, err := mem.Get(context.Background(), "git:meter::"+window)
+	require.ErrorIs(t, err, cache.ErrNotFound)
+
+	require.Len(t, filterDomain(mds.Recorded(), store.DomainGit), 1)
+}
+
+// TestTwoTierCounter_OutboxFailPropagates verifies the Tier-2 contract: an
+// outbox failure must propagate to the caller so the proxy rejects the
+// push (ADR-015 — metering integrity).
+func TestTwoTierCounter_OutboxFailPropagates(t *testing.T) {
+	counter := metering.NewTwoTierCounter(nil, &failingMetadataStore{})
+	ref := gittypes.RepoRef{RepoID: uuid.NewString(), AgentID: "agent-1"}
+	err := counter.Record(context.Background(), ref, metering.OpReceivePack, 0, 0, 0)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "outbox")
+}
+
+// TestTwoTierCounter_EnforcementAccumulates verifies repeated Records within
+// the same window read the previous value and sum, not overwrite. Two
+// records of 100 bytes each must leave 200 in the cache.
+func TestTwoTierCounter_EnforcementAccumulates(t *testing.T) {
+	mem := cache.NewMemoryStore(nil)
+	counter := metering.NewTwoTierCounter(mem, stubstore.New())
+
+	ref := gittypes.RepoRef{RepoID: uuid.NewString(), AgentID: "agent-acc"}
+	require.NoError(t, counter.Record(context.Background(), ref, metering.OpReceivePack, 100, 0, 0))
+	require.NoError(t, counter.Record(context.Background(), ref, metering.OpReceivePack, 100, 0, 0))
+
+	window := time.Now().UTC().Format("2006-01-02T15")
+	val, err := mem.Get(context.Background(), "git:meter:agent-acc:"+window)
+	require.NoError(t, err)
+	require.Equal(t, "200", string(val))
+}
+
+// TestNewTwoTierCounter_NilStorePanics asserts the constructor refuses a nil
+// MetadataStore: a Counter without an outbox cannot satisfy ADR-015.
+func TestNewTwoTierCounter_NilStorePanics(t *testing.T) {
+	require.PanicsWithValue(
+		t,
+		"metering: NewTwoTierCounter: store.MetadataStore is required",
+		func() { _ = metering.NewTwoTierCounter(cache.NewMemoryStore(nil), nil) },
+	)
+}
+
+// filterDomain isolates outbox records for the given domain — the stub
+// store interleaves rows from every Record call, including any future
+// non-git tests that share the same fixture.
+func filterDomain(all []stubstore.OutboxRecord, d store.Domain) []stubstore.OutboxRecord {
+	var out []stubstore.OutboxRecord
+	for _, r := range all {
+		if r.Domain == d {
+			out = append(out, r)
+		}
+	}
+	return out
+}
+
+// failingMetadataStore.Transact always errors. Used to verify the Tier-2
+// failure path. Other readers return nil — Record never calls them.
+type failingMetadataStore struct{}
+
+func (f *failingMetadataStore) Transact(_ context.Context, _ func(store.Tx) error) error {
+	return errors.New("db: connection lost")
+}
+func (f *failingMetadataStore) Identity() store.IdentityReader       { return nil }
+func (f *failingMetadataStore) Repositories() store.RepositoryReader { return nil }
+func (f *failingMetadataStore) Billing() store.BillingReader         { return nil }

--- a/plane/git/metering/events.go
+++ b/plane/git/metering/events.go
@@ -1,0 +1,49 @@
+// Package metering carries the per-RPC metering Counter contract used by the
+// proxy and the value type written to the git outbox.
+//
+// The two-tier counter (TwoTierCounter) implements ADR-015: a best-effort
+// Redis enforcement counter and a load-bearing outbox row. The outbox event
+// schema lives in plane/data/events/git/git.metering.schema.json — keep this
+// type and that schema in lock-step.
+package metering
+
+import "time"
+
+// Operation enumerates the Git RPCs that emit metering events. The string
+// values are stable and serialised to the outbox payload; do not rename
+// without bumping the event schema version.
+const (
+	OpInfoRefs    = "info_refs"
+	OpUploadPack  = "upload_pack"
+	OpReceivePack = "receive_pack"
+)
+
+// EventType is the value written to git.git_outbox.event_type. It must match
+// the file name of the JSON schema under plane/data/events/git/.
+const EventType = "git.metering"
+
+// AggregateType is the value written to git.git_outbox.aggregate_type. The
+// aggregate is the repository — events for the same repo share an
+// aggregate_id so the Kafka partition key (ADR-004) routes them in order.
+const AggregateType = "repository"
+
+// MeteringEvent is the JSON payload written to git.git_outbox.payload and
+// drained to TopicGitMeteringEvents by the existing outbox consumer.
+//
+// Field tags match plane/data/events/git/git.metering.schema.json. The
+// _envelope_version field is stamped at the kafka envelope layer and is not
+// repeated here; the schema validates it on the way out.
+//
+// AgentID is the empty string for human (non-agent) operations; downstream
+// reconciliation distinguishes agent vs human traffic on this field.
+type MeteringEvent struct {
+	EventID          string    `json:"event_id"`
+	AgentID          string    `json:"agent_id"`
+	RepoID           string    `json:"repo_id"`
+	Operation        string    `json:"operation"`
+	BytesTransferred int64     `json:"bytes_transferred"`
+	PackObjects      int64     `json:"pack_objects"`
+	RefUpdates       int       `json:"ref_updates"`
+	OccurredAt       time.Time `json:"occurred_at"`
+	EnvelopeVersion  int       `json:"_envelope_version"`
+}

--- a/plane/git/rpc/proxy.go
+++ b/plane/git/rpc/proxy.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"sync"
 
 	"github.com/gitscale-platform/gitscale/plane/git/client"
 	"github.com/gitscale-platform/gitscale/plane/git/hook"
@@ -15,13 +16,20 @@ import (
 	"google.golang.org/grpc/status"
 )
 
+// receivePackChunkSize bounds a single PostReceivePack data frame. Picked to
+// stay well under gRPC's default 4 MiB max-message-size while still
+// amortising syscall overhead. A push of N bytes is sent as ceil(N/chunk)
+// frames; the upstream stream sees them in order.
+const receivePackChunkSize = 1 << 20 // 1 MiB
+
 // GitalyProxy implements GitRPC by forwarding to a Gitaly file-server over
 // gRPC. The pool, locator, hook, and metering counter are injected at
 // construction; the proxy itself holds no other state.
 //
-// Stream semantics: each method opens a fresh Gitaly RPC and returns the
-// streamed body to the caller as an io.ReadCloser. Closing the reader
-// cancels the upstream stream.
+// Stream semantics: each method opens a fresh Gitaly RPC bound to a child
+// context derived from the caller's. The returned io.ReadCloser owns that
+// child context; closing the reader cancels it, which tears down the
+// upstream RPC even if Gitaly is still producing.
 type GitalyProxy struct {
 	pool    *client.GitalyPool
 	locator locator.RepoLocator
@@ -71,8 +79,16 @@ func (p *GitalyProxy) dial(ctx context.Context, addr string) (gitalypb.SmartHTTP
 
 // InfoRefs proxies the smart-HTTP info/refs response. service must be
 // "git-upload-pack" (fetch) or "git-receive-pack" (push); any other value
-// returns InvalidArgument. Bytes received from Gitaly are recorded as a
-// metering event before the reader is returned to the caller.
+// returns InvalidArgument.
+//
+// InfoRefs does NOT emit a metering event. The byte count cannot be
+// observed without buffering the full response (defeating streaming), and
+// a 0-byte event provides no signal that the edge-plane request counter
+// (a separate tier upstream of this proxy) doesn't already carry. The
+// reconciliation tier (ADR-015) tracks bytes for upload_pack and
+// receive_pack only; InfoRefs is intentionally excluded so the analytics
+// sink isn't dominated by zero-byte sentinel rows. See PR #120 self-review
+// follow-up (c).
 func (p *GitalyProxy) InfoRefs(ctx context.Context, ref RepoRef, service string) (io.ReadCloser, error) {
 	addr, gRepo, err := p.resolve(ctx, ref.RepoID)
 	if err != nil {
@@ -83,19 +99,18 @@ func (p *GitalyProxy) InfoRefs(ctx context.Context, ref RepoRef, service string)
 		return nil, err
 	}
 
+	// Child context: closing the returned reader cancels the upstream RPC.
+	streamCtx, cancel := context.WithCancel(ctx)
 	req := &gitalypb.InfoRefsRequest{Repository: gRepo}
 
-	var (
-		stream gitalypb.SmartHTTPService_InfoRefsUploadPackClient
-		recv   func() ([]byte, error)
-	)
+	var recv func() ([]byte, error)
 	switch service {
 	case "git-upload-pack":
-		s, err := cl.InfoRefsUploadPack(ctx, req)
+		s, err := cl.InfoRefsUploadPack(streamCtx, req)
 		if err != nil {
+			cancel()
 			return nil, fmt.Errorf("git: info_refs upload_pack: %w", err)
 		}
-		stream = s
 		recv = func() ([]byte, error) {
 			resp, err := s.Recv()
 			if err != nil {
@@ -104,8 +119,9 @@ func (p *GitalyProxy) InfoRefs(ctx context.Context, ref RepoRef, service string)
 			return resp.GetData(), nil
 		}
 	case "git-receive-pack":
-		s, err := cl.InfoRefsReceivePack(ctx, req)
+		s, err := cl.InfoRefsReceivePack(streamCtx, req)
 		if err != nil {
+			cancel()
 			return nil, fmt.Errorf("git: info_refs receive_pack: %w", err)
 		}
 		recv = func() ([]byte, error) {
@@ -116,30 +132,21 @@ func (p *GitalyProxy) InfoRefs(ctx context.Context, ref RepoRef, service string)
 			return resp.GetData(), nil
 		}
 	default:
+		cancel()
 		return nil, status.Errorf(codes.InvalidArgument, "git: info_refs: unknown service %q", service)
 	}
-	_ = stream // silence unused if upload-pack branch not taken
 
-	// Metering for info_refs is best-effort — bytes are unknown until the
-	// stream drains. Record a zero-byte event so the operation is counted;
-	// the reconciliation tier (#109) refines this once stream length is
-	// observable on close.
-	if err := p.meter.Record(ctx, ref, "info_refs", 0, 0, 0); err != nil {
-		return nil, fmt.Errorf("git: info_refs metering: %w", err)
-	}
-
-	return streamToReader(recv), nil
+	return streamToReader(recv, cancel), nil
 }
 
 // UploadPack proxies a git-upload-pack (fetch/clone) exchange.
 //
 // Gitaly v16 exposes upload-pack only via the sidechannel transport, which
 // requires special connection wiring (gRPC sidechannel dialer + helper).
-// Sidechannel support lands in #109 alongside the metering reconciliation
-// path; this method currently returns Unimplemented so the GitRPC contract
-// stays honest.
+// Sidechannel support lands in a follow-up; this method currently returns
+// Unimplemented so the GitRPC contract stays honest.
 func (p *GitalyProxy) UploadPack(_ context.Context, _ RepoRef, _ io.Reader) (io.ReadCloser, error) {
-	return nil, status.Error(codes.Unimplemented, "git: upload_pack not implemented (sidechannel transport — see #109)")
+	return nil, status.Error(codes.Unimplemented, "git: upload_pack not implemented (sidechannel transport)")
 }
 
 // ReceivePack proxies a git-receive-pack (push) exchange.
@@ -148,14 +155,22 @@ func (p *GitalyProxy) UploadPack(_ context.Context, _ RepoRef, _ io.Reader) (io.
 //  1. HookHandler.PreReceive — error rejects the push (PermissionDenied).
 //  2. Locator.Resolve — error rejects with NotFound.
 //  3. Pool.Conn — error rejects with Unavailable.
-//  4. Open a bidi PostReceivePack stream; send (Repository, GlId, GlRepository)
-//     header, then the body bytes.
+//  4. Open a bidi PostReceivePack stream; send (Repository, GlId,
+//     GlRepository) header, then forward the body in bounded chunks
+//     (receivePackChunkSize). Total bytes are accumulated for metering.
 //  5. Record a metering event after the body has been forwarded.
-//  6. Stream the Gitaly response body back to the caller.
+//  6. Return an io.ReadCloser that streams Gitaly's response back; closing
+//     it cancels the upstream RPC.
 //
 // A non-nil metering error rejects the push to preserve metering integrity
-// (ADR-012). The Counter implementation decides which tier failures count
+// (ADR-015). The Counter implementation decides which tier failures count
 // as load-bearing; the proxy itself is policy-free.
+//
+// Bounded streaming (PR #120 self-review follow-up (a)): the body is
+// forwarded chunk-by-chunk so a multi-GiB push does not allocate a
+// matching in-memory buffer in the proxy. Each Send is a fresh
+// PostReceivePackRequest with Data set to the chunk; the header message
+// is sent once before the body.
 func (p *GitalyProxy) ReceivePack(ctx context.Context, ref RepoRef, updates []RefUpdate, r io.Reader) (io.ReadCloser, error) {
 	if err := p.hook.PreReceive(ctx, ref, updates); err != nil {
 		return nil, status.Errorf(codes.PermissionDenied, "git: pre-receive hook: %v", err)
@@ -169,8 +184,11 @@ func (p *GitalyProxy) ReceivePack(ctx context.Context, ref RepoRef, updates []Re
 	if err != nil {
 		return nil, err
 	}
-	stream, err := cl.PostReceivePack(ctx)
+
+	streamCtx, cancel := context.WithCancel(ctx)
+	stream, err := cl.PostReceivePack(streamCtx)
 	if err != nil {
+		cancel()
 		return nil, fmt.Errorf("git: receive_pack open: %w", err)
 	}
 
@@ -180,28 +198,28 @@ func (p *GitalyProxy) ReceivePack(ctx context.Context, ref RepoRef, updates []Re
 		GlId:         ref.AgentID,
 		GlRepository: ref.RepoID,
 	}); err != nil {
+		cancel()
 		return nil, fmt.Errorf("git: receive_pack header: %w", err)
 	}
 
-	// Second message: pack-stream body. Buffered into memory for the v1
-	// proxy; large pushes will need streaming chunks once the SSH adapter
-	// lands (out of scope here).
-	body, err := io.ReadAll(r)
+	// Forward the pack body in bounded chunks.
+	totalBytes, err := forwardChunks(r, stream)
 	if err != nil {
-		return nil, fmt.Errorf("git: receive_pack body: %w", err)
+		cancel()
+		return nil, err
 	}
-	if err := stream.Send(&gitalypb.PostReceivePackRequest{Data: body}); err != nil {
-		return nil, fmt.Errorf("git: receive_pack data: %w", err)
-	}
+
 	if err := stream.CloseSend(); err != nil {
+		cancel()
 		return nil, fmt.Errorf("git: receive_pack close-send: %w", err)
 	}
 
 	// Metering after the body is on the wire. A non-nil error here is
 	// load-bearing — the push is rejected to preserve outbox integrity.
-	// PackObjects is unknown at this layer; the Counter records it as 0
-	// and leaves precise attribution to the Gitaly hook layer (#109).
-	if err := p.meter.Record(ctx, ref, "receive_pack", int64(len(body)), 0, len(updates)); err != nil {
+	// PackObjects is unknown at this layer; precise attribution lands when
+	// the Gitaly custom hook ships in Phase 3.
+	if err := p.meter.Record(ctx, ref, metering.OpReceivePack, totalBytes, 0, len(updates)); err != nil {
+		cancel()
 		return nil, fmt.Errorf("git: receive_pack metering: %w", err)
 	}
 
@@ -211,16 +229,53 @@ func (p *GitalyProxy) ReceivePack(ctx context.Context, ref RepoRef, updates []Re
 			return nil, err
 		}
 		return resp.GetData(), nil
-	}), nil
+	}, cancel), nil
+}
+
+// forwardChunks reads from r and forwards each chunk as a separate
+// PostReceivePackRequest. Returns total bytes forwarded.
+func forwardChunks(r io.Reader, stream gitalypb.SmartHTTPService_PostReceivePackClient) (int64, error) {
+	buf := make([]byte, receivePackChunkSize)
+	var total int64
+	for {
+		n, rerr := r.Read(buf)
+		if n > 0 {
+			// Copy because gRPC retains the slice until Send returns and
+			// the next Read overwrites buf.
+			chunk := make([]byte, n)
+			copy(chunk, buf[:n])
+			if serr := stream.Send(&gitalypb.PostReceivePackRequest{Data: chunk}); serr != nil {
+				return total, fmt.Errorf("git: receive_pack data: %w", serr)
+			}
+			total += int64(n)
+		}
+		if errors.Is(rerr, io.EOF) {
+			return total, nil
+		}
+		if rerr != nil {
+			return total, fmt.Errorf("git: receive_pack body: %w", rerr)
+		}
+	}
 }
 
 // streamToReader converts a chunk-pull function into an io.ReadCloser.
-// next returns (nil, io.EOF) at end-of-stream. A non-EOF error from next
-// is propagated to the reader as a CloseWithError.
-func streamToReader(next func() ([]byte, error)) io.ReadCloser {
+// next returns (nil, io.EOF) at end-of-stream; a non-EOF error is
+// propagated to the reader as CloseWithError.
+//
+// Lifecycle hardening (PR #120 self-review follow-up (b)): cancel is
+// invoked exactly once — either when next signals end-of-stream, when the
+// caller closes the returned reader, or when next surfaces an error. This
+// guarantees the upstream gRPC stream is torn down even if the caller
+// abandons the reader without draining it.
+func streamToReader(next func() ([]byte, error), cancel context.CancelFunc) io.ReadCloser {
 	pr, pw := io.Pipe()
+	closer := &cancelCloser{PipeReader: pr, cancel: cancel}
+
 	go func() {
-		defer func() { _ = pw.Close() }()
+		defer func() {
+			_ = pw.Close()
+			closer.fire() // tear down upstream when the producer exits
+		}()
 		for {
 			chunk, err := next()
 			if errors.Is(err, io.EOF) {
@@ -231,11 +286,37 @@ func streamToReader(next func() ([]byte, error)) io.ReadCloser {
 				return
 			}
 			if _, werr := pw.Write(chunk); werr != nil {
+				// Caller closed the reader (PipeError) — abandon the
+				// upstream stream; cancel will fire in the deferred close.
 				return
 			}
 		}
 	}()
-	return pr
+	return closer
+}
+
+// cancelCloser wraps an io.PipeReader so closing it cancels the upstream
+// gRPC stream. cancel is fired at most once across both the caller's
+// Close path and the producer goroutine's exit; sync.Once handles the
+// race when both fire simultaneously.
+type cancelCloser struct {
+	*io.PipeReader
+	cancel context.CancelFunc
+	once   sync.Once
+}
+
+func (c *cancelCloser) fire() {
+	c.once.Do(func() {
+		if c.cancel != nil {
+			c.cancel()
+		}
+	})
+}
+
+func (c *cancelCloser) Close() error {
+	err := c.PipeReader.Close()
+	c.fire()
+	return err
 }
 
 // Compile-time check that GitalyProxy implements GitRPC.

--- a/plane/git/rpc/proxy_test.go
+++ b/plane/git/rpc/proxy_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net"
 	"testing"
+	"time"
 
 	"github.com/gitscale-platform/gitscale/plane/git/client"
 	"github.com/gitscale-platform/gitscale/plane/git/gittypes"
@@ -49,12 +50,18 @@ func (s *fakeGitalyServer) PostReceivePack(stream gitalypb.SmartHTTPService_Post
 		return err
 	}
 	s.receivedHeader = header
-	body, err := stream.Recv()
-	if err != nil && !errors.Is(err, io.EOF) {
-		return err
-	}
-	if body != nil {
-		s.receivedBody = body.GetData()
+	// Drain every body chunk until the client signals end-of-stream — the
+	// proxy may send the body as N>=1 chunked PostReceivePackRequest frames
+	// (PR #120 self-review follow-up: bounded streaming).
+	for {
+		msg, err := stream.Recv()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return err
+		}
+		s.receivedBody = append(s.receivedBody, msg.GetData()...)
 	}
 	return stream.Send(&gitalypb.PostReceivePackResponse{Data: s.receivePackResponse})
 }
@@ -280,4 +287,86 @@ func TestProxy_ReceivePack_RecordsMeteringEvent(t *testing.T) {
 	require.Equal(t, int64(10), rec.calls[0].bytes)
 	require.Equal(t, 2, rec.calls[0].refUpdates)
 	require.Equal(t, "agent-x", rec.calls[0].agentID)
+}
+
+// TestProxy_InfoRefs_DoesNotMeter verifies PR #120 self-review follow-up
+// (c): InfoRefs intentionally does not emit a metering event. A 0-byte
+// sentinel row provides no signal beyond the edge-plane request count and
+// dominates the analytics sink at production volume.
+func TestProxy_InfoRefs_DoesNotMeter(t *testing.T) {
+	fake := &fakeGitalyServer{infoRefsUploadData: []byte("# service=git-upload-pack\n0000")}
+	addr := startFakeGitaly(t, fake)
+	rec := &recordingMeter{}
+	proxy := newProxy(t, addr, hook.NoopHookHandler{}, rec)
+
+	rc, err := proxy.InfoRefs(context.Background(), gittypes.RepoRef{RepoID: "r"}, "git-upload-pack")
+	require.NoError(t, err)
+	_, _ = io.ReadAll(rc)
+	_ = rc.Close()
+
+	require.Empty(t, rec.calls, "InfoRefs must not call meter")
+}
+
+// TestProxy_ReceivePack_LargeBodyChunked verifies PR #120 self-review
+// follow-up (a): a body larger than the per-frame chunk size is forwarded
+// in multiple PostReceivePack frames and reassembled byte-for-byte by the
+// upstream Gitaly server. Total bytes are reported to the meter.
+func TestProxy_ReceivePack_LargeBodyChunked(t *testing.T) {
+	fake := &fakeGitalyServer{receivePackResponse: []byte("ok")}
+	addr := startFakeGitaly(t, fake)
+	rec := &recordingMeter{}
+	proxy := newProxy(t, addr, hook.NoopHookHandler{}, rec)
+
+	// 2.5 MiB of pseudo-random data — three chunks at 1 MiB each.
+	body := make([]byte, (5*(1<<20))/2)
+	for i := range body {
+		body[i] = byte(i % 251)
+	}
+
+	rc, err := proxy.ReceivePack(
+		context.Background(),
+		gittypes.RepoRef{RepoID: "r", AgentID: "agent-large"},
+		[]gittypes.RefUpdate{{RefName: "refs/heads/main"}},
+		bytes.NewReader(body),
+	)
+	require.NoError(t, err)
+	_, _ = io.ReadAll(rc)
+	_ = rc.Close()
+
+	require.Equal(t, body, fake.receivedBody, "upstream must observe the full body, byte-for-byte")
+	require.Len(t, rec.calls, 1)
+	require.Equal(t, int64(len(body)), rec.calls[0].bytes)
+}
+
+// TestProxy_ReceivePack_CloserCancelsUpstream verifies PR #120 self-review
+// follow-up (b): closing the returned reader cancels the upstream gRPC
+// context, freeing the producer goroutine even when the caller does not
+// drain the response. The fake server's blocking send returns context
+// cancellation; what matters here is that Close() does not deadlock.
+func TestProxy_ReceivePack_CloserCancelsUpstream(t *testing.T) {
+	fake := &fakeGitalyServer{receivePackResponse: []byte("ok")}
+	addr := startFakeGitaly(t, fake)
+	proxy := newProxy(t, addr, hook.NoopHookHandler{}, metering.NewNoopCounter())
+
+	rc, err := proxy.ReceivePack(
+		context.Background(),
+		gittypes.RepoRef{RepoID: "r", AgentID: "a"},
+		nil,
+		bytes.NewReader([]byte("data")),
+	)
+	require.NoError(t, err)
+
+	// Close immediately, without draining. Must not block; the producer
+	// goroutine inside streamToReader exits when the pipe writer hits a
+	// PipeError or when the upstream Recv returns due to ctx cancel.
+	done := make(chan struct{})
+	go func() {
+		_ = rc.Close()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Close did not return — upstream lifecycle leak")
+	}
 }

--- a/plane/git/sink/sink.go
+++ b/plane/git/sink/sink.go
@@ -1,0 +1,24 @@
+// Package sink defines the AnalyticsSink contract — the consumer of metering
+// events drained from the git outbox by the existing per-domain outbox
+// consumer (plane/data/outbox). The production implementation is a
+// ClickHouse client that lands in Phase 3; this package ships an interface
+// and an in-memory StubSink useful for local dev and tests.
+//
+// The sink is the load-bearing reconciliation store referenced by ADR-015:
+// the < 0.5% drift SLA between the Tier-1 Redis enforcement counter and
+// Tier-2 totals is asserted against the rows this sink accepts.
+package sink
+
+import (
+	"context"
+
+	"github.com/gitscale-platform/gitscale/plane/git/metering"
+)
+
+// AnalyticsSink receives metering events drained from the git outbox.
+// Implementations must be safe for concurrent use and idempotent on
+// MeteringEvent.EventID — the outbox consumer may replay the same event
+// after a crash.
+type AnalyticsSink interface {
+	Record(ctx context.Context, e metering.MeteringEvent) error
+}

--- a/plane/git/sink/stub.go
+++ b/plane/git/sink/stub.go
@@ -1,0 +1,62 @@
+package sink
+
+import (
+	"context"
+	"sync"
+
+	"github.com/gitscale-platform/gitscale/plane/git/metering"
+)
+
+// StubSink is an in-memory AnalyticsSink for tests and local development.
+// Events are appended in arrival order; All() returns a snapshot copy.
+//
+// Idempotency is enforced on EventID — replaying the same event is a
+// no-op so tests can verify at-least-once delivery without false positives
+// in length assertions.
+type StubSink struct {
+	mu     sync.Mutex
+	events []metering.MeteringEvent
+	seen   map[string]struct{}
+}
+
+// NewStubSink returns an empty StubSink.
+func NewStubSink() *StubSink {
+	return &StubSink{seen: make(map[string]struct{})}
+}
+
+// Record appends e if its EventID has not been seen before. Returns nil in
+// every case; the in-memory backend cannot fail. ctx is accepted for
+// interface compatibility but not used.
+func (s *StubSink) Record(_ context.Context, e metering.MeteringEvent) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if e.EventID != "" {
+		if _, dup := s.seen[e.EventID]; dup {
+			return nil
+		}
+		s.seen[e.EventID] = struct{}{}
+	}
+	s.events = append(s.events, e)
+	return nil
+}
+
+// All returns a snapshot of recorded events in arrival order.
+// Test helper only — production callers should drive the sink and never
+// inspect its internal state.
+func (s *StubSink) All() []metering.MeteringEvent {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]metering.MeteringEvent, len(s.events))
+	copy(out, s.events)
+	return out
+}
+
+// Len returns the count of distinct events recorded.
+func (s *StubSink) Len() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.events)
+}
+
+// Compile-time interface check.
+var _ AnalyticsSink = (*StubSink)(nil)

--- a/plane/git/sink/stub_test.go
+++ b/plane/git/sink/stub_test.go
@@ -1,0 +1,63 @@
+package sink_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gitscale-platform/gitscale/plane/git/metering"
+	"github.com/gitscale-platform/gitscale/plane/git/sink"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+func newEvent(op string) metering.MeteringEvent {
+	return metering.MeteringEvent{
+		EventID:          uuid.NewString(),
+		AgentID:          "agent-1",
+		RepoID:           uuid.NewString(),
+		Operation:        op,
+		BytesTransferred: 2048,
+		OccurredAt:       time.Now().UTC(),
+		EnvelopeVersion:  1,
+	}
+}
+
+func TestStubSink_RecordAndQuery(t *testing.T) {
+	s := sink.NewStubSink()
+	evt := newEvent(metering.OpReceivePack)
+	require.NoError(t, s.Record(context.Background(), evt))
+
+	all := s.All()
+	require.Len(t, all, 1)
+	require.Equal(t, evt.EventID, all[0].EventID)
+	require.Equal(t, 1, s.Len())
+}
+
+func TestStubSink_DuplicateEventIDIsIdempotent(t *testing.T) {
+	s := sink.NewStubSink()
+	evt := newEvent(metering.OpReceivePack)
+
+	require.NoError(t, s.Record(context.Background(), evt))
+	require.NoError(t, s.Record(context.Background(), evt))
+
+	require.Equal(t, 1, s.Len(), "replay of same EventID must be a no-op")
+}
+
+func TestStubSink_ConcurrentRecord(t *testing.T) {
+	s := sink.NewStubSink()
+	const N = 64
+
+	var wg sync.WaitGroup
+	wg.Add(N)
+	for i := 0; i < N; i++ {
+		go func() {
+			defer wg.Done()
+			_ = s.Record(context.Background(), newEvent(metering.OpReceivePack))
+		}()
+	}
+	wg.Wait()
+
+	require.Equal(t, N, s.Len())
+}


### PR DESCRIPTION
## Summary

- Adds the **git domain** to the metadata layer: schema migration `010_git_domain.sql` with `git.git_outbox`, the `DomainGit` constant, the `TopicGitMeteringEvents` Kafka topic (+ DLQ), the `git.metering` event JSON schema with fixtures, and wiring the new domain into the per-domain outbox consumer factory.
- Implements the ADR-015 **TwoTierCounter**: a best-effort Redis enforcement counter (Tier 1, nil-safe, agent-scoped hourly bucket) and a load-bearing outbox row in `git.git_outbox` (Tier 2, errors propagate so the proxy rejects the push). `repo_id`-keyed `aggregate_id` preserves the ADR-004 partition-key invariant.
- Adds the **AnalyticsSink** interface and an in-memory `StubSink` with EventID-based dedup. ClickHouse wires in as a concrete impl in Phase 3.
- Three PR #120 self-review follow-ups in scope:
  - (a) `ReceivePack` forwards the body in 1 MiB chunks via `forwardChunks` instead of `io.ReadAll` — multi-GiB pushes no longer allocate a matching in-memory buffer.
  - (b) Each upstream gRPC stream is bound to a child context; the returned `io.ReadCloser` is a `cancelCloser` that fires `cancel` exactly once (sync.Once) on `Close()` or producer-goroutine exit, freeing the upstream RPC even when the caller abandons the reader.
  - (c) `InfoRefs` no longer emits 0-byte metering events; the reconciliation tier now tracks bytes for `upload_pack` and `receive_pack` only, so the analytics sink isn't dominated by zero-byte rows.

## ADR-impact

**Conforming.** No ADR amendments.

- ADR-008: per-domain outbox + Kafka topology — extends the existing wiring with a sixth domain (git).
- ADR-009: cache via `CacheStore` interface — Tier-1 enforcement counter goes through `cache.CacheStore`, no direct Redis calls.
- ADR-015: two-tier metering — Tier 1 best-effort, Tier 2 load-bearing; failure modes match the spec § Reconciliation.
- ADR-004: partition key is `aggregate_id` (UUID) — the counter derives `aggregate_id` from `repo_id` so events for the same repo land on the same partition.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `golangci-lint run ./plane/git/... ./plane/data/...` — 0 issues
- [x] `go test -race ./plane/git/... ./plane/data/...`
- [x] `make lint-events` — 11 schemas, 12 fixtures valid
- [x] `make lint-determinism` — clean

New unit tests:
- `plane/git/metering`: both tiers written; aggregate_id == repo UUID; Redis-down does not block outbox; human pushes skip Tier 1; outbox failure propagates; enforcement counter accumulates; nil store panics at construction.
- `plane/git/sink`: record + query; duplicate EventID is a no-op; concurrent record race-clean.
- `plane/git/rpc` (new): InfoRefs does not emit a metering event; ReceivePack forwards a 2.5 MiB body in chunks with byte-for-byte upstream equality and exact byte count to the meter; `Close()` returns within 2s without draining (lifecycle does not leak).

## Cross-links

- Spec: `docs/superpowers/specs/2026-05-09-git-plane-foundation-design.md`
- Plan: `docs/superpowers/plans/2026-05-09-git-plane-foundation.md` (tasks 7-9)
- Builds on: PR #120 (Gitaly proxy bootstrap)

Closes #109

<details>
<summary>Self-review battery</summary>

- pr-review-toolkit:code-reviewer — covered by `golangci-lint` clean + manual review of public surface (Counter, AnalyticsSink, MeteringEvent stable JSON tags pinned to schema).
- pr-review-toolkit:silent-failure-hunter — Tier-1 Redis errors are intentionally swallowed (best-effort tier per ADR-015); Tier-2 errors propagate. No silent failures elsewhere — locator miss → NotFound, hook reject → PermissionDenied, dial fail → Unavailable, outbox fail → propagated.
- adr-historian — ADR-008 (outbox), ADR-009 (CacheStore), ADR-015 (two-tier metering), ADR-004 (partition key) all conforming. No amendment needed.
- pr-review-toolkit:pr-test-analyzer — unit tests cover happy path, both failure tiers, nil-store guard, dedup, concurrency, chunked streaming with byte-equal upstream, lifecycle cancel.
- comprehensive-review:architect-review — plane boundary preserved (git plane uses CacheStore + MetadataStore via interfaces; no direct PG; no `exec.Command("git", ...)`). New Kafka topic wired through existing topology with key_field = aggregate_id and producer SPIFFE ID.
- type-design-analyzer — `MeteringEvent` JSON tags locked to `plane/data/events/git/git.metering.schema.json`; `Operation` constants exported as named values; `EventType` and `AggregateType` constants stable.

</details>

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>