### PR TITLE
[Application] AGENTS.md surfacing + Never enforcement

### DIFF
--- a/plane/application/agentsmd/diagnostic.go
+++ b/plane/application/agentsmd/diagnostic.go
@@ -1,0 +1,34 @@
+package agentsmd
+
+// Severity is the closed enumeration of diagnostic severities surfaced by
+// Parse / Lint. Only "error" and "warning" are emitted; callers may treat
+// "error" as blocking for editor surfaces (the pre-receive hook does not
+// block on parse diagnostics — see the spec error-handling table).
+type Severity string
+
+const (
+	SeverityError   Severity = "error"
+	SeverityWarning Severity = "warning"
+)
+
+// Stable diagnostic codes. New codes may be added in additive minor
+// releases; existing codes will not be renamed. The MCP `agents_md_lint`
+// tool surfaces these to humans and IDEs.
+const (
+	CodeUnknownSection            = "unknown_section"
+	CodeMalformedPredicate        = "malformed_predicate"
+	CodeUnsupportedSchemaVersion  = "unsupported_schema_version"
+	CodeDuplicatePredicate        = "duplicate_predicate"
+	CodeEmptyNeverBlock           = "empty_never_block"
+	CodeUnknownPredicate          = "unknown_predicate"
+	CodeMalformedFrontMatter      = "malformed_front_matter"
+)
+
+// Diagnostic is a single parser/linter finding. Line is 1-based; 0 means
+// "no line context available" (e.g. front-matter-level errors).
+type Diagnostic struct {
+	Code     string
+	Severity Severity
+	Line     int
+	Message  string
+}

--- a/plane/application/agentsmd/doc.go
+++ b/plane/application/agentsmd/doc.go
@@ -1,0 +1,28 @@
+// Package agentsmd parses, lints, merges, and evaluates AGENTS.md
+// policy documents — the GitScale mechanism by which humans communicate
+// hard constraints to AI agents.
+//
+// This package is pure logic. It MUST NOT import anything from
+// plane/git/...; the adapter that bridges into the pre-receive hook lives
+// in the sibling package plane/application/agentsmd/hook (see ADR-019 on
+// plane boundaries).
+//
+// Schema: only `gitscale/v1` is accepted in this iteration. The schema
+// versioning policy is an open architecture question (target: July 2026);
+// once resolved, the parser will gain a version-tracking strategy.
+//
+// Public surface:
+//
+//   - Parse([]byte) (*Policy, []Diagnostic, error) — extract a policy plus
+//     structured diagnostics. A nil/empty input yields an "empty" policy.
+//   - Lint([]byte) []Diagnostic — diagnostics-only convenience wrapper.
+//   - Merge(org, repo *Policy) *Policy — combine policies; org wins on
+//     conflicting predicates.
+//   - Evaluate(*Policy, EvaluationInput) []Violation — evaluate predicates
+//     against a set of ref updates.
+//
+// References:
+//   - Issue: https://github.com/gitscale-platform/gitscale/issues/114
+//   - Spec:  docs/superpowers/specs/2026-05-09-issue-114-agents-md-never-enforcement-design.md
+//   - ADR-008 (outbox), ADR-012 (hook layer), ADR-019 (plane boundary).
+package agentsmd

--- a/plane/application/agentsmd/evaluate.go
+++ b/plane/application/agentsmd/evaluate.go
@@ -1,0 +1,221 @@
+package agentsmd
+
+import (
+	"context"
+	"fmt"
+	"path"
+	"strings"
+)
+
+// ZeroOID is the all-zero SHA-1 OID Git uses to denote "no object" — i.e.
+// the old side of a branch creation or the new side of a branch deletion.
+const ZeroOID = "0000000000000000000000000000000000000000"
+
+// RefUpdate mirrors the shape of plane/git/gittypes.RefUpdate. We
+// duplicate the type here to keep agentsmd free of plane/git imports
+// (plane boundary). The hook adapter package converts between the two.
+type RefUpdate struct {
+	RefName string
+	OldOID  string
+	NewOID  string
+}
+
+// EvaluationInput is the per-push payload passed to Evaluate. Files is
+// invoked lazily by predicates that need a changed-file list; predicates
+// that operate purely on ref-level inputs (force_push, delete, push_to)
+// never call Files.
+type EvaluationInput struct {
+	RepoID  string
+	AgentID string
+	Updates []RefUpdate
+	Files   FileResolver
+}
+
+// FileResolver supplies the file-level information predicates need. The
+// production implementation in plane/git/gitaly wraps Gitaly RPCs; tests
+// inject in-memory implementations. All methods accept a context for
+// cancellation; implementations must not block indefinitely.
+type FileResolver interface {
+	// Changed returns the list of repository-relative paths whose blob
+	// changed between oldOID and newOID. For a branch creation
+	// (oldOID == ZeroOID) implementations should return all paths reachable
+	// from newOID.
+	Changed(ctx context.Context, oldOID, newOID string) ([]string, error)
+	// Size returns the size in bytes of the blob at the given path under
+	// the given commit OID.
+	Size(ctx context.Context, oid string, path string) (int64, error)
+	// IsFastForward reports whether newOID is a strict descendant (or
+	// equal) of oldOID. Used by force_push detection.
+	IsFastForward(ctx context.Context, oldOID, newOID string) (bool, error)
+}
+
+// Violation is a single matched Never predicate. The hook adapter formats
+// these into a human-readable, single-line message that the Git client
+// surfaces via gRPC PermissionDenied.
+type Violation struct {
+	Predicate NeverPredicate
+	RefName   string
+	Reason    string
+}
+
+// Evaluate runs every Never predicate against every ref update and
+// returns the matched violations. Order is stable: predicates iterated in
+// policy order, updates iterated in input order.
+//
+// A nil context is invalid; callers must pass a non-nil context. A nil
+// input.Files is permitted only when the policy contains no predicates
+// that need file information (modify_path, push_binary_over_size); the
+// evaluator returns an error in that case rather than silently passing.
+func Evaluate(ctx context.Context, policy *Policy, input EvaluationInput) ([]Violation, error) {
+	if policy == nil || policy.Empty || len(policy.Never) == 0 {
+		return nil, nil
+	}
+	var out []Violation
+	for _, pred := range policy.Never {
+		for _, upd := range input.Updates {
+			matched, reason, err := matchPredicate(ctx, pred, upd, input.Files)
+			if err != nil {
+				return nil, fmt.Errorf("agentsmd: evaluate %s on %s: %w", pred.Name, upd.RefName, err)
+			}
+			if matched {
+				out = append(out, Violation{Predicate: pred, RefName: upd.RefName, Reason: reason})
+			}
+		}
+	}
+	return out, nil
+}
+
+// matchPredicate returns (matched, reason, err) for a single (predicate, update) pair.
+func matchPredicate(ctx context.Context, pred NeverPredicate, upd RefUpdate, files FileResolver) (bool, string, error) {
+	switch pred.Name {
+	case PredicateDeleteBranch:
+		if !branchMatches(pred.Selector.BranchGlob, upd.RefName) {
+			return false, "", nil
+		}
+		if upd.NewOID != ZeroOID {
+			return false, "", nil
+		}
+		return true, fmt.Sprintf("branch %q deletion blocked by Never rule (glob %q)", branchName(upd.RefName), pred.Selector.BranchGlob), nil
+
+	case PredicatePushToBranch:
+		if !branchMatches(pred.Selector.BranchGlob, upd.RefName) {
+			return false, "", nil
+		}
+		return true, fmt.Sprintf("push to branch %q blocked by Never rule (glob %q)", branchName(upd.RefName), pred.Selector.BranchGlob), nil
+
+	case PredicateForcePushToBranch:
+		if !branchMatches(pred.Selector.BranchGlob, upd.RefName) {
+			return false, "", nil
+		}
+		// Branch creations and deletions are not force pushes.
+		if upd.OldOID == ZeroOID || upd.NewOID == ZeroOID {
+			return false, "", nil
+		}
+		if files == nil {
+			return false, "", fmt.Errorf("force_push_to_branch requires a FileResolver")
+		}
+		ff, err := files.IsFastForward(ctx, upd.OldOID, upd.NewOID)
+		if err != nil {
+			return false, "", err
+		}
+		if ff {
+			return false, "", nil
+		}
+		return true, fmt.Sprintf("force push to %q blocked by Never rule (glob %q)", branchName(upd.RefName), pred.Selector.BranchGlob), nil
+
+	case PredicateModifyPath:
+		if files == nil {
+			return false, "", fmt.Errorf("modify_path requires a FileResolver")
+		}
+		paths, err := files.Changed(ctx, upd.OldOID, upd.NewOID)
+		if err != nil {
+			return false, "", err
+		}
+		for _, p := range paths {
+			if pathMatches(pred.Selector.PathGlob, p) {
+				return true, fmt.Sprintf("path %q modification blocked by Never rule (glob %q)", p, pred.Selector.PathGlob), nil
+			}
+		}
+		return false, "", nil
+
+	case PredicatePushBinaryOverSize:
+		if files == nil {
+			return false, "", fmt.Errorf("push_binary_over_size requires a FileResolver")
+		}
+		paths, err := files.Changed(ctx, upd.OldOID, upd.NewOID)
+		if err != nil {
+			return false, "", err
+		}
+		for _, p := range paths {
+			sz, err := files.Size(ctx, upd.NewOID, p)
+			if err != nil {
+				return false, "", err
+			}
+			if sz > pred.Selector.MaxBytes {
+				return true, fmt.Sprintf("blob %q size %d > limit %d", p, sz, pred.Selector.MaxBytes), nil
+			}
+		}
+		return false, "", nil
+
+	default:
+		// Unknown predicate names are dropped at parse time. If one slips
+		// through here (e.g. a hand-constructed Policy), be safe: do not
+		// match, do not error. The lint diagnostic at parse time is the
+		// load-bearing surface.
+		return false, "", nil
+	}
+}
+
+// branchMatches checks whether a full ref name matches a branch glob.
+// The glob is matched against the short branch name (refs/heads/<name>);
+// non-branch refs (tags, notes) never match a branch predicate.
+func branchMatches(glob, refName string) bool {
+	const prefix = "refs/heads/"
+	if !strings.HasPrefix(refName, prefix) {
+		return false
+	}
+	name := refName[len(prefix):]
+	return globMatch(glob, name)
+}
+
+// branchName returns the short branch name for human-readable messages.
+// If refName is not a branch, it is returned unchanged.
+func branchName(refName string) string {
+	const prefix = "refs/heads/"
+	if strings.HasPrefix(refName, prefix) {
+		return refName[len(prefix):]
+	}
+	return refName
+}
+
+// pathMatches matches a repository-relative path against a glob. The
+// glob grammar matches path.Match plus a leading-component "**" form:
+// "infra/**" matches anything under infra/.
+func pathMatches(glob, p string) bool {
+	if strings.HasSuffix(glob, "/**") {
+		prefix := strings.TrimSuffix(glob, "/**")
+		return p == prefix || strings.HasPrefix(p, prefix+"/")
+	}
+	if glob == "**" {
+		return true
+	}
+	ok, err := path.Match(glob, p)
+	if err != nil {
+		return false
+	}
+	return ok
+}
+
+// globMatch matches a short branch name against a glob. We support
+// path.Match grammar; "*" does not cross "/" by stdlib semantics, which
+// is the right choice for branch names like "release/v1".
+func globMatch(glob, name string) bool {
+	if glob == "" {
+		return false
+	}
+	ok, err := path.Match(glob, name)
+	if err != nil {
+		return false
+	}
+	return ok
+}

--- a/plane/application/agentsmd/evaluate_test.go
+++ b/plane/application/agentsmd/evaluate_test.go
@@ -1,0 +1,249 @@
+package agentsmd
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+// memFiles is an in-memory FileResolver for tests. Changed map is keyed
+// by "old..new"; Size map by "oid:path"; ff map by "old..new".
+type memFiles struct {
+	changed map[string][]string
+	sizes   map[string]int64
+	ff      map[string]bool
+	err     error
+}
+
+func (m *memFiles) Changed(_ context.Context, oldOID, newOID string) ([]string, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	return m.changed[oldOID+".."+newOID], nil
+}
+
+func (m *memFiles) Size(_ context.Context, oid, path string) (int64, error) {
+	if m.err != nil {
+		return 0, m.err
+	}
+	return m.sizes[oid+":"+path], nil
+}
+
+func (m *memFiles) IsFastForward(_ context.Context, oldOID, newOID string) (bool, error) {
+	if m.err != nil {
+		return false, m.err
+	}
+	return m.ff[oldOID+".."+newOID], nil
+}
+
+func TestEvaluate_NilOrEmptyPolicy(t *testing.T) {
+	ctx := context.Background()
+	v, err := Evaluate(ctx, nil, EvaluationInput{})
+	if err != nil || v != nil {
+		t.Fatalf("nil policy: %v %v", err, v)
+	}
+	v, err = Evaluate(ctx, &Policy{Empty: true}, EvaluationInput{})
+	if err != nil || v != nil {
+		t.Fatalf("empty policy: %v %v", err, v)
+	}
+}
+
+func TestEvaluate_DeleteBranchMatches(t *testing.T) {
+	policy := &Policy{Never: []NeverPredicate{
+		{Name: PredicateDeleteBranch, Selector: PredicateSelector{BranchGlob: "main"}},
+	}}
+	v, err := Evaluate(context.Background(), policy, EvaluationInput{
+		Updates: []RefUpdate{{RefName: "refs/heads/main", OldOID: "abc123", NewOID: ZeroOID}},
+	})
+	if err != nil {
+		t.Fatalf("err=%v", err)
+	}
+	if len(v) != 1 || v[0].Predicate.Name != PredicateDeleteBranch {
+		t.Fatalf("expected single delete violation, got %+v", v)
+	}
+}
+
+func TestEvaluate_DeleteBranchSkipsNonDelete(t *testing.T) {
+	policy := &Policy{Never: []NeverPredicate{
+		{Name: PredicateDeleteBranch, Selector: PredicateSelector{BranchGlob: "main"}},
+	}}
+	v, err := Evaluate(context.Background(), policy, EvaluationInput{
+		Updates: []RefUpdate{{RefName: "refs/heads/main", OldOID: "abc", NewOID: "def"}},
+	})
+	if err != nil || len(v) != 0 {
+		t.Fatalf("non-delete must not match: %v %+v", err, v)
+	}
+}
+
+func TestEvaluate_PushToBranchGlob(t *testing.T) {
+	policy := &Policy{Never: []NeverPredicate{
+		{Name: PredicatePushToBranch, Selector: PredicateSelector{BranchGlob: "release/*"}},
+	}}
+	v, err := Evaluate(context.Background(), policy, EvaluationInput{
+		Updates: []RefUpdate{
+			{RefName: "refs/heads/release/v1", OldOID: "a", NewOID: "b"},
+			{RefName: "refs/heads/feature/x", OldOID: "a", NewOID: "b"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("err=%v", err)
+	}
+	if len(v) != 1 || v[0].RefName != "refs/heads/release/v1" {
+		t.Fatalf("expected one match on release/v1, got %+v", v)
+	}
+}
+
+func TestEvaluate_ForcePushDetection(t *testing.T) {
+	policy := &Policy{Never: []NeverPredicate{
+		{Name: PredicateForcePushToBranch, Selector: PredicateSelector{BranchGlob: "main"}},
+	}}
+	files := &memFiles{ff: map[string]bool{
+		"old..new":      false, // non-FF -> force push
+		"old..ffnew":    true,  // FF -> not a force push
+	}}
+	v, err := Evaluate(context.Background(), policy, EvaluationInput{
+		Updates: []RefUpdate{
+			{RefName: "refs/heads/main", OldOID: "old", NewOID: "new"},
+			{RefName: "refs/heads/main", OldOID: "old", NewOID: "ffnew"},
+			{RefName: "refs/heads/main", OldOID: ZeroOID, NewOID: "new"}, // creation
+		},
+		Files: files,
+	})
+	if err != nil {
+		t.Fatalf("err=%v", err)
+	}
+	if len(v) != 1 {
+		t.Fatalf("expected 1 force-push violation, got %d: %+v", len(v), v)
+	}
+}
+
+func TestEvaluate_ForcePushRequiresResolver(t *testing.T) {
+	policy := &Policy{Never: []NeverPredicate{
+		{Name: PredicateForcePushToBranch, Selector: PredicateSelector{BranchGlob: "main"}},
+	}}
+	_, err := Evaluate(context.Background(), policy, EvaluationInput{
+		Updates: []RefUpdate{{RefName: "refs/heads/main", OldOID: "a", NewOID: "b"}},
+	})
+	if err == nil {
+		t.Fatalf("expected error when FileResolver is nil")
+	}
+}
+
+func TestEvaluate_ModifyPath(t *testing.T) {
+	policy := &Policy{Never: []NeverPredicate{
+		{Name: PredicateModifyPath, Selector: PredicateSelector{PathGlob: "infra/**"}},
+	}}
+	files := &memFiles{changed: map[string][]string{
+		"a..b": {"src/main.go", "infra/terraform/main.tf"},
+	}}
+	v, err := Evaluate(context.Background(), policy, EvaluationInput{
+		Updates: []RefUpdate{{RefName: "refs/heads/main", OldOID: "a", NewOID: "b"}},
+		Files:   files,
+	})
+	if err != nil {
+		t.Fatalf("err=%v", err)
+	}
+	if len(v) != 1 {
+		t.Fatalf("expected 1 modify_path violation, got %+v", v)
+	}
+}
+
+func TestEvaluate_ModifyPath_NoMatch(t *testing.T) {
+	policy := &Policy{Never: []NeverPredicate{
+		{Name: PredicateModifyPath, Selector: PredicateSelector{PathGlob: "infra/**"}},
+	}}
+	files := &memFiles{changed: map[string][]string{
+		"a..b": {"src/main.go"},
+	}}
+	v, err := Evaluate(context.Background(), policy, EvaluationInput{
+		Updates: []RefUpdate{{RefName: "refs/heads/main", OldOID: "a", NewOID: "b"}},
+		Files:   files,
+	})
+	if err != nil || len(v) != 0 {
+		t.Fatalf("expected no match: %v %+v", err, v)
+	}
+}
+
+func TestEvaluate_PushBinaryOverSize(t *testing.T) {
+	policy := &Policy{Never: []NeverPredicate{
+		{Name: PredicatePushBinaryOverSize, Selector: PredicateSelector{MaxBytes: 1024}},
+	}}
+	files := &memFiles{
+		changed: map[string][]string{"a..b": {"big.bin"}},
+		sizes:   map[string]int64{"b:big.bin": 5000},
+	}
+	v, err := Evaluate(context.Background(), policy, EvaluationInput{
+		Updates: []RefUpdate{{RefName: "refs/heads/main", OldOID: "a", NewOID: "b"}},
+		Files:   files,
+	})
+	if err != nil {
+		t.Fatalf("err=%v", err)
+	}
+	if len(v) != 1 {
+		t.Fatalf("expected 1 size violation, got %+v", v)
+	}
+}
+
+func TestEvaluate_FileResolverErrorPropagates(t *testing.T) {
+	policy := &Policy{Never: []NeverPredicate{
+		{Name: PredicateModifyPath, Selector: PredicateSelector{PathGlob: "**"}},
+	}}
+	files := &memFiles{err: errors.New("boom")}
+	_, err := Evaluate(context.Background(), policy, EvaluationInput{
+		Updates: []RefUpdate{{RefName: "refs/heads/main", OldOID: "a", NewOID: "b"}},
+		Files:   files,
+	})
+	if err == nil {
+		t.Fatalf("expected error from resolver")
+	}
+}
+
+func TestEvaluate_NonBranchRefSkipped(t *testing.T) {
+	policy := &Policy{Never: []NeverPredicate{
+		{Name: PredicateDeleteBranch, Selector: PredicateSelector{BranchGlob: "main"}},
+	}}
+	v, err := Evaluate(context.Background(), policy, EvaluationInput{
+		Updates: []RefUpdate{{RefName: "refs/tags/v1", OldOID: "abc", NewOID: ZeroOID}},
+	})
+	if err != nil || len(v) != 0 {
+		t.Fatalf("tag delete must not match branch predicate: %v %+v", err, v)
+	}
+}
+
+func TestEvaluate_LazyFileResolver(t *testing.T) {
+	// A policy of only ref-level predicates must not call FileResolver,
+	// even if it is nil.
+	policy := &Policy{Never: []NeverPredicate{
+		{Name: PredicateDeleteBranch, Selector: PredicateSelector{BranchGlob: "main"}},
+	}}
+	v, err := Evaluate(context.Background(), policy, EvaluationInput{
+		Updates: []RefUpdate{{RefName: "refs/heads/main", OldOID: "abc", NewOID: ZeroOID}},
+		Files:   nil,
+	})
+	if err != nil {
+		t.Fatalf("nil resolver should be fine for ref-level predicates: %v", err)
+	}
+	if len(v) != 1 {
+		t.Fatalf("expected match, got %+v", v)
+	}
+}
+
+func TestPathMatches_DoubleStar(t *testing.T) {
+	cases := []struct {
+		glob, path string
+		want       bool
+	}{
+		{"infra/**", "infra/main.tf", true},
+		{"infra/**", "infra/terraform/main.tf", true},
+		{"infra/**", "src/main.go", false},
+		{"infra/**", "infra", true},
+		{"**", "anything", true},
+		{"*.go", "main.go", true},
+		{"*.go", "sub/main.go", false},
+	}
+	for _, c := range cases {
+		if got := pathMatches(c.glob, c.path); got != c.want {
+			t.Errorf("pathMatches(%q, %q) = %v, want %v", c.glob, c.path, got, c.want)
+		}
+	}
+}

--- a/plane/application/agentsmd/hook/blob_reader.go
+++ b/plane/application/agentsmd/hook/blob_reader.go
@@ -1,0 +1,41 @@
+package hook
+
+import (
+	"context"
+	"errors"
+)
+
+// ErrBlobNotFound signals an absent blob (e.g. AGENTS.md missing).
+// Distinct from infra errors so the handler can fail open on absence
+// (treat as empty policy) and fail closed on infra errors.
+var ErrBlobNotFound = errors.New("agentsmd/hook: blob not found")
+
+// BlobReader is the bridge into plane/git for fetching blob bytes,
+// listing changed paths, sizing blobs, and computing fast-forward
+// ancestry. The production implementation lives in plane/git/gitaly
+// (see GitalyBlobReader); tests inject in-memory implementations.
+//
+// Implementations must:
+//   - return ErrBlobNotFound (or wrap it) when the requested blob does
+//     not exist; any other error is treated as load-bearing infra
+//     failure and the push is rejected with codes.Unavailable.
+//   - be safe for concurrent use.
+type BlobReader interface {
+	// ReadBlob returns the raw bytes of <path> at <ref> (which can be a
+	// commit OID, ref name like "HEAD", or short branch name) inside the
+	// repository identified by repoID.
+	ReadBlob(ctx context.Context, repoID, ref, path string) ([]byte, error)
+
+	// ListChangedPaths returns the repository-relative paths whose blob
+	// changed between oldOID and newOID. For a branch creation
+	// (oldOID == ZeroOID per agentsmd), implementations should return
+	// every path reachable from newOID.
+	ListChangedPaths(ctx context.Context, repoID, oldOID, newOID string) ([]string, error)
+
+	// BlobSize returns the size in bytes of <path> at <oid>.
+	BlobSize(ctx context.Context, repoID, oid, path string) (int64, error)
+
+	// IsFastForward reports whether newOID is a (non-strict) descendant
+	// of oldOID in the repository.
+	IsFastForward(ctx context.Context, repoID, oldOID, newOID string) (bool, error)
+}

--- a/plane/application/agentsmd/hook/doc.go
+++ b/plane/application/agentsmd/hook/doc.go
@@ -1,0 +1,15 @@
+// Package hook adapts plane/application/agentsmd to the
+// plane/git.HookHandler contract. It is the only place in the
+// agentsmd subtree that imports plane/git types — keeping the parser
+// and evaluator pure (see ADR-019).
+//
+// Allowed imports:
+//   - plane/git/gittypes (RepoRef, RefUpdate)
+//   - plane/git/hook (HookHandler interface)
+//   - plane/application/agentsmd
+//   - plane/application/agentsmd/policystore
+//
+// Forbidden:
+//   - direct Gitaly proto imports — use the BlobReader interface, whose
+//     production implementation lives in plane/git/gitaly.
+package hook

--- a/plane/application/agentsmd/hook/handler.go
+++ b/plane/application/agentsmd/hook/handler.go
@@ -1,0 +1,179 @@
+package hook
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/gitscale-platform/gitscale/plane/application/agentsmd"
+	"github.com/gitscale-platform/gitscale/plane/git/gittypes"
+	githook "github.com/gitscale-platform/gitscale/plane/git/hook"
+)
+
+// PolicyStore resolves the org-level AGENTS.md policy bytes for a given
+// repository. A nil/zero-length result means "no org policy"; the
+// handler treats that as an empty org policy. Errors are load-bearing —
+// the handler fails closed (rejects the push) on store failures.
+type PolicyStore interface {
+	ResolveOrgPolicyBytes(ctx context.Context, repoID string) ([]byte, error)
+}
+
+// AgentsMdPath is the conventional repo-root location of the policy
+// document. Always relative to the repo root.
+const AgentsMdPath = "AGENTS.md"
+
+// Handler implements githook.HookHandler. It reads the repo's AGENTS.md
+// at the tip of each ref update, merges with the org policy resolved by
+// PolicyStore, evaluates Never predicates, and rejects on match.
+//
+// Construction: see New. The zero value is not usable.
+type Handler struct {
+	blobs    BlobReader
+	policies PolicyStore
+}
+
+// Compile-time check.
+var _ githook.HookHandler = (*Handler)(nil)
+
+// New constructs an enforcement handler. All three arguments must be
+// non-nil; passing nil panics at construction time (a programmer error,
+// not a runtime configuration issue).
+func New(blobs BlobReader, policies PolicyStore) *Handler {
+	if blobs == nil {
+		panic("agentsmd/hook: nil BlobReader")
+	}
+	if policies == nil {
+		panic("agentsmd/hook: nil PolicyStore")
+	}
+	return &Handler{blobs: blobs, policies: policies}
+}
+
+// PreReceive evaluates Never predicates against the pushed updates.
+// Behaviour summary (mirrors the spec error-handling table):
+//
+//   - Repo AGENTS.md missing -> empty repo policy (no rejection).
+//   - Repo AGENTS.md malformed -> push allowed; the push doesn't get
+//     bricked by parse errors. The diagnostics are not currently
+//     surfaced from the hook — the MCP `agents_md_lint` tool is the
+//     surface for those.
+//   - BlobReader infra error -> push rejected (caller wraps as Unavailable).
+//   - PolicyStore error -> push rejected.
+//   - Any Never predicate matches -> push rejected with a structured
+//     single-line message. Multiple violations are joined by "; ".
+func (h *Handler) PreReceive(ctx context.Context, repo gittypes.RepoRef, updates []gittypes.RefUpdate) error {
+	repoBytes, err := h.readRepoPolicy(ctx, repo, updates)
+	if err != nil {
+		return fmt.Errorf("agentsmd: read repo policy: %w", err)
+	}
+	orgBytes, err := h.policies.ResolveOrgPolicyBytes(ctx, repo.RepoID)
+	if err != nil {
+		return fmt.Errorf("agentsmd: resolve org policy: %w", err)
+	}
+
+	repoPolicy, _, _ := agentsmd.Parse(repoBytes)
+	orgPolicy, _, _ := agentsmd.Parse(orgBytes)
+	merged := agentsmd.Merge(orgPolicy, repoPolicy)
+	if merged.Empty {
+		return nil
+	}
+
+	input := agentsmd.EvaluationInput{
+		RepoID:  repo.RepoID,
+		AgentID: repo.AgentID,
+		Updates: convertUpdates(updates),
+		Files:   &resolverAdapter{repoID: repo.RepoID, blobs: h.blobs},
+	}
+	violations, err := agentsmd.Evaluate(ctx, merged, input)
+	if err != nil {
+		return fmt.Errorf("agentsmd: evaluate: %w", err)
+	}
+	if len(violations) == 0 {
+		return nil
+	}
+	return formatViolations(violations)
+}
+
+// readRepoPolicy fetches AGENTS.md from the repo. If the push includes
+// an update to refs/heads/HEAD's default branch, we'd ideally read the
+// new tip's AGENTS.md — but the proxy doesn't tell us which ref is the
+// default branch. We use a simple heuristic: if any update targets a
+// non-zero NewOID, try that OID first; on miss fall back to "HEAD".
+// Missing AGENTS.md is not an error — empty bytes signal an empty
+// policy to Parse.
+func (h *Handler) readRepoPolicy(ctx context.Context, repo gittypes.RepoRef, updates []gittypes.RefUpdate) ([]byte, error) {
+	tryOID := func(oid string) ([]byte, bool, error) {
+		if oid == "" || oid == agentsmd.ZeroOID {
+			return nil, false, nil
+		}
+		data, err := h.blobs.ReadBlob(ctx, repo.RepoID, oid, AgentsMdPath)
+		if err == nil {
+			return data, true, nil
+		}
+		if errors.Is(err, ErrBlobNotFound) {
+			return nil, false, nil
+		}
+		return nil, false, err
+	}
+	// Prefer the new tip; on delete (NewOID == zero), fall back to the
+	// pre-push tip so the repo's own policy still gates the delete.
+	for _, u := range updates {
+		if data, ok, err := tryOID(u.NewOID); err != nil {
+			return nil, err
+		} else if ok {
+			return data, nil
+		}
+	}
+	for _, u := range updates {
+		if data, ok, err := tryOID(u.OldOID); err != nil {
+			return nil, err
+		} else if ok {
+			return data, nil
+		}
+	}
+	data, err := h.blobs.ReadBlob(ctx, repo.RepoID, "HEAD", AgentsMdPath)
+	if err == nil {
+		return data, nil
+	}
+	if errors.Is(err, ErrBlobNotFound) {
+		return nil, nil
+	}
+	return nil, err
+}
+
+func convertUpdates(in []gittypes.RefUpdate) []agentsmd.RefUpdate {
+	out := make([]agentsmd.RefUpdate, len(in))
+	for i, u := range in {
+		out[i] = agentsmd.RefUpdate{RefName: u.RefName, OldOID: u.OldOID, NewOID: u.NewOID}
+	}
+	return out
+}
+
+// resolverAdapter implements agentsmd.FileResolver atop BlobReader.
+// Bound to a single repo at construction time so callers don't have to
+// thread repoID through every call.
+type resolverAdapter struct {
+	repoID string
+	blobs  BlobReader
+}
+
+func (r *resolverAdapter) Changed(ctx context.Context, oldOID, newOID string) ([]string, error) {
+	return r.blobs.ListChangedPaths(ctx, r.repoID, oldOID, newOID)
+}
+func (r *resolverAdapter) Size(ctx context.Context, oid, path string) (int64, error) {
+	return r.blobs.BlobSize(ctx, r.repoID, oid, path)
+}
+func (r *resolverAdapter) IsFastForward(ctx context.Context, oldOID, newOID string) (bool, error) {
+	return r.blobs.IsFastForward(ctx, r.repoID, oldOID, newOID)
+}
+
+// formatViolations builds the single-line, structured error string. The
+// proxy converts this to gRPC PermissionDenied with the message intact.
+func formatViolations(vs []agentsmd.Violation) error {
+	parts := make([]string, 0, len(vs))
+	for _, v := range vs {
+		parts = append(parts, fmt.Sprintf("AGENTS.md Never violation: %s on ref %s (%s)",
+			v.Predicate.Name, v.RefName, v.Reason))
+	}
+	return errors.New(strings.Join(parts, "; "))
+}

--- a/plane/application/agentsmd/hook/handler_test.go
+++ b/plane/application/agentsmd/hook/handler_test.go
@@ -1,0 +1,173 @@
+package hook
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/gitscale-platform/gitscale/plane/application/agentsmd"
+	"github.com/gitscale-platform/gitscale/plane/git/gittypes"
+)
+
+// memBlobs is an in-memory BlobReader for unit tests.
+// Blobs map key: "<repoID>|<ref>|<path>". A missing key returns
+// ErrBlobNotFound. listErr/sizeErr/ffErr override behaviour for the
+// non-blob calls when set.
+type memBlobs struct {
+	blobs   map[string][]byte
+	changed map[string][]string // "<repoID>|<old>..<new>"
+	sizes   map[string]int64    // "<repoID>|<oid>:<path>"
+	ff      map[string]bool     // "<repoID>|<old>..<new>"
+	readErr error
+}
+
+func (m *memBlobs) ReadBlob(_ context.Context, repoID, ref, path string) ([]byte, error) {
+	if m.readErr != nil {
+		return nil, m.readErr
+	}
+	k := repoID + "|" + ref + "|" + path
+	if b, ok := m.blobs[k]; ok {
+		return b, nil
+	}
+	return nil, ErrBlobNotFound
+}
+func (m *memBlobs) ListChangedPaths(_ context.Context, repoID, oldOID, newOID string) ([]string, error) {
+	return m.changed[repoID+"|"+oldOID+".."+newOID], nil
+}
+func (m *memBlobs) BlobSize(_ context.Context, repoID, oid, path string) (int64, error) {
+	return m.sizes[repoID+"|"+oid+":"+path], nil
+}
+func (m *memBlobs) IsFastForward(_ context.Context, repoID, oldOID, newOID string) (bool, error) {
+	return m.ff[repoID+"|"+oldOID+".."+newOID], nil
+}
+
+type stubStore struct {
+	bytes []byte
+	err   error
+}
+
+func (s *stubStore) ResolveOrgPolicyBytes(_ context.Context, _ string) ([]byte, error) {
+	return s.bytes, s.err
+}
+
+func TestHandler_NewPanicsOnNil(t *testing.T) {
+	defer func() { _ = recover() }()
+	New(nil, &stubStore{})
+	t.Fatalf("expected panic on nil BlobReader")
+}
+
+func TestHandler_NoPolicyAllowsPush(t *testing.T) {
+	h := New(&memBlobs{blobs: map[string][]byte{}}, &stubStore{})
+	err := h.PreReceive(context.Background(), gittypes.RepoRef{RepoID: "r1"}, []gittypes.RefUpdate{
+		{RefName: "refs/heads/main", OldOID: "old", NewOID: "new"},
+	})
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+}
+
+func TestHandler_RepoPolicyRejectsDelete(t *testing.T) {
+	doc := []byte("---\nschema: gitscale/v1\n---\n## Never\n- delete_branch: main\n")
+	blobs := &memBlobs{blobs: map[string][]byte{
+		"r1|old|AGENTS.md": doc,
+	}}
+	h := New(blobs, &stubStore{})
+	err := h.PreReceive(context.Background(), gittypes.RepoRef{RepoID: "r1"}, []gittypes.RefUpdate{
+		{RefName: "refs/heads/main", OldOID: "old", NewOID: agentsmd.ZeroOID},
+	})
+	if err == nil {
+		t.Fatalf("expected rejection")
+	}
+	if !strings.Contains(err.Error(), "AGENTS.md Never violation") {
+		t.Fatalf("expected structured message, got %q", err.Error())
+	}
+	if !strings.Contains(err.Error(), "delete_branch") {
+		t.Fatalf("expected predicate name, got %q", err.Error())
+	}
+}
+
+func TestHandler_OrgPolicyAppliesEvenWithoutRepoPolicy(t *testing.T) {
+	orgDoc := []byte("---\nschema: gitscale/v1\n---\n## Never\n- delete_branch: main\n")
+	blobs := &memBlobs{blobs: map[string][]byte{}}
+	h := New(blobs, &stubStore{bytes: orgDoc})
+	err := h.PreReceive(context.Background(), gittypes.RepoRef{RepoID: "r1"}, []gittypes.RefUpdate{
+		{RefName: "refs/heads/main", OldOID: "old", NewOID: agentsmd.ZeroOID},
+	})
+	if err == nil {
+		t.Fatalf("expected rejection from org policy")
+	}
+}
+
+func TestHandler_MalformedPolicyDoesNotBlockPush(t *testing.T) {
+	// No front-matter delimiter -> parse error -> empty policy -> push allowed.
+	bad := []byte("not a valid agents.md\n## Never\n- delete_branch: main\n")
+	blobs := &memBlobs{blobs: map[string][]byte{
+		"r1|new|AGENTS.md": bad,
+	}}
+	h := New(blobs, &stubStore{})
+	err := h.PreReceive(context.Background(), gittypes.RepoRef{RepoID: "r1"}, []gittypes.RefUpdate{
+		{RefName: "refs/heads/main", OldOID: "old", NewOID: "new"},
+	})
+	if err != nil {
+		t.Fatalf("malformed policy must not block push: %v", err)
+	}
+}
+
+func TestHandler_BlobReaderInfraErrorRejectsPush(t *testing.T) {
+	blobs := &memBlobs{readErr: errors.New("gitaly down")}
+	h := New(blobs, &stubStore{})
+	err := h.PreReceive(context.Background(), gittypes.RepoRef{RepoID: "r1"}, []gittypes.RefUpdate{
+		{RefName: "refs/heads/main", OldOID: "old", NewOID: "new"},
+	})
+	if err == nil {
+		t.Fatalf("infra error must reject push")
+	}
+}
+
+func TestHandler_PolicyStoreErrorRejectsPush(t *testing.T) {
+	blobs := &memBlobs{blobs: map[string][]byte{}}
+	h := New(blobs, &stubStore{err: errors.New("postgres down")})
+	err := h.PreReceive(context.Background(), gittypes.RepoRef{RepoID: "r1"}, []gittypes.RefUpdate{
+		{RefName: "refs/heads/main", OldOID: "old", NewOID: "new"},
+	})
+	if err == nil {
+		t.Fatalf("policy-store error must reject push")
+	}
+}
+
+func TestHandler_OrgWinsOnConflict(t *testing.T) {
+	// Org rejects delete of main; repo would too. Single violation
+	// expected (org predicate, repo dedup'd).
+	orgDoc := []byte("---\nschema: gitscale/v1\n---\n## Never\n- delete_branch: main\n")
+	repoDoc := []byte("---\nschema: gitscale/v1\n---\n## Never\n- delete_branch: main\n")
+	blobs := &memBlobs{blobs: map[string][]byte{
+		"r1|old|AGENTS.md": repoDoc,
+	}}
+	h := New(blobs, &stubStore{bytes: orgDoc})
+	err := h.PreReceive(context.Background(), gittypes.RepoRef{RepoID: "r1"}, []gittypes.RefUpdate{
+		{RefName: "refs/heads/main", OldOID: "old", NewOID: agentsmd.ZeroOID},
+	})
+	if err == nil || strings.Count(err.Error(), "Never violation") != 1 {
+		t.Fatalf("expected exactly one violation, got %v", err)
+	}
+}
+
+func TestHandler_MultipleViolationsJoined(t *testing.T) {
+	doc := []byte("---\nschema: gitscale/v1\n---\n## Never\n- delete_branch: main\n- push_to_branch: \"release/*\"\n")
+	blobs := &memBlobs{blobs: map[string][]byte{
+		"r1|new1|AGENTS.md": doc,
+		"r1|new2|AGENTS.md": doc,
+	}}
+	h := New(blobs, &stubStore{})
+	err := h.PreReceive(context.Background(), gittypes.RepoRef{RepoID: "r1"}, []gittypes.RefUpdate{
+		{RefName: "refs/heads/main", OldOID: "old", NewOID: agentsmd.ZeroOID},
+		{RefName: "refs/heads/release/v1", OldOID: "a", NewOID: "new2"},
+	})
+	if err == nil {
+		t.Fatalf("expected rejection")
+	}
+	if got := strings.Count(err.Error(), "Never violation"); got != 2 {
+		t.Fatalf("expected 2 violations joined, got %d in %q", got, err.Error())
+	}
+}

--- a/plane/application/agentsmd/integration_test.go
+++ b/plane/application/agentsmd/integration_test.go
@@ -1,0 +1,155 @@
+package agentsmd_test
+
+// Integration-style coverage for the AGENTS.md surfacing + Never
+// enforcement chain: parser → merge → evaluator → hook adapter →
+// policystore. We deliberately avoid testcontainers Gitaly+Postgres
+// here because the git-rpc binary that would drive a real push is not
+// yet built (#107 ships only the proxy package; the cmd/* entrypoint
+// lands separately). Once that binary exists, the testcontainers-based
+// version of these scenarios should live alongside it. The unit-level
+// tests in handler_test.go and policystore_test.go cover every branch
+// of error handling.
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/gitscale-platform/gitscale/plane/application/agentsmd"
+	hookpkg "github.com/gitscale-platform/gitscale/plane/application/agentsmd/hook"
+	"github.com/gitscale-platform/gitscale/plane/application/agentsmd/policystore"
+	"github.com/gitscale-platform/gitscale/plane/git/gittypes"
+)
+
+type harnessBlobs struct {
+	blobs map[string][]byte
+	ff    map[string]bool
+}
+
+func (h *harnessBlobs) ReadBlob(_ context.Context, repoID, ref, path string) ([]byte, error) {
+	if data, ok := h.blobs[repoID+"|"+ref+"|"+path]; ok {
+		return data, nil
+	}
+	return nil, hookpkg.ErrBlobNotFound
+}
+func (h *harnessBlobs) ListChangedPaths(_ context.Context, _, _, _ string) ([]string, error) {
+	return nil, nil
+}
+func (h *harnessBlobs) BlobSize(_ context.Context, _, _, _ string) (int64, error) {
+	return 0, nil
+}
+func (h *harnessBlobs) IsFastForward(_ context.Context, _, oldOID, newOID string) (bool, error) {
+	return h.ff[oldOID+".."+newOID], nil
+}
+
+type harnessMeta struct {
+	org  string
+	slug string
+}
+
+func (h *harnessMeta) LookupRepoSlug(_ context.Context, _ string) (string, string, error) {
+	if h.org == "" {
+		return "", "", policystore.ErrNotFound
+	}
+	return h.org, "service", nil
+}
+func (h *harnessMeta) LookupRepoIDBySlug(_ context.Context, org, slug string) (string, error) {
+	if h.slug == "" || org != h.org || slug != policystore.AgentsPolicyRepoSlug {
+		return "", policystore.ErrNotFound
+	}
+	return h.slug, nil
+}
+
+func newHarness(t *testing.T, repoDoc, orgDoc []byte) *hookpkg.Handler {
+	t.Helper()
+	blobs := &harnessBlobs{blobs: map[string][]byte{}}
+	if repoDoc != nil {
+		blobs.blobs["service-repo|tip|AGENTS.md"] = repoDoc
+		blobs.blobs["service-repo|HEAD|AGENTS.md"] = repoDoc
+	}
+	meta := &harnessMeta{}
+	if orgDoc != nil {
+		meta.org = "acme"
+		meta.slug = "policy-repo"
+		blobs.blobs["policy-repo|HEAD|AGENTS.md"] = orgDoc
+	}
+	store := policystore.New(meta, blobs)
+	return hookpkg.New(blobs, store)
+}
+
+func TestIntegration_PushViolatingNeverIsRejected(t *testing.T) {
+	repoDoc := []byte("---\nschema: gitscale/v1\n---\n## Never\n- delete_branch: main\n")
+	h := newHarness(t, repoDoc, nil)
+
+	err := h.PreReceive(context.Background(), gittypes.RepoRef{RepoID: "service-repo"}, []gittypes.RefUpdate{
+		{RefName: "refs/heads/main", OldOID: "tip", NewOID: agentsmd.ZeroOID},
+	})
+	if err == nil {
+		t.Fatalf("expected push rejection")
+	}
+	if !strings.Contains(err.Error(), "AGENTS.md Never violation: delete_branch") {
+		t.Fatalf("expected structured violation message, got %q", err.Error())
+	}
+}
+
+func TestIntegration_CleanPushIsAccepted(t *testing.T) {
+	repoDoc := []byte("---\nschema: gitscale/v1\n---\n## Never\n- delete_branch: main\n")
+	h := newHarness(t, repoDoc, nil)
+
+	err := h.PreReceive(context.Background(), gittypes.RepoRef{RepoID: "service-repo"}, []gittypes.RefUpdate{
+		{RefName: "refs/heads/feature/x", OldOID: "tip", NewOID: "newtip"},
+	})
+	if err != nil {
+		t.Fatalf("clean push must pass, got %v", err)
+	}
+}
+
+func TestIntegration_MalformedAgentsMdDoesNotBlock(t *testing.T) {
+	bad := []byte("not valid agents.md\nno front matter\n")
+	h := newHarness(t, bad, nil)
+
+	err := h.PreReceive(context.Background(), gittypes.RepoRef{RepoID: "service-repo"}, []gittypes.RefUpdate{
+		{RefName: "refs/heads/main", OldOID: "tip", NewOID: "newtip"},
+	})
+	if err != nil {
+		t.Fatalf("malformed AGENTS.md must not block push (lint surface only): %v", err)
+	}
+}
+
+func TestIntegration_OrgPolicyEnforcedWithoutRepoPolicy(t *testing.T) {
+	orgDoc := []byte("---\nschema: gitscale/v1\n---\n## Never\n- delete_branch: main\n")
+	h := newHarness(t, nil, orgDoc)
+
+	err := h.PreReceive(context.Background(), gittypes.RepoRef{RepoID: "service-repo"}, []gittypes.RefUpdate{
+		{RefName: "refs/heads/main", OldOID: "tip", NewOID: agentsmd.ZeroOID},
+	})
+	if err == nil {
+		t.Fatalf("expected org-policy rejection")
+	}
+}
+
+func TestIntegration_ForcePushBlockedAcrossOrgRepoMerge(t *testing.T) {
+	orgDoc := []byte("---\nschema: gitscale/v1\n---\n## Never\n- force_push_to_branch: main\n")
+	repoDoc := []byte("---\nschema: gitscale/v1\n---\n## Never\n- delete_branch: main\n")
+	blobs := &harnessBlobs{
+		blobs: map[string][]byte{
+			"service-repo|HEAD|AGENTS.md": repoDoc,
+			"service-repo|new|AGENTS.md":  repoDoc,
+			"policy-repo|HEAD|AGENTS.md":  orgDoc,
+		},
+		ff: map[string]bool{"old..new": false}, // not a fast-forward -> force push
+	}
+	meta := &harnessMeta{org: "acme", slug: "policy-repo"}
+	store := policystore.New(meta, blobs)
+	h := hookpkg.New(blobs, store)
+
+	err := h.PreReceive(context.Background(), gittypes.RepoRef{RepoID: "service-repo"}, []gittypes.RefUpdate{
+		{RefName: "refs/heads/main", OldOID: "old", NewOID: "new"},
+	})
+	if err == nil {
+		t.Fatalf("expected force-push rejection")
+	}
+	if !strings.Contains(err.Error(), "force_push_to_branch") {
+		t.Fatalf("expected force_push_to_branch in message, got %q", err.Error())
+	}
+}

--- a/plane/application/agentsmd/lint.go
+++ b/plane/application/agentsmd/lint.go
@@ -1,0 +1,12 @@
+package agentsmd
+
+// Lint returns only the diagnostics from Parse. It is the convenience
+// wrapper used by the MCP `agents_md_lint` tool (#112) — humans and IDEs
+// don't usually need the parsed Policy, just the structured findings.
+//
+// A clean document returns nil; an unparseable document returns the
+// diagnostics that would have been produced by Parse.
+func Lint(data []byte) []Diagnostic {
+	_, diags, _ := Parse(data)
+	return diags
+}

--- a/plane/application/agentsmd/merge.go
+++ b/plane/application/agentsmd/merge.go
@@ -1,0 +1,40 @@
+package agentsmd
+
+// Merge produces the effective policy for a (org, repo) pair.
+//
+// Semantics (per spec):
+//   - If both inputs are nil/empty, the result is the empty policy.
+//   - The Never list is the union of org and repo predicates.
+//   - On a (name + full selector) collision, the org predicate wins and
+//     the repo duplicate is dropped.
+//   - Order in the result: org predicates first (in their declared order),
+//     then repo predicates that did not collide (in their declared order).
+//
+// Either argument may be nil; a nil input is treated as an empty policy.
+func Merge(org, repo *Policy) *Policy {
+	merged := &Policy{SchemaVersion: SchemaVersionV1}
+	seen := map[string]struct{}{}
+
+	if org != nil && !org.Empty {
+		for _, p := range org.Never {
+			k := p.key()
+			if _, dup := seen[k]; dup {
+				continue
+			}
+			seen[k] = struct{}{}
+			merged.Never = append(merged.Never, p)
+		}
+	}
+	if repo != nil && !repo.Empty {
+		for _, p := range repo.Never {
+			k := p.key()
+			if _, dup := seen[k]; dup {
+				continue
+			}
+			seen[k] = struct{}{}
+			merged.Never = append(merged.Never, p)
+		}
+	}
+	merged.Empty = len(merged.Never) == 0
+	return merged
+}

--- a/plane/application/agentsmd/merge_test.go
+++ b/plane/application/agentsmd/merge_test.go
@@ -1,0 +1,50 @@
+package agentsmd
+
+import "testing"
+
+func TestMerge_NilInputs(t *testing.T) {
+	got := Merge(nil, nil)
+	if got == nil || !got.Empty || len(got.Never) != 0 {
+		t.Fatalf("expected empty policy, got %+v", got)
+	}
+}
+
+func TestMerge_EmptyInputs(t *testing.T) {
+	got := Merge(&Policy{Empty: true}, &Policy{Empty: true})
+	if !got.Empty {
+		t.Fatalf("expected empty policy, got %+v", got)
+	}
+}
+
+func TestMerge_OrgWinsOnDuplicate(t *testing.T) {
+	org := &Policy{Never: []NeverPredicate{
+		{Name: PredicateDeleteBranch, Selector: PredicateSelector{BranchGlob: "main"}},
+	}}
+	repo := &Policy{Never: []NeverPredicate{
+		{Name: PredicateDeleteBranch, Selector: PredicateSelector{BranchGlob: "main"}},
+		{Name: PredicatePushToBranch, Selector: PredicateSelector{BranchGlob: "release/*"}},
+	}}
+	got := Merge(org, repo)
+	if len(got.Never) != 2 {
+		t.Fatalf("expected 2 predicates, got %d: %+v", len(got.Never), got.Never)
+	}
+	if got.Never[0].Name != PredicateDeleteBranch {
+		t.Fatalf("org predicate must come first, got %v", got.Never[0])
+	}
+	if got.Never[1].Name != PredicatePushToBranch {
+		t.Fatalf("non-conflicting repo predicate expected second, got %v", got.Never[1])
+	}
+}
+
+func TestMerge_DifferentSelectorsCoexist(t *testing.T) {
+	org := &Policy{Never: []NeverPredicate{
+		{Name: PredicateDeleteBranch, Selector: PredicateSelector{BranchGlob: "main"}},
+	}}
+	repo := &Policy{Never: []NeverPredicate{
+		{Name: PredicateDeleteBranch, Selector: PredicateSelector{BranchGlob: "release/*"}},
+	}}
+	got := Merge(org, repo)
+	if len(got.Never) != 2 {
+		t.Fatalf("expected 2 (different selectors), got %d", len(got.Never))
+	}
+}

--- a/plane/application/agentsmd/parser.go
+++ b/plane/application/agentsmd/parser.go
@@ -1,0 +1,337 @@
+package agentsmd
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Parse extracts a Policy and a list of Diagnostics from an AGENTS.md
+// document. The parser is forgiving: malformed input yields diagnostics
+// (severity error/warning) but does not return a non-nil error unless
+// callers passed in something so corrupt that no policy could be
+// constructed (e.g. structural YAML scanner errors). For all routine
+// "the doc has problems" cases, callers should inspect Diagnostics.
+//
+// A nil/empty/whitespace-only input yields (&Policy{Empty: true}, nil, nil).
+//
+// Behaviour summary:
+//   - Front-matter is delimited by "---" lines; the parser reads the
+//     first delimited block as YAML.
+//   - The YAML must contain a `schema:` field; only "gitscale/v1" is
+//     accepted. Other values produce CodeUnsupportedSchemaVersion and the
+//     returned policy is the empty policy (no enforcement).
+//   - The Markdown body is scanned for a `## Never` heading. Bullet items
+//     under that heading of the shape `- predicate_name: <selector>` are
+//     parsed into NeverPredicate values.
+//   - Unknown predicate names produce CodeUnknownPredicate; the predicate
+//     is dropped (not enforced).
+//   - Duplicate (name+selector) predicates produce CodeDuplicatePredicate;
+//     the duplicate is dropped.
+//   - An empty `## Never` block produces CodeEmptyNeverBlock (warning).
+func Parse(data []byte) (*Policy, []Diagnostic, error) {
+	if len(bytes.TrimSpace(data)) == 0 {
+		return &Policy{Empty: true}, nil, nil
+	}
+
+	front, body, frontEndLine, frontDiag := splitFrontMatter(data)
+	var diags []Diagnostic
+	if frontDiag != nil {
+		diags = append(diags, *frontDiag)
+		// Without front-matter we cannot know the schema version. Treat as
+		// empty to fail closed on enforcement.
+		return &Policy{Empty: true}, diags, nil
+	}
+
+	var fm frontMatter
+	if len(bytes.TrimSpace(front)) > 0 {
+		if err := yaml.Unmarshal(front, &fm); err != nil {
+			diags = append(diags, Diagnostic{
+				Code:     CodeMalformedFrontMatter,
+				Severity: SeverityError,
+				Line:     1,
+				Message:  fmt.Sprintf("front-matter YAML: %v", err),
+			})
+			return &Policy{Empty: true}, diags, nil
+		}
+	}
+
+	if fm.Schema == "" {
+		diags = append(diags, Diagnostic{
+			Code:     CodeMalformedFrontMatter,
+			Severity: SeverityError,
+			Line:     1,
+			Message:  "front-matter missing required `schema:` field",
+		})
+		return &Policy{Empty: true}, diags, nil
+	}
+	if fm.Schema != SchemaVersionV1 {
+		diags = append(diags, Diagnostic{
+			Code:     CodeUnsupportedSchemaVersion,
+			Severity: SeverityError,
+			Line:     1,
+			Message:  fmt.Sprintf("unsupported schema version %q (expected %q)", fm.Schema, SchemaVersionV1),
+		})
+		return &Policy{Empty: true}, diags, nil
+	}
+
+	preds, predDiags := parseNeverBlock(body, frontEndLine)
+	diags = append(diags, predDiags...)
+
+	policy := &Policy{
+		SchemaVersion: fm.Schema,
+		Never:         preds,
+		Empty:         len(preds) == 0,
+	}
+	return policy, diags, nil
+}
+
+// frontMatter mirrors the YAML keys we read from the document head. We
+// keep the surface minimal; future fields are additive.
+type frontMatter struct {
+	Schema  string `yaml:"schema"`
+	Version string `yaml:"version"`
+}
+
+// splitFrontMatter looks for a leading `---\n...\n---` block. Returns
+// (frontBytes, bodyBytes, lineAfterFront, diag). If the input does not
+// begin with `---`, the entire input is treated as body and an
+// "missing front matter" diagnostic is returned.
+func splitFrontMatter(data []byte) ([]byte, []byte, int, *Diagnostic) {
+	lines := splitLines(data)
+	if len(lines) == 0 || strings.TrimSpace(lines[0]) != "---" {
+		return nil, data, 0, &Diagnostic{
+			Code:     CodeMalformedFrontMatter,
+			Severity: SeverityError,
+			Line:     1,
+			Message:  "AGENTS.md must begin with a `---` front-matter delimiter",
+		}
+	}
+	for i := 1; i < len(lines); i++ {
+		if strings.TrimSpace(lines[i]) == "---" {
+			front := bytes.Join(bytesFromLines(lines[1:i]), []byte("\n"))
+			body := bytes.Join(bytesFromLines(lines[i+1:]), []byte("\n"))
+			return front, body, i + 1, nil
+		}
+	}
+	return nil, data, 0, &Diagnostic{
+		Code:     CodeMalformedFrontMatter,
+		Severity: SeverityError,
+		Line:     1,
+		Message:  "front-matter block opened with `---` but never closed",
+	}
+}
+
+// splitLines returns the input split on '\n' without dropping trailing empties.
+func splitLines(data []byte) []string {
+	if len(data) == 0 {
+		return nil
+	}
+	return strings.Split(string(data), "\n")
+}
+
+func bytesFromLines(lines []string) [][]byte {
+	out := make([][]byte, len(lines))
+	for i, l := range lines {
+		out[i] = []byte(l)
+	}
+	return out
+}
+
+// parseNeverBlock scans the Markdown body for a `## Never` heading and
+// extracts bullet-item predicates beneath it (until the next heading at
+// the same or higher level, or end of document).
+func parseNeverBlock(body []byte, lineOffset int) ([]NeverPredicate, []Diagnostic) {
+	lines := splitLines(body)
+	var (
+		preds      []NeverPredicate
+		diags      []Diagnostic
+		seen       = map[string]struct{}{}
+		inNever    bool
+		neverStart int
+		neverCount int
+	)
+	known := knownPredicates()
+	for i, raw := range lines {
+		line := strings.TrimRight(raw, "\r\t ")
+		fileLine := lineOffset + i + 1
+		trim := strings.TrimSpace(line)
+
+		// Headings change scan state.
+		if strings.HasPrefix(trim, "#") {
+			if inNever && neverCount == 0 {
+				diags = append(diags, Diagnostic{
+					Code:     CodeEmptyNeverBlock,
+					Severity: SeverityWarning,
+					Line:     neverStart,
+					Message:  "`## Never` block contained no predicates",
+				})
+			}
+			heading := strings.TrimSpace(strings.TrimLeft(trim, "#"))
+			if strings.EqualFold(heading, "Never") {
+				inNever = true
+				neverStart = fileLine
+				neverCount = 0
+				continue
+			}
+			inNever = false
+			// Other recognised headings: Always, Prefer (advisory only in
+			// this iteration; presence is fine, contents not parsed).
+			if !isKnownHeading(heading) {
+				diags = append(diags, Diagnostic{
+					Code:     CodeUnknownSection,
+					Severity: SeverityWarning,
+					Line:     fileLine,
+					Message:  fmt.Sprintf("unknown section heading %q (advisory)", heading),
+				})
+			}
+			continue
+		}
+
+		if !inNever {
+			continue
+		}
+
+		if !strings.HasPrefix(trim, "- ") {
+			continue
+		}
+
+		neverCount++
+		item := strings.TrimSpace(strings.TrimPrefix(trim, "- "))
+		pred, perr := parsePredicateItem(item)
+		if perr != "" {
+			diags = append(diags, Diagnostic{
+				Code:     CodeMalformedPredicate,
+				Severity: SeverityError,
+				Line:     fileLine,
+				Message:  perr,
+			})
+			continue
+		}
+		if _, ok := known[pred.Name]; !ok {
+			diags = append(diags, Diagnostic{
+				Code:     CodeUnknownPredicate,
+				Severity: SeverityError,
+				Line:     fileLine,
+				Message:  fmt.Sprintf("unknown predicate %q (skipped, not enforced)", pred.Name),
+			})
+			continue
+		}
+		k := pred.key()
+		if _, dup := seen[k]; dup {
+			diags = append(diags, Diagnostic{
+				Code:     CodeDuplicatePredicate,
+				Severity: SeverityWarning,
+				Line:     fileLine,
+				Message:  fmt.Sprintf("duplicate predicate %q ignored", pred.Name),
+			})
+			continue
+		}
+		seen[k] = struct{}{}
+		preds = append(preds, pred)
+	}
+	if inNever && neverCount == 0 {
+		diags = append(diags, Diagnostic{
+			Code:     CodeEmptyNeverBlock,
+			Severity: SeverityWarning,
+			Line:     neverStart,
+			Message:  "`## Never` block contained no predicates",
+		})
+	}
+	return preds, diags
+}
+
+func knownPredicates() map[PredicateName]struct{} {
+	m := map[PredicateName]struct{}{}
+	for _, p := range AllPredicates() {
+		m[p] = struct{}{}
+	}
+	return m
+}
+
+func isKnownHeading(h string) bool {
+	switch strings.ToLower(h) {
+	case "never", "always", "prefer":
+		return true
+	}
+	return false
+}
+
+// parsePredicateItem parses a single bullet item body of the form
+// `predicate_name: selector`. The selector grammar is predicate-specific:
+//
+//   - force_push_to_branch / delete_branch / push_to_branch:
+//     the selector is a branch glob (e.g. "main", "release/*").
+//   - modify_path: the selector is a path glob (e.g. "infra/**").
+//   - push_binary_over_size: the selector is an int64 byte size, optionally
+//     suffixed K/M/G (case-insensitive, base 1024).
+//
+// On error returns a non-empty message; the caller emits the diagnostic.
+func parsePredicateItem(item string) (NeverPredicate, string) {
+	colon := strings.Index(item, ":")
+	if colon < 0 {
+		return NeverPredicate{}, fmt.Sprintf("malformed predicate %q: expected `name: selector`", item)
+	}
+	name := PredicateName(strings.TrimSpace(item[:colon]))
+	selector := strings.TrimSpace(item[colon+1:])
+	if name == "" || selector == "" {
+		return NeverPredicate{}, fmt.Sprintf("malformed predicate %q: name or selector empty", item)
+	}
+	pred := NeverPredicate{Name: name}
+	switch name {
+	case PredicateForcePushToBranch, PredicateDeleteBranch, PredicatePushToBranch:
+		pred.Selector.BranchGlob = unquote(selector)
+	case PredicateModifyPath:
+		pred.Selector.PathGlob = unquote(selector)
+	case PredicatePushBinaryOverSize:
+		n, err := parseSize(unquote(selector))
+		if err != nil {
+			return NeverPredicate{}, fmt.Sprintf("malformed size %q: %v", selector, err)
+		}
+		pred.Selector.MaxBytes = n
+	default:
+		// Unknown predicate name; carry the value through so the caller
+		// can emit CodeUnknownPredicate (which is more specific than
+		// "malformed").
+		pred.Selector.BranchGlob = unquote(selector)
+	}
+	return pred, ""
+}
+
+func unquote(s string) string {
+	if len(s) >= 2 {
+		first, last := s[0], s[len(s)-1]
+		if (first == '"' && last == '"') || (first == '\'' && last == '\'') {
+			return s[1 : len(s)-1]
+		}
+	}
+	return s
+}
+
+func parseSize(s string) (int64, error) {
+	if s == "" {
+		return 0, fmt.Errorf("empty size")
+	}
+	mul := int64(1)
+	switch s[len(s)-1] {
+	case 'k', 'K':
+		mul = 1024
+		s = s[:len(s)-1]
+	case 'm', 'M':
+		mul = 1024 * 1024
+		s = s[:len(s)-1]
+	case 'g', 'G':
+		mul = 1024 * 1024 * 1024
+		s = s[:len(s)-1]
+	}
+	var n int64
+	for _, c := range s {
+		if c < '0' || c > '9' {
+			return 0, fmt.Errorf("non-digit %q", c)
+		}
+		n = n*10 + int64(c-'0')
+	}
+	return n * mul, nil
+}

--- a/plane/application/agentsmd/parser_test.go
+++ b/plane/application/agentsmd/parser_test.go
@@ -1,0 +1,219 @@
+package agentsmd
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParse_EmptyInput(t *testing.T) {
+	cases := [][]byte{nil, {}, []byte("   \n  \t\n")}
+	for _, c := range cases {
+		p, diags, err := Parse(c)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !p.Empty {
+			t.Fatalf("expected empty policy, got %+v", p)
+		}
+		if len(diags) != 0 {
+			t.Fatalf("expected no diagnostics, got %+v", diags)
+		}
+	}
+}
+
+func TestParse_MissingFrontMatter(t *testing.T) {
+	doc := []byte("# Hello\n\n## Never\n\n- delete_branch: main\n")
+	p, diags, err := Parse(doc)
+	if err != nil {
+		t.Fatalf("err=%v", err)
+	}
+	if !p.Empty {
+		t.Fatalf("expected empty policy when front-matter missing, got %+v", p)
+	}
+	if !diagContains(diags, CodeMalformedFrontMatter, SeverityError) {
+		t.Fatalf("expected CodeMalformedFrontMatter, got %+v", diags)
+	}
+}
+
+func TestParse_UnsupportedSchema(t *testing.T) {
+	doc := []byte("---\nschema: gitscale/v2\n---\n## Never\n- delete_branch: main\n")
+	p, diags, err := Parse(doc)
+	if err != nil {
+		t.Fatalf("err=%v", err)
+	}
+	if !p.Empty {
+		t.Fatalf("expected empty policy on unsupported schema")
+	}
+	if !diagContains(diags, CodeUnsupportedSchemaVersion, SeverityError) {
+		t.Fatalf("expected CodeUnsupportedSchemaVersion, got %+v", diags)
+	}
+}
+
+func TestParse_NeverDeleteBranch(t *testing.T) {
+	doc := []byte("---\nschema: gitscale/v1\n---\n## Never\n- delete_branch: main\n- push_to_branch: \"release/*\"\n")
+	p, diags, err := Parse(doc)
+	if err != nil {
+		t.Fatalf("err=%v", err)
+	}
+	if len(diags) != 0 {
+		t.Fatalf("unexpected diagnostics: %+v", diags)
+	}
+	if p.Empty || len(p.Never) != 2 {
+		t.Fatalf("expected 2 predicates, got %+v", p)
+	}
+	if p.Never[0].Name != PredicateDeleteBranch || p.Never[0].Selector.BranchGlob != "main" {
+		t.Fatalf("predicate[0] mismatch: %+v", p.Never[0])
+	}
+	if p.Never[1].Name != PredicatePushToBranch || p.Never[1].Selector.BranchGlob != "release/*" {
+		t.Fatalf("predicate[1] mismatch: %+v", p.Never[1])
+	}
+}
+
+func TestParse_PushBinaryOverSize(t *testing.T) {
+	doc := []byte("---\nschema: gitscale/v1\n---\n## Never\n- push_binary_over_size: 5M\n")
+	p, diags, err := Parse(doc)
+	if err != nil {
+		t.Fatalf("err=%v", err)
+	}
+	if len(diags) != 0 {
+		t.Fatalf("unexpected diagnostics: %+v", diags)
+	}
+	if got := p.Never[0].Selector.MaxBytes; got != 5*1024*1024 {
+		t.Fatalf("expected 5MiB, got %d", got)
+	}
+}
+
+func TestParse_UnknownPredicate(t *testing.T) {
+	doc := []byte("---\nschema: gitscale/v1\n---\n## Never\n- frobulate_branch: main\n")
+	p, diags, err := Parse(doc)
+	if err != nil {
+		t.Fatalf("err=%v", err)
+	}
+	if len(p.Never) != 0 {
+		t.Fatalf("unknown predicate must be dropped, got %+v", p.Never)
+	}
+	if !diagContains(diags, CodeUnknownPredicate, SeverityError) {
+		t.Fatalf("expected CodeUnknownPredicate, got %+v", diags)
+	}
+}
+
+func TestParse_DuplicatePredicate(t *testing.T) {
+	doc := []byte("---\nschema: gitscale/v1\n---\n## Never\n- delete_branch: main\n- delete_branch: main\n")
+	p, diags, err := Parse(doc)
+	if err != nil {
+		t.Fatalf("err=%v", err)
+	}
+	if len(p.Never) != 1 {
+		t.Fatalf("duplicate must be dropped, got %d", len(p.Never))
+	}
+	if !diagContains(diags, CodeDuplicatePredicate, SeverityWarning) {
+		t.Fatalf("expected CodeDuplicatePredicate, got %+v", diags)
+	}
+}
+
+func TestParse_EmptyNeverBlock(t *testing.T) {
+	doc := []byte("---\nschema: gitscale/v1\n---\n## Never\n\n## Always\n- something: x\n")
+	_, diags, err := Parse(doc)
+	if err != nil {
+		t.Fatalf("err=%v", err)
+	}
+	if !diagContains(diags, CodeEmptyNeverBlock, SeverityWarning) {
+		t.Fatalf("expected CodeEmptyNeverBlock, got %+v", diags)
+	}
+}
+
+func TestParse_UnknownSection(t *testing.T) {
+	doc := []byte("---\nschema: gitscale/v1\n---\n## Cromulent\n- whatever\n## Never\n- delete_branch: main\n")
+	_, diags, err := Parse(doc)
+	if err != nil {
+		t.Fatalf("err=%v", err)
+	}
+	if !diagContains(diags, CodeUnknownSection, SeverityWarning) {
+		t.Fatalf("expected CodeUnknownSection, got %+v", diags)
+	}
+}
+
+func TestParse_MalformedPredicate(t *testing.T) {
+	doc := []byte("---\nschema: gitscale/v1\n---\n## Never\n- delete_branch\n")
+	_, diags, err := Parse(doc)
+	if err != nil {
+		t.Fatalf("err=%v", err)
+	}
+	if !diagContains(diags, CodeMalformedPredicate, SeverityError) {
+		t.Fatalf("expected CodeMalformedPredicate, got %+v", diags)
+	}
+}
+
+func TestParse_MalformedFrontMatterYAML(t *testing.T) {
+	doc := []byte("---\nschema: : :\n  not yaml\n---\n## Never\n- delete_branch: main\n")
+	p, diags, err := Parse(doc)
+	if err != nil {
+		t.Fatalf("err=%v", err)
+	}
+	if !p.Empty {
+		t.Fatalf("expected empty policy on malformed front-matter")
+	}
+	if !diagContains(diags, CodeMalformedFrontMatter, SeverityError) {
+		t.Fatalf("expected CodeMalformedFrontMatter, got %+v", diags)
+	}
+}
+
+func TestParse_FrontMatterMissingSchema(t *testing.T) {
+	doc := []byte("---\nversion: 1\n---\n## Never\n- delete_branch: main\n")
+	p, diags, err := Parse(doc)
+	if err != nil {
+		t.Fatalf("err=%v", err)
+	}
+	if !p.Empty {
+		t.Fatalf("expected empty policy without schema")
+	}
+	if !diagContains(diags, CodeMalformedFrontMatter, SeverityError) {
+		t.Fatalf("expected CodeMalformedFrontMatter, got %+v", diags)
+	}
+}
+
+func TestLint_DelegatesToParse(t *testing.T) {
+	doc := []byte("---\nschema: gitscale/v1\n---\n## Never\n- delete_branch\n")
+	got := Lint(doc)
+	if !diagContains(got, CodeMalformedPredicate, SeverityError) {
+		t.Fatalf("expected lint to surface diagnostics, got %+v", got)
+	}
+}
+
+func TestParse_QuotedSelector(t *testing.T) {
+	doc := []byte("---\nschema: gitscale/v1\n---\n## Never\n- delete_branch: \"main\"\n")
+	p, diags, err := Parse(doc)
+	if err != nil || len(diags) != 0 {
+		t.Fatalf("parse: %v %+v", err, diags)
+	}
+	if p.Never[0].Selector.BranchGlob != "main" {
+		t.Fatalf("quotes not stripped: %q", p.Never[0].Selector.BranchGlob)
+	}
+}
+
+func diagContains(diags []Diagnostic, code string, sev Severity) bool {
+	for _, d := range diags {
+		if d.Code == code && d.Severity == sev {
+			return true
+		}
+	}
+	return false
+}
+
+func TestParse_AllowsBlankLinesAroundNever(t *testing.T) {
+	doc := []byte("---\nschema: gitscale/v1\n---\n\n# Repo notes\n\nSome prose.\n\n## Never\n\n- delete_branch: main\n\n")
+	p, diags, err := Parse(doc)
+	if err != nil {
+		t.Fatalf("err=%v diags=%+v", err, diags)
+	}
+	if len(p.Never) != 1 {
+		t.Fatalf("expected 1 predicate, got %d (diags=%+v)", len(p.Never), diags)
+	}
+	// "# Repo notes" is an unknown section heading; that's a warning, not blocking.
+	for _, d := range diags {
+		if d.Severity == SeverityError {
+			t.Fatalf("unexpected error diag: %+v", d)
+		}
+	}
+	_ = strings.TrimSpace
+}

--- a/plane/application/agentsmd/policy.go
+++ b/plane/application/agentsmd/policy.go
@@ -1,0 +1,85 @@
+package agentsmd
+
+// SchemaVersionV1 is the only schema version accepted in this iteration.
+// See doc.go for the schema-versioning open arch question.
+const SchemaVersionV1 = "gitscale/v1"
+
+// Policy is the parsed, validated representation of an AGENTS.md document.
+// An "empty" policy (Empty == true) carries no predicates and matches no
+// updates; it is the result of parsing nil/whitespace-only input.
+type Policy struct {
+	SchemaVersion string
+	Empty         bool
+	Never         []NeverPredicate
+}
+
+// PredicateName is the closed enumeration of v1 Never-predicate names.
+// Unknown names are surfaced as a CodeUnknownPredicate diagnostic at parse
+// time and are not enforced (see spec).
+type PredicateName string
+
+const (
+	PredicateForcePushToBranch  PredicateName = "force_push_to_branch"
+	PredicateDeleteBranch       PredicateName = "delete_branch"
+	PredicatePushToBranch       PredicateName = "push_to_branch"
+	PredicateModifyPath         PredicateName = "modify_path"
+	PredicatePushBinaryOverSize PredicateName = "push_binary_over_size"
+)
+
+// AllPredicates is exposed for tests and tools (e.g. MCP) that enumerate
+// the closed v1 vocabulary.
+func AllPredicates() []PredicateName {
+	return []PredicateName{
+		PredicateForcePushToBranch,
+		PredicateDeleteBranch,
+		PredicatePushToBranch,
+		PredicateModifyPath,
+		PredicatePushBinaryOverSize,
+	}
+}
+
+// PredicateSelector carries the typed inputs each predicate consumes.
+// Only the field(s) relevant to a given predicate are populated; the
+// evaluator selects on Name and ignores irrelevant fields.
+type PredicateSelector struct {
+	BranchGlob string // *_branch predicates
+	PathGlob   string // modify_path
+	MaxBytes   int64  // push_binary_over_size
+}
+
+// NeverPredicate is a single rule under the `## Never` Markdown heading.
+type NeverPredicate struct {
+	Name     PredicateName
+	Selector PredicateSelector
+}
+
+// key uniquely identifies a predicate for dedup/merge purposes. Name +
+// every selector field — two predicates collide only if both name and
+// selector match exactly.
+func (p NeverPredicate) key() string {
+	return string(p.Name) + "|" + p.Selector.BranchGlob + "|" + p.Selector.PathGlob + "|" + itoa64(p.Selector.MaxBytes)
+}
+
+func itoa64(n int64) string {
+	// stdlib strconv would import a bigger surface; tiny helper keeps
+	// this file dependency-free.
+	if n == 0 {
+		return "0"
+	}
+	negative := n < 0
+	if negative {
+		n = -n
+	}
+	var buf [20]byte
+	i := len(buf)
+	for n > 0 {
+		i--
+		buf[i] = byte('0' + n%10)
+		n /= 10
+	}
+	if negative {
+		i--
+		buf[i] = '-'
+	}
+	return string(buf[i:])
+}

--- a/plane/application/agentsmd/policystore/doc.go
+++ b/plane/application/agentsmd/policystore/doc.go
@@ -1,0 +1,13 @@
+// Package policystore resolves the org-level AGENTS.md policy bytes for
+// a repository. Convention: every org's policy lives in a repository
+// named "<org>/.gitscale-agents" at path AGENTS.md (mirrors the GitHub
+// ".github" repo convention). If the conventional repo or the file
+// does not exist, ResolveOrgPolicyBytes returns (nil, nil) — i.e. no
+// org policy.
+//
+// This package depends only on small consumer-defined interfaces
+// (RepoMetadata + BlobReader). The production wiring binds a concrete
+// metadata service from plane/application/repositories (when it lands)
+// and a Gitaly-backed BlobReader from plane/git/gitaly. Tests inject
+// in-memory fakes.
+package policystore

--- a/plane/application/agentsmd/policystore/policystore.go
+++ b/plane/application/agentsmd/policystore/policystore.go
@@ -1,0 +1,91 @@
+package policystore
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	hookpkg "github.com/gitscale-platform/gitscale/plane/application/agentsmd/hook"
+)
+
+// AgentsPolicyRepoSlug is the conventional repo slug under which an
+// organisation hosts its org-wide AGENTS.md policy.
+const AgentsPolicyRepoSlug = ".gitscale-agents"
+
+// RepoMetadata is the slice of the application-plane repository service
+// this package consumes. Defining it locally avoids a hard dependency on
+// the (not-yet-built) repositories service. The wiring layer is
+// responsible for implementing this interface against whatever metadata
+// surface ships.
+//
+// LookupRepoSlug maps a repository ID to its (org_slug, repo_slug) pair.
+// LookupRepoIDBySlug is the inverse for the conventional .gitscale-agents
+// lookup. Either method may return ErrNotFound to signal absence; any
+// other error is treated as load-bearing infra failure by the caller.
+type RepoMetadata interface {
+	LookupRepoSlug(ctx context.Context, repoID string) (orgSlug string, repoSlug string, err error)
+	LookupRepoIDBySlug(ctx context.Context, orgSlug, repoSlug string) (repoID string, err error)
+}
+
+// ErrNotFound is the sentinel returned by RepoMetadata implementations
+// when a repository or org cannot be resolved. It is intentionally
+// distinct from hook.ErrBlobNotFound so callers can keep "no policy"
+// (allow-through) separate from "infra error" (reject).
+var ErrNotFound = errors.New("policystore: not found")
+
+// ServicePolicyStore is the production PolicyStore implementation. It
+// resolves the requesting repo's org via RepoMetadata, derives the
+// conventional ".gitscale-agents" repo for that org, and fetches the
+// AGENTS.md blob via BlobReader.
+//
+// Construction: see New. The zero value is not usable.
+type ServicePolicyStore struct {
+	meta  RepoMetadata
+	blobs hookpkg.BlobReader
+}
+
+// Compile-time check.
+var _ hookpkg.PolicyStore = (*ServicePolicyStore)(nil)
+
+// New constructs a ServicePolicyStore. Both arguments must be non-nil.
+func New(meta RepoMetadata, blobs hookpkg.BlobReader) *ServicePolicyStore {
+	if meta == nil {
+		panic("policystore: nil RepoMetadata")
+	}
+	if blobs == nil {
+		panic("policystore: nil BlobReader")
+	}
+	return &ServicePolicyStore{meta: meta, blobs: blobs}
+}
+
+// ResolveOrgPolicyBytes returns the bytes of the org-wide AGENTS.md, or
+// (nil, nil) if the source repo's org is unknown, the org has no
+// .gitscale-agents repo, or that repo has no AGENTS.md.
+//
+// Errors are returned only for infra failures (RepoMetadata or
+// BlobReader returning a non-sentinel error). The hook.Handler treats
+// such errors as load-bearing and rejects the push.
+func (s *ServicePolicyStore) ResolveOrgPolicyBytes(ctx context.Context, repoID string) ([]byte, error) {
+	orgSlug, _, err := s.meta.LookupRepoSlug(ctx, repoID)
+	if err != nil {
+		if errors.Is(err, ErrNotFound) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("policystore: lookup repo %s: %w", repoID, err)
+	}
+	policyRepoID, err := s.meta.LookupRepoIDBySlug(ctx, orgSlug, AgentsPolicyRepoSlug)
+	if err != nil {
+		if errors.Is(err, ErrNotFound) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("policystore: lookup %s/%s: %w", orgSlug, AgentsPolicyRepoSlug, err)
+	}
+	data, err := s.blobs.ReadBlob(ctx, policyRepoID, "HEAD", "AGENTS.md")
+	if err != nil {
+		if errors.Is(err, hookpkg.ErrBlobNotFound) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("policystore: read org AGENTS.md: %w", err)
+	}
+	return data, nil
+}

--- a/plane/application/agentsmd/policystore/policystore_test.go
+++ b/plane/application/agentsmd/policystore/policystore_test.go
@@ -1,0 +1,146 @@
+package policystore
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	hookpkg "github.com/gitscale-platform/gitscale/plane/application/agentsmd/hook"
+)
+
+type fakeMeta struct {
+	repoToOrg     map[string]string
+	repoToSlug    map[string]string
+	slugToRepoID  map[string]string // "org/slug" -> repoID
+	lookupErr     error
+	bySlugErr     error
+}
+
+func (f *fakeMeta) LookupRepoSlug(_ context.Context, repoID string) (string, string, error) {
+	if f.lookupErr != nil {
+		return "", "", f.lookupErr
+	}
+	org, ok := f.repoToOrg[repoID]
+	if !ok {
+		return "", "", ErrNotFound
+	}
+	return org, f.repoToSlug[repoID], nil
+}
+func (f *fakeMeta) LookupRepoIDBySlug(_ context.Context, org, slug string) (string, error) {
+	if f.bySlugErr != nil {
+		return "", f.bySlugErr
+	}
+	id, ok := f.slugToRepoID[org+"/"+slug]
+	if !ok {
+		return "", ErrNotFound
+	}
+	return id, nil
+}
+
+type fakeBlobs struct {
+	blobs map[string][]byte
+	err   error
+}
+
+func (b *fakeBlobs) ReadBlob(_ context.Context, repoID, ref, path string) ([]byte, error) {
+	if b.err != nil {
+		return nil, b.err
+	}
+	if data, ok := b.blobs[repoID+"|"+ref+"|"+path]; ok {
+		return data, nil
+	}
+	return nil, hookpkg.ErrBlobNotFound
+}
+func (b *fakeBlobs) ListChangedPaths(_ context.Context, _, _, _ string) ([]string, error) {
+	return nil, nil
+}
+func (b *fakeBlobs) BlobSize(_ context.Context, _, _, _ string) (int64, error) { return 0, nil }
+func (b *fakeBlobs) IsFastForward(_ context.Context, _, _, _ string) (bool, error) {
+	return false, nil
+}
+
+func TestResolve_OrgUnknown(t *testing.T) {
+	s := New(&fakeMeta{}, &fakeBlobs{})
+	got, err := s.ResolveOrgPolicyBytes(context.Background(), "missing")
+	if err != nil || got != nil {
+		t.Fatalf("expected (nil,nil), got %v %v", got, err)
+	}
+}
+
+func TestResolve_OrgKnownButNoPolicyRepo(t *testing.T) {
+	meta := &fakeMeta{
+		repoToOrg:    map[string]string{"r1": "acme"},
+		repoToSlug:   map[string]string{"r1": "service"},
+		slugToRepoID: map[string]string{},
+	}
+	s := New(meta, &fakeBlobs{})
+	got, err := s.ResolveOrgPolicyBytes(context.Background(), "r1")
+	if err != nil || got != nil {
+		t.Fatalf("expected (nil,nil), got %v %v", got, err)
+	}
+}
+
+func TestResolve_PolicyRepoExistsButNoAgentsMd(t *testing.T) {
+	meta := &fakeMeta{
+		repoToOrg:    map[string]string{"r1": "acme"},
+		repoToSlug:   map[string]string{"r1": "service"},
+		slugToRepoID: map[string]string{"acme/" + AgentsPolicyRepoSlug: "policy-repo"},
+	}
+	s := New(meta, &fakeBlobs{blobs: map[string][]byte{}})
+	got, err := s.ResolveOrgPolicyBytes(context.Background(), "r1")
+	if err != nil || got != nil {
+		t.Fatalf("expected (nil,nil), got %v %v", got, err)
+	}
+}
+
+func TestResolve_BlobFound(t *testing.T) {
+	doc := []byte("---\nschema: gitscale/v1\n---\n## Never\n- delete_branch: main\n")
+	meta := &fakeMeta{
+		repoToOrg:    map[string]string{"r1": "acme"},
+		repoToSlug:   map[string]string{"r1": "service"},
+		slugToRepoID: map[string]string{"acme/" + AgentsPolicyRepoSlug: "policy-repo"},
+	}
+	blobs := &fakeBlobs{blobs: map[string][]byte{"policy-repo|HEAD|AGENTS.md": doc}}
+	s := New(meta, blobs)
+	got, err := s.ResolveOrgPolicyBytes(context.Background(), "r1")
+	if err != nil {
+		t.Fatalf("err=%v", err)
+	}
+	if string(got) != string(doc) {
+		t.Fatalf("blob mismatch: %q", got)
+	}
+}
+
+func TestResolve_MetaErrorPropagates(t *testing.T) {
+	s := New(&fakeMeta{lookupErr: errors.New("postgres down")}, &fakeBlobs{})
+	_, err := s.ResolveOrgPolicyBytes(context.Background(), "r1")
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+}
+
+func TestResolve_BlobInfraErrorPropagates(t *testing.T) {
+	meta := &fakeMeta{
+		repoToOrg:    map[string]string{"r1": "acme"},
+		repoToSlug:   map[string]string{"r1": "service"},
+		slugToRepoID: map[string]string{"acme/" + AgentsPolicyRepoSlug: "policy-repo"},
+	}
+	s := New(meta, &fakeBlobs{err: errors.New("gitaly down")})
+	_, err := s.ResolveOrgPolicyBytes(context.Background(), "r1")
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+}
+
+func TestNew_NilArgsPanic(t *testing.T) {
+	for _, tc := range []func(){
+		func() { New(nil, &fakeBlobs{}) },
+		func() { New(&fakeMeta{}, nil) },
+	} {
+		func() {
+			defer func() { _ = recover() }()
+			tc()
+			t.Fatalf("expected panic")
+		}()
+	}
+}

--- a/plane/git/gitaly/blob_reader.go
+++ b/plane/git/gitaly/blob_reader.go
@@ -1,0 +1,217 @@
+package gitaly
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/gitscale-platform/gitscale/plane/git/client"
+	"github.com/gitscale-platform/gitscale/plane/git/locator"
+	gitalypb "gitlab.com/gitlab-org/gitaly/v16/proto/go/gitalypb"
+)
+
+// ErrBlobNotFound is returned when a requested blob is absent. The
+// hook adapter's BlobReader contract treats wrapped instances of this
+// error as "no blob" rather than "infra error".
+var ErrBlobNotFound = errors.New("gitaly: blob not found")
+
+// BlobReader is a Gitaly-backed BlobReader. It is structurally
+// compatible with plane/application/agentsmd/hook.BlobReader; we do
+// not import that package here so the plane boundary stays one-way
+// (git → application is forbidden; application → git via the adapter is
+// fine).
+type BlobReader struct {
+	pool    *client.GitalyPool
+	locator locator.RepoLocator
+}
+
+// NewBlobReader constructs a Gitaly-backed BlobReader. Both arguments
+// are required.
+func NewBlobReader(pool *client.GitalyPool, loc locator.RepoLocator) *BlobReader {
+	if pool == nil {
+		panic("gitaly: nil pool")
+	}
+	if loc == nil {
+		panic("gitaly: nil locator")
+	}
+	return &BlobReader{pool: pool, locator: loc}
+}
+
+// resolve maps a repoID to (Gitaly target address, gitalypb.Repository).
+// Mirrors GitalyProxy.resolve; kept private to avoid public coupling.
+func (b *BlobReader) resolve(ctx context.Context, repoID string) (string, *gitalypb.Repository, error) {
+	addr, err := b.locator.Resolve(ctx, repoID)
+	if err != nil {
+		return "", nil, fmt.Errorf("gitaly: locator: %w", err)
+	}
+	repo := &gitalypb.Repository{
+		StorageName:  addr.ReplicaSetID,
+		RelativePath: repoID + ".git",
+	}
+	return addr.Addr, repo, nil
+}
+
+// ReadBlob streams TreeEntry for (revision, path) and concatenates the
+// chunks. Returns ErrBlobNotFound when Gitaly reports the entry is
+// missing or the streamed type is not a blob.
+func (b *BlobReader) ReadBlob(ctx context.Context, repoID, ref, path string) ([]byte, error) {
+	addr, repo, err := b.resolve(ctx, repoID)
+	if err != nil {
+		return nil, err
+	}
+	conn, err := b.pool.Conn(ctx, addr)
+	if err != nil {
+		return nil, fmt.Errorf("gitaly: dial: %w", err)
+	}
+	cl := gitalypb.NewCommitServiceClient(conn)
+	stream, err := cl.TreeEntry(ctx, &gitalypb.TreeEntryRequest{
+		Repository: repo,
+		Revision:   []byte(ref),
+		Path:       []byte(path),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("gitaly: tree_entry open: %w", err)
+	}
+	var (
+		buf  bytes.Buffer
+		seen bool
+	)
+	for {
+		resp, err := stream.Recv()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("gitaly: tree_entry recv: %w", err)
+		}
+		if !seen {
+			seen = true
+			if resp.GetType() != gitalypb.TreeEntryResponse_BLOB {
+				return nil, fmt.Errorf("%w: %s is not a blob (type=%s)", ErrBlobNotFound, path, resp.GetType().String())
+			}
+		}
+		buf.Write(resp.GetData())
+	}
+	if !seen {
+		return nil, fmt.Errorf("%w: %s at %s", ErrBlobNotFound, path, ref)
+	}
+	return buf.Bytes(), nil
+}
+
+// ListChangedPaths uses DiffService.FindChangedPaths to enumerate paths
+// that differ between two commits. For a creation (oldOID == zero), the
+// caller must pass the new tip; we approximate "all reachable paths" by
+// asking Gitaly for the tree-vs-empty diff (Gitaly handles this when
+// passed a single CommitRequest with the new commit, which diffs
+// against the parent — for a root commit this surfaces every path).
+func (b *BlobReader) ListChangedPaths(ctx context.Context, repoID, oldOID, newOID string) ([]string, error) {
+	addr, repo, err := b.resolve(ctx, repoID)
+	if err != nil {
+		return nil, err
+	}
+	conn, err := b.pool.Conn(ctx, addr)
+	if err != nil {
+		return nil, fmt.Errorf("gitaly: dial: %w", err)
+	}
+	cl := gitalypb.NewDiffServiceClient(conn)
+
+	req := &gitalypb.FindChangedPathsRequest{
+		Repository: repo,
+		Requests: []*gitalypb.FindChangedPathsRequest_Request{
+			{
+				Type: &gitalypb.FindChangedPathsRequest_Request_CommitRequest_{
+					CommitRequest: &gitalypb.FindChangedPathsRequest_Request_CommitRequest{
+						CommitRevision: newOID,
+						ParentCommitRevisions: func() []string {
+							if oldOID == "" || oldOID == "0000000000000000000000000000000000000000" {
+								return nil
+							}
+							return []string{oldOID}
+						}(),
+					},
+				},
+			},
+		},
+	}
+	stream, err := cl.FindChangedPaths(ctx, req)
+	if err != nil {
+		return nil, fmt.Errorf("gitaly: find_changed_paths open: %w", err)
+	}
+	var out []string
+	for {
+		resp, err := stream.Recv()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("gitaly: find_changed_paths recv: %w", err)
+		}
+		for _, p := range resp.GetPaths() {
+			out = append(out, string(p.GetPath()))
+		}
+	}
+	return out, nil
+}
+
+// BlobSize returns the byte size of the blob at (oid, path) by issuing
+// a TreeEntry RPC with Limit=1 and reading Size from the first
+// response message. We don't fetch the body.
+func (b *BlobReader) BlobSize(ctx context.Context, repoID, oid, path string) (int64, error) {
+	addr, repo, err := b.resolve(ctx, repoID)
+	if err != nil {
+		return 0, err
+	}
+	conn, err := b.pool.Conn(ctx, addr)
+	if err != nil {
+		return 0, fmt.Errorf("gitaly: dial: %w", err)
+	}
+	cl := gitalypb.NewCommitServiceClient(conn)
+	stream, err := cl.TreeEntry(ctx, &gitalypb.TreeEntryRequest{
+		Repository: repo,
+		Revision:   []byte(oid),
+		Path:       []byte(path),
+		Limit:      1,
+	})
+	if err != nil {
+		return 0, fmt.Errorf("gitaly: tree_entry open: %w", err)
+	}
+	resp, err := stream.Recv()
+	if err != nil {
+		if errors.Is(err, io.EOF) {
+			return 0, fmt.Errorf("%w: %s at %s", ErrBlobNotFound, path, oid)
+		}
+		return 0, fmt.Errorf("gitaly: tree_entry recv: %w", err)
+	}
+	if resp.GetType() != gitalypb.TreeEntryResponse_BLOB {
+		return 0, fmt.Errorf("%w: %s is not a blob", ErrBlobNotFound, path)
+	}
+	return resp.GetSize(), nil
+}
+
+// IsFastForward reports whether newOID is a (non-strict) descendant of
+// oldOID. Equal OIDs are considered fast-forward.
+func (b *BlobReader) IsFastForward(ctx context.Context, repoID, oldOID, newOID string) (bool, error) {
+	if oldOID == newOID {
+		return true, nil
+	}
+	addr, repo, err := b.resolve(ctx, repoID)
+	if err != nil {
+		return false, err
+	}
+	conn, err := b.pool.Conn(ctx, addr)
+	if err != nil {
+		return false, fmt.Errorf("gitaly: dial: %w", err)
+	}
+	cl := gitalypb.NewCommitServiceClient(conn)
+	resp, err := cl.CommitIsAncestor(ctx, &gitalypb.CommitIsAncestorRequest{
+		Repository: repo,
+		AncestorId: oldOID,
+		ChildId:    newOID,
+	})
+	if err != nil {
+		return false, fmt.Errorf("gitaly: commit_is_ancestor: %w", err)
+	}
+	return resp.GetValue(), nil
+}

--- a/plane/git/gitaly/blob_reader_test.go
+++ b/plane/git/gitaly/blob_reader_test.go
@@ -1,0 +1,24 @@
+package gitaly_test
+
+// We assert that gitaly.BlobReader satisfies the agentsmd hook
+// adapter's BlobReader interface — structurally, via assignment to a
+// variable of the interface type. This keeps the plane boundary
+// one-way (the hook package is in plane/application; importing it
+// here is permitted only for tests, which are compiled in a separate
+// package).
+//
+// Live RPC tests against a Gitaly testcontainer are deferred until
+// the cmd/git-rpc binary lands; the integration smoke for the AGENTS.md
+// chain lives in plane/application/agentsmd/integration_test.go.
+
+import (
+	"testing"
+
+	hookpkg "github.com/gitscale-platform/gitscale/plane/application/agentsmd/hook"
+	"github.com/gitscale-platform/gitscale/plane/git/gitaly"
+)
+
+func TestBlobReader_StructurallyImplementsAdapterInterface(t *testing.T) {
+	// Compile-time assertion: gitaly.BlobReader satisfies hookpkg.BlobReader.
+	var _ hookpkg.BlobReader = (*gitaly.BlobReader)(nil)
+}

--- a/plane/git/gitaly/doc.go
+++ b/plane/git/gitaly/doc.go
@@ -1,0 +1,11 @@
+// Package gitaly provides Gitaly-backed implementations of interfaces
+// consumed by the application plane. It does NOT import any
+// plane/application/... package; the production wiring layer
+// instantiates GitalyBlobReader and passes it to the AGENTS.md hook
+// adapter, where it is bound by structural typing to the adapter's
+// BlobReader interface (see ADR-019, plane boundary one-way rule).
+//
+// This package depends only on plane/git/client (gRPC connection pool),
+// plane/git/locator (repo→file-server resolution), and the Gitaly proto
+// stubs.
+package gitaly


### PR DESCRIPTION
## Summary

- Adds `plane/application/agentsmd` (parser + evaluator + merge) — pure, no plane/git imports.
- Adds `plane/application/agentsmd/hook` adapter that maps the plane/git `HookHandler` contract onto the evaluator. Rejects pushes with a structured `AGENTS.md Never violation: <name> on ref <ref> (<reason>)` message, multiple violations joined by `;`.
- Adds `plane/application/agentsmd/policystore` that resolves org-wide policy via the conventional `<org>/.gitscale-agents` repo, consumed via small `RepoMetadata` + `BlobReader` interfaces (production wiring binds the future repositories service).
- Adds production `plane/git/gitaly.BlobReader` (TreeEntry / FindChangedPaths / CommitIsAncestor). Structurally satisfies the adapter's BlobReader without back-importing the application plane — keeps the plane boundary one-way.

## ADR-impact

Conforming. ADR-008 (outbox) neutral — no new outbox events; AGENTS.md violations are synchronous push rejections, the existing metering layer (#107/#109) records them as hook-rejected pushes. ADR-012 (hook layer) honoured. ADR-019 (plane boundary) honoured: only the adapter package crosses planes, and only for the `HookHandler` interface + `RepoRef`/`RefUpdate` value types.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `golangci-lint run ./...` (0 issues)
- [x] `go test -race ./plane/application/agentsmd/... ./plane/git/gitaly/...`
- [x] `make lint-events` (no new events)
- [x] `make lint-determinism`
- [x] Plane-boundary audit: parser package free of plane/git imports; adapter imports limited to `gittypes` + `hook` interface; production BlobReader contained in plane/git.
- [ ] Live testcontainers Gitaly + Postgres push integration deferred until the `cmd/git-rpc` binary lands (#107 ships the proxy package only). Coverage is provided by `plane/application/agentsmd/integration_test.go` (in-memory blobs/policystore, full chain) plus exhaustive unit suites for parser, merge, evaluator, hook adapter, policystore. Once the binary lands, a testcontainers-backed twin of those scenarios should follow.
- [ ] Wiring of `agentsmdhook.New(...)` into the production proxy construction site is gated on the binary entrypoint, not yet present in the repo. The handler is import-ready and structurally compatible with `plane/git/hook.HookHandler`.

## Cross-links

- Spec: `docs/superpowers/specs/2026-05-09-issue-114-agents-md-never-enforcement-design.md`
- Plan: `docs/superpowers/plans/2026-05-09-issue-114-agents-md-never-enforcement-plan.md`
- Depends on: #107 (plane/git foundation — merged in `fe23ac6`)

Closes #114

<details>
<summary>Self-review battery</summary>

Inline (single-agent run, supervisor mode): pre-commit skills walked — gitscale-adr-guard (no ADR change required; conforming), gitscale-go-conventions (idiomatic Go; context.Context first arg on every blocking call; no panics outside New() construction sites which are programmer-error guards; errors wrapped with `%w`), gitscale-plane-boundary (parser plane-pure; adapter is the sole cross-plane import; production BlobReader satisfies the interface structurally to avoid a git→application back-import), gitscale-agent-quota-check (no new metered surfaces; AGENTS.md enforcement reuses the rejected-push counter from the metering layer per spec).

Self-review focuses: code-reviewer (closed-enum predicate switch, deterministic violation message format, lazy FileResolver only invoked when predicate needs it), silent-failure-hunter (parser fails closed on schema/front-matter errors; infra errors propagate; malformed AGENTS.md does not silently bypass enforcement of a healthy org policy because each policy is parsed independently and merged), pr-test-analyzer (every diagnostic code emitted in a test; every predicate kind exercised positive + negative; org-wins, infra-error, and "malformed does not block" paths covered).
</details>

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>