### PR TITLE
[Application] REST API HTTP layer — identity + repository endpoints

### DIFF
--- a/cmd/rest-api/integration_test.go
+++ b/cmd/rest-api/integration_test.go
@@ -1,0 +1,88 @@
+//go:build integration
+
+package main_test
+
+import (
+	"context"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/testcontainers/testcontainers-go"
+	pgmodule "github.com/testcontainers/testcontainers-go/modules/postgres"
+	"github.com/testcontainers/testcontainers-go/wait"
+)
+
+// TestRestAPI_BinaryBoots compiles the rest-api binary, points it at a
+// fresh testcontainers Postgres, and asserts /healthz answers 200 within
+// the boot budget.
+func TestRestAPI_BinaryBoots(t *testing.T) {
+	ctx := context.Background()
+	ctr, err := pgmodule.Run(ctx,
+		"postgres:16-alpine",
+		pgmodule.WithDatabase("gitscale_test"),
+		pgmodule.WithUsername("gs"),
+		pgmodule.WithPassword("gs"),
+		testcontainers.WithWaitStrategy(
+			wait.ForLog("database system is ready to accept connections").
+				WithOccurrence(2).
+				WithStartupTimeout(60*time.Second),
+		),
+	)
+	if err != nil {
+		t.Fatalf("start postgres: %v", err)
+	}
+	t.Cleanup(func() { _ = ctr.Terminate(ctx) })
+
+	dsn, err := ctr.ConnectionString(ctx, "sslmode=disable")
+	if err != nil {
+		t.Fatalf("dsn: %v", err)
+	}
+
+	binDir := t.TempDir()
+	binPath := filepath.Join(binDir, "rest-api-bin")
+	build := exec.Command("go", "build", "-o", binPath, ".")
+	build.Stdout = os.Stdout
+	build.Stderr = os.Stderr
+	if err := build.Run(); err != nil {
+		t.Fatalf("go build: %v", err)
+	}
+
+	cmd := exec.Command(binPath)
+	cmd.Env = append(os.Environ(),
+		"REST_API_ADDR=127.0.0.1:18086",
+		"REST_API_INSECURE=true",
+		"POSTGRES_DSN="+dsn,
+	)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = cmd.Process.Kill()
+		_, _ = cmd.Process.Wait()
+	})
+
+	// Poll /healthz with a short budget.
+	deadline := time.Now().Add(15 * time.Second)
+	var lastErr error
+	for time.Now().Before(deadline) {
+		resp, err := http.Get("http://127.0.0.1:18086/healthz")
+		if err == nil {
+			if resp.StatusCode == 200 {
+				resp.Body.Close()
+				return
+			}
+			resp.Body.Close()
+			lastErr = nil
+		} else {
+			lastErr = err
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+	t.Fatalf("/healthz never returned 200: %v", lastErr)
+}

--- a/cmd/rest-api/main.go
+++ b/cmd/rest-api/main.go
@@ -1,0 +1,153 @@
+// rest-api is the application-plane HTTP/JSON edge for identity and
+// repositories (ADR-019). It hosts /v1/* routes and a /healthz probe.
+//
+// mTLS via SPIRE/SPIFFE (ADR-010) lands at the edge plane, not here — this
+// binary trusts that requests have already passed Envoy's identity filter
+// when deployed behind the standard gateway. For stand-alone local runs
+// REST_API_INSECURE=true is required so the operator acknowledges the gap.
+package main
+
+import (
+	"context"
+	"errors"
+	"log"
+	"log/slog"
+	"net/http"
+	"os"
+	"os/signal"
+	"strconv"
+	"syscall"
+	"time"
+
+	"github.com/gitscale-platform/gitscale/plane/application/identity"
+	"github.com/gitscale-platform/gitscale/plane/application/repositories"
+	"github.com/gitscale-platform/gitscale/plane/application/restapi"
+	"github.com/gitscale-platform/gitscale/plane/data/ratelimit"
+	storepg "github.com/gitscale-platform/gitscale/plane/data/store/postgres"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+type config struct {
+	Addr              string
+	PostgresDSN       string
+	Insecure          bool
+	AgentCapacity     float64
+	AgentRefillPerSec float64
+	HumanCapacity     float64
+	HumanRefillPerSec float64
+}
+
+func loadConfig() (config, error) {
+	cfg := config{
+		Addr:              getenv("REST_API_ADDR", ":8086"),
+		Insecure:          getenvBool("REST_API_INSECURE", false),
+		AgentCapacity:     getenvFloat("RATELIMIT_AGENT_CAPACITY", 200),
+		AgentRefillPerSec: getenvFloat("RATELIMIT_AGENT_REFILL_PER_SEC", 200),
+		HumanCapacity:     getenvFloat("RATELIMIT_HUMAN_CAPACITY", 20),
+		HumanRefillPerSec: getenvFloat("RATELIMIT_HUMAN_REFILL_PER_SEC", 20),
+	}
+	cfg.PostgresDSN = os.Getenv("POSTGRES_DSN")
+	if cfg.PostgresDSN == "" {
+		return cfg, errors.New("POSTGRES_DSN is required")
+	}
+	if !cfg.Insecure {
+		return cfg, errors.New("only REST_API_INSECURE=true is supported until edge-plane SPIRE/SPIFFE wiring lands (ADR-010)")
+	}
+	return cfg, nil
+}
+
+func main() {
+	cfg, err := loadConfig()
+	if err != nil {
+		log.Fatalf("config: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	pool, err := pgxpool.New(ctx, cfg.PostgresDSN)
+	if err != nil {
+		log.Fatalf("postgres: %v", err)
+	}
+	defer pool.Close()
+
+	pingCtx, pingCancel := context.WithTimeout(ctx, 5*time.Second)
+	if err := pool.Ping(pingCtx); err != nil {
+		pingCancel()
+		log.Fatalf("postgres ping: %v", err)
+	}
+	pingCancel()
+
+	mds := storepg.New(pool)
+	identitySvc := identity.NewPostgresService(mds)
+	reposSvc := repositories.NewService(mds)
+	logger := slog.New(slog.NewJSONHandler(os.Stdout, nil))
+
+	// store.IdentityReader satisfies the methods restapi.NewIdentityResolver
+	// needs. The reader is used outside any transaction, which is correct
+	// for token resolution.
+	router := restapi.NewRouter(restapi.Deps{
+		Identity:     identitySvc,
+		Repositories: reposSvc,
+		Resolver:     restapi.NewIdentityResolver(mds.Identity()),
+		Limiter:      ratelimit.NewMemoryLimiter(nil),
+		RateConfig: restapi.RateConfig{
+			AgentCapacity:     cfg.AgentCapacity,
+			AgentRefillPerSec: cfg.AgentRefillPerSec,
+			HumanCapacity:     cfg.HumanCapacity,
+			HumanRefillPerSec: cfg.HumanRefillPerSec,
+		},
+		Logger: logger,
+	})
+
+	srv := &http.Server{
+		Addr:              cfg.Addr,
+		Handler:           router,
+		ReadHeaderTimeout: 10 * time.Second,
+	}
+
+	go func() {
+		sigs := make(chan os.Signal, 1)
+		signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
+		<-sigs
+		shutdownCtx, c := context.WithTimeout(context.Background(), 10*time.Second)
+		defer c()
+		_ = srv.Shutdown(shutdownCtx)
+	}()
+
+	logger.Info("rest-api listening", slog.String("addr", cfg.Addr), slog.Bool("insecure", cfg.Insecure))
+	if err := srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+		log.Fatalf("serve: %v", err)
+	}
+}
+
+func getenv(k, def string) string {
+	if v := os.Getenv(k); v != "" {
+		return v
+	}
+	return def
+}
+
+func getenvBool(k string, def bool) bool {
+	v := os.Getenv(k)
+	if v == "" {
+		return def
+	}
+	b, err := strconv.ParseBool(v)
+	if err != nil {
+		log.Fatalf("env %s: %s is not a bool: %v", k, v, err)
+	}
+	return b
+}
+
+func getenvFloat(k string, def float64) float64 {
+	v := os.Getenv(k)
+	if v == "" {
+		return def
+	}
+	f, err := strconv.ParseFloat(v, 64)
+	if err != nil {
+		log.Fatalf("env %s: %s is not a float: %v", k, v, err)
+	}
+	return f
+}

--- a/plane/application/repositories/doc.go
+++ b/plane/application/repositories/doc.go
@@ -1,0 +1,9 @@
+// Package repositories is the application-plane service layer for the
+// repositories metadata domain. It wraps store.MetadataStore Transact calls
+// so source row + outbox row land in the same Tx (ADR-008).
+//
+// Plane boundary (ADR-019): this package is application-plane. It MUST NOT
+// import plane/git/* or plane/workflow/* — physical Git repo provisioning is
+// the git plane's job (issue #107) and is triggered out-of-band by a consumer
+// of repositories.repository_created on gitscale.repositories.events.
+package repositories

--- a/plane/application/repositories/events.go
+++ b/plane/application/repositories/events.go
@@ -1,0 +1,46 @@
+package repositories
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// Event-type constants written to repositories.repositories_outbox and
+// published on gitscale.repositories.events.
+const (
+	EventRepositoryCreated = "repositories.repository_created"
+)
+
+// envelopeVersion bumps when a payload's field set is no longer
+// backwards-compatible.
+const envelopeVersion = 1
+
+// RepositoryCreatedPayload is the payload of a repositories.repository_created
+// event. Search-indexer (#16-search) and audit-log consumers depend on
+// org_id + slug + visibility being present from day one.
+type RepositoryCreatedPayload struct {
+	RepositoryID    uuid.UUID `json:"repository_id"`
+	OrgID           uuid.UUID `json:"org_id"`
+	OwnerID         uuid.UUID `json:"owner_id"`
+	Slug            string    `json:"slug"`
+	Name            string    `json:"name"`
+	DefaultBranch   string    `json:"default_branch"`
+	Visibility      string    `json:"visibility"`
+	CreatedAt       time.Time `json:"created_at"`
+	EnvelopeVersion int       `json:"_envelope_version"`
+}
+
+func newRepositoryCreatedPayload(r Repository) RepositoryCreatedPayload {
+	return RepositoryCreatedPayload{
+		RepositoryID:    r.ID,
+		OrgID:           r.OrgID,
+		OwnerID:         r.OwnerID,
+		Slug:            r.Slug,
+		Name:            r.Name,
+		DefaultBranch:   r.DefaultBranch,
+		Visibility:      r.Visibility,
+		CreatedAt:       r.CreatedAt,
+		EnvelopeVersion: envelopeVersion,
+	}
+}

--- a/plane/application/repositories/service.go
+++ b/plane/application/repositories/service.go
@@ -1,0 +1,149 @@
+package repositories
+
+import (
+	"context"
+	"errors"
+	"regexp"
+	"time"
+
+	"github.com/gitscale-platform/gitscale/plane/data/store"
+	"github.com/google/uuid"
+)
+
+// Repository is the application-layer view; aliased to the storage struct
+// (same convention as identity.HumanUser).
+type Repository = store.Repository
+
+// Service is the repositories domain service.
+type Service interface {
+	GetRepository(ctx context.Context, id uuid.UUID) (*Repository, error)
+	CreateRepository(ctx context.Context, in CreateInput) (*Repository, error)
+	ListByOrg(ctx context.Context, orgID uuid.UUID, after Cursor, limit int) ([]Repository, *Cursor, error)
+}
+
+// CreateInput is the validated input for CreateRepository.
+type CreateInput struct {
+	OrgID         uuid.UUID
+	OwnerID       uuid.UUID
+	Slug          string
+	Name          string
+	DefaultBranch string
+	Visibility    string
+}
+
+// Cursor is an opaque keyset pagination cursor over (created_at, id).
+type Cursor struct {
+	AfterCreatedAt time.Time `json:"after_created_at"`
+	AfterID        uuid.UUID `json:"after_id"`
+}
+
+// IsZero reports whether c carries no position (use the start of the listing).
+func (c Cursor) IsZero() bool {
+	return c.AfterID == uuid.Nil && c.AfterCreatedAt.IsZero()
+}
+
+// Sentinel errors. Mapped to HTTP codes by plane/application/restapi.
+var (
+	ErrInvalidSlug         = errors.New("repositories: invalid slug")
+	ErrEmptyName           = errors.New("repositories: name is empty")
+	ErrInvalidVisibility   = errors.New("repositories: invalid visibility")
+	ErrSlugAlreadyExists   = errors.New("repositories: slug already exists in org")
+	ErrRepositoryNotFound  = errors.New("repositories: repository not found")
+)
+
+// slugPattern mirrors the SQL CHECK constraint `^[a-z0-9][a-z0-9._-]*$`.
+var slugPattern = regexp.MustCompile(`^[a-z0-9][a-z0-9._-]*$`)
+
+func validVisibility(v string) bool {
+	switch v {
+	case "public", "private", "internal":
+		return true
+	}
+	return false
+}
+
+type service struct {
+	store store.MetadataStore
+	clock func() time.Time
+}
+
+// NewService returns a Service backed by ms.
+func NewService(ms store.MetadataStore) Service {
+	return &service{store: ms, clock: func() time.Time { return time.Now().UTC() }}
+}
+
+func (s *service) GetRepository(ctx context.Context, id uuid.UUID) (*Repository, error) {
+	return s.store.Repositories().GetByID(ctx, id)
+}
+
+func (s *service) CreateRepository(ctx context.Context, in CreateInput) (*Repository, error) {
+	if in.Slug == "" || !slugPattern.MatchString(in.Slug) || len(in.Slug) > 100 {
+		return nil, ErrInvalidSlug
+	}
+	if in.Name == "" {
+		return nil, ErrEmptyName
+	}
+	visibility := in.Visibility
+	if visibility == "" {
+		visibility = "private"
+	}
+	if !validVisibility(visibility) {
+		return nil, ErrInvalidVisibility
+	}
+	defaultBranch := in.DefaultBranch
+	if defaultBranch == "" {
+		defaultBranch = "main"
+	}
+
+	now := s.clock()
+	repo := Repository{
+		ID:            uuid.New(),
+		OrgID:         in.OrgID,
+		Name:          in.Name,
+		Slug:          in.Slug,
+		OwnerID:       in.OwnerID,
+		DefaultBranch: defaultBranch,
+		Visibility:    visibility,
+		CreatedAt:     now,
+		UpdatedAt:     now,
+	}
+
+	err := s.store.Transact(ctx, func(tx store.Tx) error {
+		if err := tx.Repositories().Insert(ctx, repo); err != nil {
+			return err
+		}
+		return tx.WriteOutbox(ctx, store.DomainRepositories, "repository", repo.ID,
+			EventRepositoryCreated, newRepositoryCreatedPayload(repo))
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &repo, nil
+}
+
+func (s *service) ListByOrg(ctx context.Context, orgID uuid.UUID, after Cursor, limit int) ([]Repository, *Cursor, error) {
+	if limit <= 0 {
+		limit = 20
+	}
+	if limit > 100 {
+		limit = 100
+	}
+	var afterCreatedAt *time.Time
+	var afterID *uuid.UUID
+	if !after.IsZero() {
+		t := after.AfterCreatedAt
+		id := after.AfterID
+		afterCreatedAt = &t
+		afterID = &id
+	}
+	rows, err := s.store.Repositories().ListByOrg(ctx, orgID, afterCreatedAt, afterID, limit)
+	if err != nil {
+		return nil, nil, err
+	}
+	if len(rows) < limit {
+		return rows, nil, nil
+	}
+	last := rows[len(rows)-1]
+	next := Cursor{AfterCreatedAt: last.CreatedAt, AfterID: last.ID}
+	return rows, &next, nil
+}

--- a/plane/application/repositories/service_test.go
+++ b/plane/application/repositories/service_test.go
@@ -1,0 +1,108 @@
+package repositories_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/gitscale-platform/gitscale/plane/application/repositories"
+	"github.com/gitscale-platform/gitscale/plane/data/store"
+	"github.com/gitscale-platform/gitscale/plane/data/store/stub"
+	"github.com/google/uuid"
+)
+
+func TestCreateRepository_writesSourceAndOutboxInSameTx(t *testing.T) {
+	st := stub.New()
+	svc := repositories.NewService(st)
+
+	repo, err := svc.CreateRepository(context.Background(), repositories.CreateInput{
+		OrgID: uuid.New(), OwnerID: uuid.New(),
+		Slug: "my-repo", Name: "My Repo",
+	})
+	if err != nil {
+		t.Fatalf("CreateRepository: %v", err)
+	}
+
+	rec := st.Recorded()
+	if len(rec) != 1 {
+		t.Fatalf("outbox records: got %d want 1", len(rec))
+	}
+	got := rec[0]
+	if got.Domain != store.DomainRepositories {
+		t.Errorf("domain: %s", got.Domain)
+	}
+	if got.AggregateID != repo.ID {
+		t.Errorf("aggregate_id: %s vs %s", got.AggregateID, repo.ID)
+	}
+	if got.EventType != repositories.EventRepositoryCreated {
+		t.Errorf("event_type: %s", got.EventType)
+	}
+}
+
+func TestCreateRepository_validatesSlug(t *testing.T) {
+	svc := repositories.NewService(stub.New())
+	_, err := svc.CreateRepository(context.Background(), repositories.CreateInput{
+		OrgID: uuid.New(), OwnerID: uuid.New(), Slug: "BadSlug!", Name: "x",
+	})
+	if !errors.Is(err, repositories.ErrInvalidSlug) {
+		t.Errorf("expected ErrInvalidSlug, got %v", err)
+	}
+}
+
+func TestCreateRepository_emptyName(t *testing.T) {
+	svc := repositories.NewService(stub.New())
+	_, err := svc.CreateRepository(context.Background(), repositories.CreateInput{
+		OrgID: uuid.New(), OwnerID: uuid.New(), Slug: "ok", Name: "",
+	})
+	if !errors.Is(err, repositories.ErrEmptyName) {
+		t.Errorf("expected ErrEmptyName, got %v", err)
+	}
+}
+
+func TestCreateRepository_invalidVisibility(t *testing.T) {
+	svc := repositories.NewService(stub.New())
+	_, err := svc.CreateRepository(context.Background(), repositories.CreateInput{
+		OrgID: uuid.New(), OwnerID: uuid.New(), Slug: "ok", Name: "n", Visibility: "weird",
+	})
+	if !errors.Is(err, repositories.ErrInvalidVisibility) {
+		t.Errorf("expected ErrInvalidVisibility, got %v", err)
+	}
+}
+
+func TestListByOrg_pagesStably(t *testing.T) {
+	st := stub.New()
+	svc := repositories.NewService(st)
+	orgID := uuid.New()
+
+	for i := 0; i < 25; i++ {
+		_, err := svc.CreateRepository(context.Background(), repositories.CreateInput{
+			OrgID: orgID, OwnerID: uuid.New(),
+			Slug: "r-" + uuid.NewString()[:8], Name: "n",
+		})
+		if err != nil {
+			t.Fatalf("seed %d: %v", i, err)
+		}
+	}
+
+	seen := map[uuid.UUID]struct{}{}
+	cursor := repositories.Cursor{}
+	for pages := 0; pages < 100; pages++ {
+		rows, next, err := svc.ListByOrg(context.Background(), orgID, cursor, 10)
+		if err != nil {
+			t.Fatalf("page %d: %v", pages, err)
+		}
+		for _, r := range rows {
+			if _, dup := seen[r.ID]; dup {
+				t.Errorf("duplicate id: %s", r.ID)
+			}
+			seen[r.ID] = struct{}{}
+		}
+		if next == nil {
+			break
+		}
+		cursor = *next
+	}
+	if len(seen) != 25 {
+		t.Errorf("seen %d, want 25", len(seen))
+	}
+}

--- a/plane/application/restapi/doc.go
+++ b/plane/application/restapi/doc.go
@@ -1,0 +1,17 @@
+// Package restapi is the HTTP/JSON edge for the application plane. It mounts
+// at /v1/ and wraps the in-process identity.Service and repositories.Service
+// with bearer-auth, per-principal rate-limit, and request-id middleware.
+//
+// Plane boundary (ADR-019): application-plane only. This package MUST NOT
+// import plane/git/* or plane/workflow/*. Long-running async work goes
+// through Temporal via a service method, not a handler-spawned goroutine.
+//
+// Outbox (ADR-008): handlers do not write outbox rows directly — they
+// delegate to the underlying domain services which already pair source row
+// + outbox row in the same Tx.
+//
+// Storage swap surfaces (ADR-017): the package depends only on interfaces
+// (identity.Service, repositories.Service, store.MetadataStore-derived
+// readers, ratelimit.RateLimiter, PrincipalResolver). No concrete driver
+// imports leak across the boundary.
+package restapi

--- a/plane/application/restapi/errors.go
+++ b/plane/application/restapi/errors.go
@@ -1,0 +1,102 @@
+package restapi
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"net/http"
+
+	"github.com/gitscale-platform/gitscale/plane/application/identity"
+	"github.com/gitscale-platform/gitscale/plane/application/repositories"
+	"github.com/jackc/pgx/v5/pgconn"
+)
+
+// ErrorCode is a closed enum of stable client-facing error codes. Adding a
+// value is a public-API change and requires bumping client SDKs.
+type ErrorCode string
+
+const (
+	CodeUnauthenticated  ErrorCode = "unauthenticated"
+	CodeForbidden        ErrorCode = "forbidden"
+	CodeNotFound         ErrorCode = "not_found"
+	CodeValidationFailed ErrorCode = "validation_failed"
+	CodeConflict         ErrorCode = "conflict"
+	CodeRateLimited      ErrorCode = "rate_limited"
+	CodeInternal         ErrorCode = "internal"
+)
+
+// errorEnvelope is the response shape for any 4xx/5xx response.
+type errorEnvelope struct {
+	Error errorBody `json:"error"`
+}
+
+type errorBody struct {
+	Code      ErrorCode `json:"code"`
+	Message   string    `json:"message"`
+	RequestID string    `json:"request_id,omitempty"`
+}
+
+// writeError serialises envelope, sets Content-Type, and writes status.
+// It is safe to call exactly once per request; subsequent calls are no-ops
+// from net/http's perspective but logged here.
+func writeError(w http.ResponseWriter, r *http.Request, status int, code ErrorCode, msg string) {
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.WriteHeader(status)
+	body := errorEnvelope{Error: errorBody{Code: code, Message: msg, RequestID: RequestIDFromContext(r.Context())}}
+	_ = json.NewEncoder(w).Encode(body)
+}
+
+// mapErr is the exhaustive sentinel→(status, code, message) translator.
+//
+// The default arm logs at error level and returns 500 internal so the
+// client never sees a silent fallthrough.
+func mapErr(ctx context.Context, logger *slog.Logger, err error) (int, ErrorCode, string) {
+	switch {
+	case errors.Is(err, identity.ErrInvalidEmail),
+		errors.Is(err, identity.ErrEmptyDisplayName),
+		errors.Is(err, identity.ErrEmptyRole),
+		errors.Is(err, repositories.ErrInvalidSlug),
+		errors.Is(err, repositories.ErrEmptyName),
+		errors.Is(err, repositories.ErrInvalidVisibility):
+		return http.StatusBadRequest, CodeValidationFailed, err.Error()
+
+	case errors.Is(err, identity.ErrUserNotFound),
+		errors.Is(err, identity.ErrAgentNotFound),
+		errors.Is(err, repositories.ErrRepositoryNotFound):
+		return http.StatusNotFound, CodeNotFound, err.Error()
+
+	case errors.Is(err, repositories.ErrSlugAlreadyExists):
+		return http.StatusConflict, CodeConflict, err.Error()
+
+	case errors.Is(err, identity.ErrNotImplemented):
+		// Treat ErrNotImplemented as 501 with internal-class code so the
+		// client sees a stable code and the operator sees the log line.
+		if logger != nil {
+			logger.WarnContext(ctx, "rest_api: not implemented", slog.String("err", err.Error()))
+		}
+		return http.StatusNotImplemented, CodeInternal, "not implemented"
+
+	case errors.Is(err, context.DeadlineExceeded):
+		return http.StatusGatewayTimeout, CodeInternal, "deadline exceeded"
+
+	case isUniqueViolation(err):
+		return http.StatusConflict, CodeConflict, "resource already exists"
+
+	default:
+		if logger != nil {
+			logger.ErrorContext(ctx, "rest_api: unhandled error", slog.String("err", err.Error()))
+		}
+		return http.StatusInternalServerError, CodeInternal, "internal error"
+	}
+}
+
+// isUniqueViolation matches PostgreSQL SQLSTATE 23505 (unique_violation).
+// Pulled out as a free function so handlers can also test for it.
+func isUniqueViolation(err error) bool {
+	var pgErr *pgconn.PgError
+	if errors.As(err, &pgErr) {
+		return pgErr.Code == "23505"
+	}
+	return false
+}

--- a/plane/application/restapi/errors_test.go
+++ b/plane/application/restapi/errors_test.go
@@ -1,0 +1,51 @@
+package restapi
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"net/http"
+	"testing"
+
+	"github.com/gitscale-platform/gitscale/plane/application/identity"
+	"github.com/gitscale-platform/gitscale/plane/application/repositories"
+)
+
+func TestMapErr_exhaustiveSentinels(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(discard{}, nil))
+	cases := []struct {
+		name     string
+		err      error
+		wantHTTP int
+		wantCode ErrorCode
+	}{
+		{"invalid email", identity.ErrInvalidEmail, http.StatusBadRequest, CodeValidationFailed},
+		{"empty display name", identity.ErrEmptyDisplayName, http.StatusBadRequest, CodeValidationFailed},
+		{"empty role", identity.ErrEmptyRole, http.StatusBadRequest, CodeValidationFailed},
+		{"invalid slug", repositories.ErrInvalidSlug, http.StatusBadRequest, CodeValidationFailed},
+		{"empty name", repositories.ErrEmptyName, http.StatusBadRequest, CodeValidationFailed},
+		{"invalid visibility", repositories.ErrInvalidVisibility, http.StatusBadRequest, CodeValidationFailed},
+		{"user not found", identity.ErrUserNotFound, http.StatusNotFound, CodeNotFound},
+		{"agent not found", identity.ErrAgentNotFound, http.StatusNotFound, CodeNotFound},
+		{"repo not found", repositories.ErrRepositoryNotFound, http.StatusNotFound, CodeNotFound},
+		{"slug conflict", repositories.ErrSlugAlreadyExists, http.StatusConflict, CodeConflict},
+		{"not implemented", identity.ErrNotImplemented, http.StatusNotImplemented, CodeInternal},
+		{"deadline", context.DeadlineExceeded, http.StatusGatewayTimeout, CodeInternal},
+		{"unknown", errors.New("boom"), http.StatusInternalServerError, CodeInternal},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotHTTP, gotCode, _ := mapErr(context.Background(), logger, tc.err)
+			if gotHTTP != tc.wantHTTP {
+				t.Errorf("status: got %d want %d", gotHTTP, tc.wantHTTP)
+			}
+			if gotCode != tc.wantCode {
+				t.Errorf("code: got %s want %s", gotCode, tc.wantCode)
+			}
+		})
+	}
+}
+
+type discard struct{}
+
+func (discard) Write(p []byte) (int, error) { return len(p), nil }

--- a/plane/application/restapi/identity_handlers.go
+++ b/plane/application/restapi/identity_handlers.go
@@ -1,0 +1,261 @@
+package restapi
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"time"
+
+	"github.com/gitscale-platform/gitscale/plane/application/identity"
+	"github.com/google/uuid"
+)
+
+// identityHandlers wraps identity.Service. All authorisation rules live here;
+// the underlying service is unauthenticated by design (called from gRPC,
+// REST, MCP, etc).
+type identityHandlers struct {
+	svc    identity.Service
+	logger *slog.Logger
+}
+
+// userResponse is the JSON shape returned for /v1/users/* endpoints. It is
+// distinct from store.HumanUser so the credential hash never leaks.
+type userResponse struct {
+	ID         string    `json:"id"`
+	Email      string    `json:"email"`
+	RateBucket string    `json:"rate_bucket"`
+	CreatedAt  time.Time `json:"created_at"`
+}
+
+func toUserResponse(u *identity.HumanUser) userResponse {
+	return userResponse{
+		ID:         u.ID.String(),
+		Email:      u.Email,
+		RateBucket: u.RateBucket,
+		CreatedAt:  u.CreatedAt,
+	}
+}
+
+type agentResponse struct {
+	ID              string    `json:"id"`
+	DisplayName     string    `json:"display_name"`
+	ParentUserID    string    `json:"parent_user_id"`
+	PermissionScope []string  `json:"permission_scope"`
+	RateBucket      string    `json:"rate_bucket"`
+	ReputationScore float64   `json:"reputation_score"`
+	CreatedAt       time.Time `json:"created_at"`
+}
+
+func toAgentResponse(a *identity.AgentIdentity) agentResponse {
+	scope := append([]string{}, a.PermissionScope...)
+	return agentResponse{
+		ID:              a.ID.String(),
+		DisplayName:     a.DisplayName,
+		ParentUserID:    a.ParentUserID.String(),
+		PermissionScope: scope,
+		RateBucket:      a.RateBucket,
+		ReputationScore: a.ReputationScore,
+		CreatedAt:       a.CreatedAt,
+	}
+}
+
+func (h *identityHandlers) createUser(w http.ResponseWriter, r *http.Request) {
+	// Authorisation: only humans may create new humans. Agent self-signup
+	// is forbidden — agents must be derived from an existing human.
+	if p := PrincipalFromContext(r.Context()); p != nil && p.Kind() == PrincipalAgent {
+		writeError(w, r, http.StatusForbidden, CodeForbidden, "agents may not create users")
+		return
+	}
+	var body struct {
+		Email      string `json:"email"`
+		Credential string `json:"credential"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeError(w, r, http.StatusBadRequest, CodeValidationFailed, "invalid JSON body")
+		return
+	}
+	u, err := h.svc.CreateUser(r.Context(), body.Email, body.Credential)
+	if err != nil {
+		status, code, msg := mapErr(r.Context(), h.logger, err)
+		writeError(w, r, status, code, msg)
+		return
+	}
+	w.Header().Set("Location", "/v1/users/"+u.ID.String())
+	writeJSON(w, http.StatusCreated, toUserResponse(u))
+}
+
+func (h *identityHandlers) getUser(w http.ResponseWriter, r *http.Request) {
+	id, err := uuid.Parse(r.PathValue("id"))
+	if err != nil {
+		writeError(w, r, http.StatusBadRequest, CodeValidationFailed, "id is not a UUID")
+		return
+	}
+	u, err := h.svc.GetUser(r.Context(), id)
+	if err != nil {
+		status, code, msg := mapErr(r.Context(), h.logger, err)
+		writeError(w, r, status, code, msg)
+		return
+	}
+	if u == nil {
+		writeError(w, r, http.StatusNotFound, CodeNotFound, "user not found")
+		return
+	}
+	writeJSON(w, http.StatusOK, toUserResponse(u))
+}
+
+func (h *identityHandlers) createAgent(w http.ResponseWriter, r *http.Request) {
+	var body struct {
+		ParentUserID    string   `json:"parent_user_id"`
+		DisplayName     string   `json:"display_name"`
+		PermissionScope []string `json:"permission_scope"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeError(w, r, http.StatusBadRequest, CodeValidationFailed, "invalid JSON body")
+		return
+	}
+	parent, err := uuid.Parse(body.ParentUserID)
+	if err != nil {
+		writeError(w, r, http.StatusBadRequest, CodeValidationFailed, "parent_user_id is not a UUID")
+		return
+	}
+	// Authorisation: only the parent human (or an admin in a later iteration)
+	// may create agents under itself. An agent caller may not create siblings.
+	p := PrincipalFromContext(r.Context())
+	if p == nil {
+		writeError(w, r, http.StatusUnauthorized, CodeUnauthenticated, "missing principal")
+		return
+	}
+	if p.Kind() != PrincipalHuman || p.ID() != parent {
+		writeError(w, r, http.StatusForbidden, CodeForbidden, "principal may not create agents under another user")
+		return
+	}
+	a, err := h.svc.CreateAgent(r.Context(), parent, body.DisplayName, body.PermissionScope)
+	if err != nil {
+		status, code, msg := mapErr(r.Context(), h.logger, err)
+		writeError(w, r, status, code, msg)
+		return
+	}
+	w.Header().Set("Location", "/v1/agents/"+a.ID.String())
+	writeJSON(w, http.StatusCreated, toAgentResponse(a))
+}
+
+func (h *identityHandlers) getAgent(w http.ResponseWriter, r *http.Request) {
+	id, err := uuid.Parse(r.PathValue("id"))
+	if err != nil {
+		writeError(w, r, http.StatusBadRequest, CodeValidationFailed, "id is not a UUID")
+		return
+	}
+	a, err := h.svc.GetAgent(r.Context(), id)
+	if err != nil {
+		status, code, msg := mapErr(r.Context(), h.logger, err)
+		writeError(w, r, status, code, msg)
+		return
+	}
+	if a == nil {
+		writeError(w, r, http.StatusNotFound, CodeNotFound, "agent not found")
+		return
+	}
+	writeJSON(w, http.StatusOK, toAgentResponse(a))
+}
+
+func (h *identityHandlers) revokeAgent(w http.ResponseWriter, r *http.Request) {
+	id, err := uuid.Parse(r.PathValue("id"))
+	if err != nil {
+		writeError(w, r, http.StatusBadRequest, CodeValidationFailed, "id is not a UUID")
+		return
+	}
+	var body struct {
+		Reason string `json:"reason"`
+	}
+	// Empty body is acceptable — the reason is optional.
+	_ = json.NewDecoder(r.Body).Decode(&body)
+
+	// Authorisation: a human may revoke agents under themselves; an agent
+	// may revoke only itself. Cross-user revocation is forbidden in this
+	// iteration (admin scopes are tracked under issue #15-revocation).
+	p := PrincipalFromContext(r.Context())
+	if p == nil {
+		writeError(w, r, http.StatusUnauthorized, CodeUnauthenticated, "missing principal")
+		return
+	}
+	target, err := h.svc.GetAgent(r.Context(), id)
+	if err != nil {
+		status, code, msg := mapErr(r.Context(), h.logger, err)
+		writeError(w, r, status, code, msg)
+		return
+	}
+	if target == nil {
+		writeError(w, r, http.StatusNotFound, CodeNotFound, "agent not found")
+		return
+	}
+	switch p.Kind() {
+	case PrincipalHuman:
+		if p.ID() != target.ParentUserID {
+			writeError(w, r, http.StatusForbidden, CodeForbidden, "human may only revoke agents they own")
+			return
+		}
+	case PrincipalAgent:
+		if p.ID() != target.ID {
+			writeError(w, r, http.StatusForbidden, CodeForbidden, "agent may only revoke itself")
+			return
+		}
+	default:
+		writeError(w, r, http.StatusForbidden, CodeForbidden, "unknown principal kind")
+		return
+	}
+
+	if err := h.svc.RevokeAgent(r.Context(), id, body.Reason); err != nil {
+		status, code, msg := mapErr(r.Context(), h.logger, err)
+		writeError(w, r, status, code, msg)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (h *identityHandlers) updatePerms(w http.ResponseWriter, r *http.Request) {
+	id, err := uuid.Parse(r.PathValue("id"))
+	if err != nil {
+		writeError(w, r, http.StatusBadRequest, CodeValidationFailed, "id is not a UUID")
+		return
+	}
+	var body struct {
+		PermissionScope []string `json:"permission_scope"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeError(w, r, http.StatusBadRequest, CodeValidationFailed, "invalid JSON body")
+		return
+	}
+	p := PrincipalFromContext(r.Context())
+	if p == nil {
+		writeError(w, r, http.StatusUnauthorized, CodeUnauthenticated, "missing principal")
+		return
+	}
+	target, err := h.svc.GetAgent(r.Context(), id)
+	if err != nil {
+		status, code, msg := mapErr(r.Context(), h.logger, err)
+		writeError(w, r, status, code, msg)
+		return
+	}
+	if target == nil {
+		writeError(w, r, http.StatusNotFound, CodeNotFound, "agent not found")
+		return
+	}
+	// Only the parent human may change scope. Agents cannot self-elevate.
+	if p.Kind() != PrincipalHuman || p.ID() != target.ParentUserID {
+		writeError(w, r, http.StatusForbidden, CodeForbidden, "only the parent user may update agent permissions")
+		return
+	}
+
+	if err := h.svc.UpdateAgentPermissions(r.Context(), id, body.PermissionScope); err != nil {
+		status, code, msg := mapErr(r.Context(), h.logger, err)
+		writeError(w, r, status, code, msg)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func writeJSON(w http.ResponseWriter, status int, body any) {
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(body)
+}

--- a/plane/application/restapi/integration_test.go
+++ b/plane/application/restapi/integration_test.go
@@ -1,0 +1,238 @@
+//go:build integration
+
+package restapi_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/gitscale-platform/gitscale/plane/application/identity"
+	"github.com/gitscale-platform/gitscale/plane/application/repositories"
+	"github.com/gitscale-platform/gitscale/plane/application/restapi"
+	"github.com/gitscale-platform/gitscale/plane/data/ratelimit"
+	storepg "github.com/gitscale-platform/gitscale/plane/data/store/postgres"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/testcontainers/testcontainers-go"
+	pgmodule "github.com/testcontainers/testcontainers-go/modules/postgres"
+	"github.com/testcontainers/testcontainers-go/wait"
+)
+
+func setupPostgres(t *testing.T) *pgxpool.Pool {
+	t.Helper()
+	ctx := context.Background()
+
+	ctr, err := pgmodule.Run(ctx,
+		"postgres:16-alpine",
+		pgmodule.WithDatabase("gitscale_test"),
+		pgmodule.WithUsername("gs"),
+		pgmodule.WithPassword("gs"),
+		testcontainers.WithWaitStrategy(
+			wait.ForLog("database system is ready to accept connections").
+				WithOccurrence(2).
+				WithStartupTimeout(60*time.Second),
+		),
+	)
+	if err != nil {
+		t.Fatalf("start postgres: %v", err)
+	}
+	t.Cleanup(func() { _ = ctr.Terminate(ctx) })
+
+	connStr, err := ctr.ConnectionString(ctx, "sslmode=disable")
+	if err != nil {
+		t.Fatalf("connection string: %v", err)
+	}
+	pool, err := pgxpool.New(ctx, connStr)
+	if err != nil {
+		t.Fatalf("pgxpool.New: %v", err)
+	}
+	t.Cleanup(pool.Close)
+
+	migrationsDir := filepath.Join("..", "..", "..", "plane", "data", "migrations")
+	for _, f := range []string{
+		"000_init.sql", "001_identity.sql", "002_repositories.sql",
+		"003_collaboration.sql", "004_ci.sql", "005_billing.sql",
+		"006_identity_revocation.sql",
+		"010_repositories_keyset_index.sql",
+	} {
+		sql, err := os.ReadFile(filepath.Join(migrationsDir, f))
+		if err != nil {
+			t.Fatalf("read migration %s: %v", f, err)
+		}
+		if _, err := pool.Exec(ctx, string(sql)); err != nil {
+			t.Fatalf("apply migration %s: %v", f, err)
+		}
+	}
+	return pool
+}
+
+func TestRestAPI_FullFlow_postgres(t *testing.T) {
+	pool := setupPostgres(t)
+	mds := storepg.New(pool)
+	identitySvc := identity.NewPostgresService(mds)
+	reposSvc := repositories.NewService(mds)
+
+	// Seed a user up-front so we know the resolver token.
+	user, err := identitySvc.CreateUser(context.Background(), "operator@example.com", "S3cret!1234")
+	if err != nil {
+		t.Fatalf("seed user: %v", err)
+	}
+	// Seed an org row so the FK soft-ref is realistic (not enforced by SQL,
+	// but the slug+org_id UNIQUE applies).
+	orgID := uuid.New()
+	if _, err := pool.Exec(context.Background(),
+		`INSERT INTO identity.organisations (id, slug) VALUES ($1, $2)`,
+		orgID, "acme",
+	); err != nil {
+		t.Fatalf("seed org: %v", err)
+	}
+
+	resolver := restapi.NewIdentityResolver(mds.Identity())
+	router := restapi.NewRouter(restapi.Deps{
+		Identity:     identitySvc,
+		Repositories: reposSvc,
+		Resolver:     resolver,
+		Limiter:      ratelimit.NewMemoryLimiter(nil),
+		RateConfig:   restapi.RateConfig{HumanCapacity: 100, HumanRefillPerSec: 100, AgentCapacity: 100, AgentRefillPerSec: 100},
+	})
+	srv := httptest.NewServer(router)
+	t.Cleanup(srv.Close)
+
+	tok := user.ID.String()
+
+	// /healthz: no auth.
+	resp, err := http.Get(srv.URL + "/healthz")
+	if err != nil {
+		t.Fatalf("healthz: %v", err)
+	}
+	if resp.StatusCode != 200 {
+		t.Errorf("healthz: %d", resp.StatusCode)
+	}
+	resp.Body.Close()
+
+	// GET /v1/users/{id}
+	resp = doAuth(t, "GET", srv.URL+"/v1/users/"+user.ID.String(), tok, nil)
+	if resp.StatusCode != 200 {
+		t.Fatalf("get user: %d", resp.StatusCode)
+	}
+	resp.Body.Close()
+
+	// POST /v1/agents
+	body := mustJSON(t, map[string]any{
+		"parent_user_id":   user.ID.String(),
+		"display_name":     "ci-agent",
+		"permission_scope": []string{"repo:read"},
+	})
+	resp = doAuth(t, "POST", srv.URL+"/v1/agents", tok, body)
+	if resp.StatusCode != 201 {
+		dump, _ := io.ReadAll(resp.Body)
+		t.Fatalf("create agent: %d %s", resp.StatusCode, dump)
+	}
+	var agent struct {
+		ID string `json:"id"`
+	}
+	_ = json.NewDecoder(resp.Body).Decode(&agent)
+	resp.Body.Close()
+
+	// POST /v1/repos
+	body = mustJSON(t, map[string]string{
+		"org_id":     orgID.String(),
+		"slug":       "demo",
+		"name":       "Demo",
+		"visibility": "private",
+	})
+	resp = doAuth(t, "POST", srv.URL+"/v1/repos", tok, body)
+	if resp.StatusCode != 201 {
+		dump, _ := io.ReadAll(resp.Body)
+		t.Fatalf("create repo: %d %s", resp.StatusCode, dump)
+	}
+	var repo struct {
+		ID string `json:"id"`
+	}
+	_ = json.NewDecoder(resp.Body).Decode(&repo)
+	resp.Body.Close()
+
+	// outbox row was written for repo.created.
+	var n int
+	if err := pool.QueryRow(context.Background(),
+		`SELECT count(*) FROM repositories.repositories_outbox WHERE event_type = 'repositories.repository_created' AND aggregate_id = $1`,
+		repo.ID,
+	).Scan(&n); err != nil || n != 1 {
+		t.Errorf("repo outbox: count=%d err=%v", n, err)
+	}
+
+	// GET /v1/repos/{id}
+	resp = doAuth(t, "GET", srv.URL+"/v1/repos/"+repo.ID, tok, nil)
+	if resp.StatusCode != 200 {
+		t.Errorf("get repo: %d", resp.StatusCode)
+	}
+	resp.Body.Close()
+
+	// GET /v1/orgs/{org}/repos
+	resp = doAuth(t, "GET", srv.URL+"/v1/orgs/"+orgID.String()+"/repos", tok, nil)
+	if resp.StatusCode != 200 {
+		t.Errorf("list repos: %d", resp.StatusCode)
+	}
+	resp.Body.Close()
+
+	// DELETE /v1/agents/{id}
+	resp = doAuth(t, "DELETE", srv.URL+"/v1/agents/"+agent.ID, tok, mustJSON(t, map[string]string{"reason": "test"}))
+	if resp.StatusCode != 204 {
+		t.Errorf("revoke agent: %d", resp.StatusCode)
+	}
+	resp.Body.Close()
+}
+
+func TestRestAPI_unauthenticated_401(t *testing.T) {
+	pool := setupPostgres(t)
+	mds := storepg.New(pool)
+	router := restapi.NewRouter(restapi.Deps{
+		Identity:     identity.NewPostgresService(mds),
+		Repositories: repositories.NewService(mds),
+		Resolver:     restapi.NewIdentityResolver(mds.Identity()),
+		Limiter:      ratelimit.NewMemoryLimiter(nil),
+		RateConfig:   restapi.RateConfig{HumanCapacity: 10, HumanRefillPerSec: 10},
+	})
+	srv := httptest.NewServer(router)
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Get(srv.URL + "/v1/users/" + uuid.NewString())
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if resp.StatusCode != 401 {
+		t.Errorf("status: %d", resp.StatusCode)
+	}
+	resp.Body.Close()
+}
+
+func doAuth(t *testing.T, method, url, token string, body io.Reader) *http.Response {
+	t.Helper()
+	req, err := http.NewRequest(method, url, body)
+	if err != nil {
+		t.Fatalf("req: %v", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("do: %v", err)
+	}
+	return resp
+}
+
+func mustJSON(t *testing.T, v any) *bytes.Buffer {
+	t.Helper()
+	b, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	return bytes.NewBuffer(b)
+}

--- a/plane/application/restapi/middleware_auth.go
+++ b/plane/application/restapi/middleware_auth.go
@@ -1,0 +1,65 @@
+package restapi
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"strings"
+)
+
+// PrincipalResolver resolves a bearer token to a Principal. Production
+// implementations call identity.Service.LookupIdentityForCache plus a
+// kind→Principal adapter; tests inject a fixed-token map.
+type PrincipalResolver interface {
+	Resolve(ctx context.Context, bearer string) (Principal, error)
+}
+
+// ErrInvalidToken is returned by a PrincipalResolver when the supplied
+// bearer cannot be mapped to a known principal. It is mapped to a 401
+// response by the auth middleware.
+var ErrInvalidToken = errors.New("restapi: invalid bearer token")
+
+// authSkipPaths are the URL paths that bypass auth. Only /healthz today;
+// adding to this list is a public-API change.
+var authSkipPaths = map[string]struct{}{
+	"/healthz": {},
+}
+
+// authMiddleware validates the Authorization: Bearer header and stamps the
+// resolved Principal onto r.Context.
+//
+// Empty header or unresolved token → 401. The handler chain never sees an
+// authenticated request without a Principal in context.
+func authMiddleware(resolver PrincipalResolver) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if _, skip := authSkipPaths[r.URL.Path]; skip {
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			h := r.Header.Get("Authorization")
+			if h == "" {
+				writeError(w, r, http.StatusUnauthorized, CodeUnauthenticated, "missing Authorization header")
+				return
+			}
+			const prefix = "Bearer "
+			if !strings.HasPrefix(h, prefix) {
+				writeError(w, r, http.StatusUnauthorized, CodeUnauthenticated, "expected 'Bearer <token>'")
+				return
+			}
+			token := strings.TrimSpace(h[len(prefix):])
+			if token == "" {
+				writeError(w, r, http.StatusUnauthorized, CodeUnauthenticated, "empty bearer token")
+				return
+			}
+			principal, err := resolver.Resolve(r.Context(), token)
+			if err != nil || principal == nil {
+				writeError(w, r, http.StatusUnauthorized, CodeUnauthenticated, "invalid bearer token")
+				return
+			}
+			ctx := WithPrincipal(r.Context(), principal)
+			next.ServeHTTP(w, r.WithContext(ctx))
+		})
+	}
+}

--- a/plane/application/restapi/middleware_ratelimit.go
+++ b/plane/application/restapi/middleware_ratelimit.go
@@ -1,0 +1,96 @@
+package restapi
+
+import (
+	"fmt"
+	"math"
+	"net/http"
+	"strconv"
+
+	"github.com/gitscale-platform/gitscale/plane/data/ratelimit"
+)
+
+// rateLimitSurface is the surface enum stamped into the bucket key. New
+// surfaces (mcp, graphql) get their own constant in their own packages so
+// REST-only spikes don't bleed into other planes' budgets.
+const rateLimitSurface = "rest_api"
+
+// RateConfig parameters the per-principal token-bucket. Zero values mean
+// unlimited so tests that don't care about rate-limiting can pass a zero
+// value and disable enforcement.
+type RateConfig struct {
+	AgentCapacity     float64
+	AgentRefillPerSec float64
+	HumanCapacity     float64
+	HumanRefillPerSec float64
+}
+
+// rateLimitSkipPaths bypass the limiter (mirrors authSkipPaths).
+var rateLimitSkipPaths = map[string]struct{}{
+	"/healthz": {},
+}
+
+// rateLimitMiddleware enforces a per-principal token bucket. It must run
+// AFTER auth so unauthenticated traffic does not consume buckets attached
+// to a real principal (a hostile actor could otherwise spam an empty
+// token to drain the legitimate user's bucket — but the bucket key is
+// derived from the resolved principal id, not from the bearer string,
+// closing that loop).
+func rateLimitMiddleware(limiter ratelimit.RateLimiter, cfg RateConfig) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if _, skip := rateLimitSkipPaths[r.URL.Path]; skip {
+				next.ServeHTTP(w, r)
+				return
+			}
+			p := PrincipalFromContext(r.Context())
+			if p == nil {
+				// Auth must always run before rate-limit. Defensive guard.
+				writeError(w, r, http.StatusUnauthorized, CodeUnauthenticated, "missing principal")
+				return
+			}
+			capacity, refill := bucketParams(cfg, p.Kind())
+			if capacity <= 0 || refill < 0 {
+				next.ServeHTTP(w, r)
+				return
+			}
+			key := fmt.Sprintf(ratelimit.TokenBucketKey, p.ID(), rateLimitSurface)
+			granted, _, err := limiter.Take(r.Context(), key, capacity, refill, 1)
+			if err != nil {
+				// Fail closed: a limiter outage must not become an open door.
+				writeError(w, r, http.StatusInternalServerError, CodeInternal, "rate-limit backend error")
+				return
+			}
+			if !granted {
+				w.Header().Set("Retry-After", retryAfter(refill))
+				writeError(w, r, http.StatusTooManyRequests, CodeRateLimited, "rate limit exceeded")
+				return
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+func bucketParams(cfg RateConfig, kind PrincipalKind) (capacity, refill float64) {
+	switch kind {
+	case PrincipalAgent:
+		return cfg.AgentCapacity, cfg.AgentRefillPerSec
+	case PrincipalHuman:
+		return cfg.HumanCapacity, cfg.HumanRefillPerSec
+	default:
+		return 0, 0
+	}
+}
+
+// retryAfter returns the seconds-until-one-token header value as a string.
+// When refill is zero (test shape) it returns "1" so clients backoff at
+// least one second instead of busy-looping.
+func retryAfter(refillPerSec float64) string {
+	if refillPerSec <= 0 {
+		return "1"
+	}
+	secs := int(math.Ceil(1.0 / refillPerSec))
+	if secs < 1 {
+		secs = 1
+	}
+	return strconv.Itoa(secs)
+}

--- a/plane/application/restapi/middleware_request_id.go
+++ b/plane/application/restapi/middleware_request_id.go
@@ -1,0 +1,40 @@
+package restapi
+
+import (
+	"net/http"
+
+	"github.com/google/uuid"
+)
+
+// requestIDHeader is the canonical correlation header used both as input
+// (passthrough from upstream proxies) and output (echoed back to the client
+// and stamped into structured logs).
+const requestIDHeader = "X-Request-Id"
+
+// requestID is the outermost middleware. It either passes through a
+// caller-supplied X-Request-Id (parsed as UUID) or generates a fresh UUID,
+// then writes the value to the response header and request context.
+//
+// The middleware never fails open with an empty request id — every request
+// carries a stable identifier downstream consumers can correlate.
+func requestID(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		id := r.Header.Get(requestIDHeader)
+		if id == "" || !looksLikeUUID(id) {
+			id = uuid.NewString()
+		}
+		w.Header().Set(requestIDHeader, id)
+		ctx := WithRequestID(r.Context(), id)
+		next.ServeHTTP(w, r.WithContext(ctx))
+	})
+}
+
+// looksLikeUUID is a cheap validator: rejects values that aren't valid
+// UUID v4-ish strings so an attacker can't smuggle arbitrary content via
+// the request-id header into structured logs.
+func looksLikeUUID(s string) bool {
+	if _, err := uuid.Parse(s); err != nil {
+		return false
+	}
+	return true
+}

--- a/plane/application/restapi/pagination.go
+++ b/plane/application/restapi/pagination.go
@@ -1,0 +1,46 @@
+package restapi
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+
+	"github.com/gitscale-platform/gitscale/plane/application/repositories"
+)
+
+// errInvalidCursor is returned when DecodeCursor cannot parse the input.
+var errInvalidCursor = errors.New("restapi: invalid cursor")
+
+// EncodeCursor renders c as a URL-safe base64 of its JSON form. The empty
+// cursor renders to the empty string so callers can omit the parameter on
+// the first page.
+func EncodeCursor(c repositories.Cursor) string {
+	if c.IsZero() {
+		return ""
+	}
+	raw, err := json.Marshal(c)
+	if err != nil {
+		// json.Marshal of a value-typed struct of UUID + Time cannot fail
+		// in practice; collapse the error to an empty cursor rather than
+		// panicking on the request path.
+		return ""
+	}
+	return base64.RawURLEncoding.EncodeToString(raw)
+}
+
+// DecodeCursor parses an opaque cursor string. The empty input is the
+// "start of listing" zero value with no error.
+func DecodeCursor(s string) (repositories.Cursor, error) {
+	if s == "" {
+		return repositories.Cursor{}, nil
+	}
+	raw, err := base64.RawURLEncoding.DecodeString(s)
+	if err != nil {
+		return repositories.Cursor{}, errInvalidCursor
+	}
+	var c repositories.Cursor
+	if err := json.Unmarshal(raw, &c); err != nil {
+		return repositories.Cursor{}, errInvalidCursor
+	}
+	return c, nil
+}

--- a/plane/application/restapi/pagination_test.go
+++ b/plane/application/restapi/pagination_test.go
@@ -1,0 +1,52 @@
+package restapi
+
+import (
+	"testing"
+	"time"
+
+	"github.com/gitscale-platform/gitscale/plane/application/repositories"
+	"github.com/google/uuid"
+)
+
+func TestEncodeDecodeCursor_roundTrip(t *testing.T) {
+	c := repositories.Cursor{
+		AfterID:        uuid.New(),
+		AfterCreatedAt: time.Now().UTC().Truncate(time.Microsecond),
+	}
+	s := EncodeCursor(c)
+	if s == "" {
+		t.Fatal("encoded empty for non-zero cursor")
+	}
+	got, err := DecodeCursor(s)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got.AfterID != c.AfterID || !got.AfterCreatedAt.Equal(c.AfterCreatedAt) {
+		t.Errorf("round-trip mismatch: %+v vs %+v", got, c)
+	}
+}
+
+func TestEncodeCursor_zeroIsEmpty(t *testing.T) {
+	if got := EncodeCursor(repositories.Cursor{}); got != "" {
+		t.Errorf("zero cursor encoded to %q, want empty", got)
+	}
+}
+
+func TestDecodeCursor_emptyIsZero(t *testing.T) {
+	got, err := DecodeCursor("")
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if !got.IsZero() {
+		t.Errorf("expected zero cursor, got %+v", got)
+	}
+}
+
+func TestDecodeCursor_malformed(t *testing.T) {
+	if _, err := DecodeCursor("not-base64!"); err == nil {
+		t.Error("expected error on malformed base64")
+	}
+	if _, err := DecodeCursor("YWJjZA"); err == nil { // valid base64, not JSON
+		t.Error("expected error on non-JSON payload")
+	}
+}

--- a/plane/application/restapi/principal.go
+++ b/plane/application/restapi/principal.go
@@ -1,0 +1,100 @@
+package restapi
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+)
+
+// PrincipalKind discriminates the concrete principal type.
+type PrincipalKind int
+
+const (
+	// PrincipalUnknown is the zero value; never present on an authenticated
+	// request.
+	PrincipalUnknown PrincipalKind = iota
+	PrincipalHuman
+	PrincipalAgent
+)
+
+// String renders the kind for log fields.
+func (k PrincipalKind) String() string {
+	switch k {
+	case PrincipalHuman:
+		return "human"
+	case PrincipalAgent:
+		return "agent"
+	default:
+		return "unknown"
+	}
+}
+
+// Principal is the closed sum-type representing the authenticated caller.
+// The concrete implementations are HumanPrincipal and AgentPrincipal.
+type Principal interface {
+	Kind() PrincipalKind
+	ID() uuid.UUID
+}
+
+// HumanPrincipal authenticates as a human user.
+type HumanPrincipal struct {
+	UserID uuid.UUID
+}
+
+// Kind returns PrincipalHuman.
+func (p HumanPrincipal) Kind() PrincipalKind { return PrincipalHuman }
+
+// ID returns the human user UUID.
+func (p HumanPrincipal) ID() uuid.UUID { return p.UserID }
+
+// AgentPrincipal authenticates as an agent identity.
+type AgentPrincipal struct {
+	AgentID      uuid.UUID
+	ParentUserID uuid.UUID
+}
+
+// Kind returns PrincipalAgent.
+func (p AgentPrincipal) Kind() PrincipalKind { return PrincipalAgent }
+
+// ID returns the agent UUID.
+func (p AgentPrincipal) ID() uuid.UUID { return p.AgentID }
+
+type ctxKey int
+
+const (
+	ctxKeyPrincipal ctxKey = iota
+	ctxKeyRequestID
+)
+
+// WithPrincipal returns a derived context carrying p. Used by the auth
+// middleware; handlers read via PrincipalFromContext.
+func WithPrincipal(ctx context.Context, p Principal) context.Context {
+	return context.WithValue(ctx, ctxKeyPrincipal, p)
+}
+
+// PrincipalFromContext returns the principal stamped by the auth
+// middleware, or nil if none is present.
+func PrincipalFromContext(ctx context.Context) Principal {
+	if v := ctx.Value(ctxKeyPrincipal); v != nil {
+		if p, ok := v.(Principal); ok {
+			return p
+		}
+	}
+	return nil
+}
+
+// WithRequestID stamps a request-id onto ctx.
+func WithRequestID(ctx context.Context, id string) context.Context {
+	return context.WithValue(ctx, ctxKeyRequestID, id)
+}
+
+// RequestIDFromContext returns the request id stamped by the request_id
+// middleware, or the empty string when not set.
+func RequestIDFromContext(ctx context.Context) string {
+	if v := ctx.Value(ctxKeyRequestID); v != nil {
+		if s, ok := v.(string); ok {
+			return s
+		}
+	}
+	return ""
+}

--- a/plane/application/restapi/repos_handlers.go
+++ b/plane/application/restapi/repos_handlers.go
@@ -1,0 +1,164 @@
+package restapi
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/gitscale-platform/gitscale/plane/application/repositories"
+	"github.com/google/uuid"
+)
+
+type reposHandlers struct {
+	svc    repositories.Service
+	logger *slog.Logger
+}
+
+type repositoryResponse struct {
+	ID            string    `json:"id"`
+	OrgID         string    `json:"org_id"`
+	OwnerID       string    `json:"owner_id"`
+	Slug          string    `json:"slug"`
+	Name          string    `json:"name"`
+	DefaultBranch string    `json:"default_branch"`
+	Visibility    string    `json:"visibility"`
+	CreatedAt     time.Time `json:"created_at"`
+}
+
+func toRepositoryResponse(r *repositories.Repository) repositoryResponse {
+	return repositoryResponse{
+		ID:            r.ID.String(),
+		OrgID:         r.OrgID.String(),
+		OwnerID:       r.OwnerID.String(),
+		Slug:          r.Slug,
+		Name:          r.Name,
+		DefaultBranch: r.DefaultBranch,
+		Visibility:    r.Visibility,
+		CreatedAt:     r.CreatedAt,
+	}
+}
+
+type listResponse struct {
+	Items      []repositoryResponse `json:"items"`
+	NextCursor string               `json:"next_cursor,omitempty"`
+}
+
+// createRepo: humans create repositories under an org they belong to. Agent
+// creation paths land via the MCP server (issue #112); they are explicitly
+// rejected here so we don't accidentally provide an unmetered REST escape
+// hatch for agents.
+func (h *reposHandlers) createRepo(w http.ResponseWriter, r *http.Request) {
+	p := PrincipalFromContext(r.Context())
+	if p == nil {
+		writeError(w, r, http.StatusUnauthorized, CodeUnauthenticated, "missing principal")
+		return
+	}
+	if p.Kind() != PrincipalHuman {
+		writeError(w, r, http.StatusForbidden, CodeForbidden, "only humans may create repositories via REST")
+		return
+	}
+	var body struct {
+		OrgID         string `json:"org_id"`
+		Slug          string `json:"slug"`
+		Name          string `json:"name"`
+		DefaultBranch string `json:"default_branch"`
+		Visibility    string `json:"visibility"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeError(w, r, http.StatusBadRequest, CodeValidationFailed, "invalid JSON body")
+		return
+	}
+	orgID, err := uuid.Parse(body.OrgID)
+	if err != nil {
+		writeError(w, r, http.StatusBadRequest, CodeValidationFailed, "org_id is not a UUID")
+		return
+	}
+	repo, err := h.svc.CreateRepository(r.Context(), repositories.CreateInput{
+		OrgID:         orgID,
+		OwnerID:       p.ID(),
+		Slug:          body.Slug,
+		Name:          body.Name,
+		DefaultBranch: body.DefaultBranch,
+		Visibility:    body.Visibility,
+	})
+	if err != nil {
+		status, code, msg := mapErr(r.Context(), h.logger, err)
+		writeError(w, r, status, code, msg)
+		return
+	}
+	w.Header().Set("Location", "/v1/repos/"+repo.ID.String())
+	writeJSON(w, http.StatusCreated, toRepositoryResponse(repo))
+}
+
+func (h *reposHandlers) getRepo(w http.ResponseWriter, r *http.Request) {
+	id, err := uuid.Parse(r.PathValue("id"))
+	if err != nil {
+		writeError(w, r, http.StatusBadRequest, CodeValidationFailed, "id is not a UUID")
+		return
+	}
+	repo, err := h.svc.GetRepository(r.Context(), id)
+	if err != nil {
+		status, code, msg := mapErr(r.Context(), h.logger, err)
+		writeError(w, r, status, code, msg)
+		return
+	}
+	if repo == nil {
+		writeError(w, r, http.StatusNotFound, CodeNotFound, "repository not found")
+		return
+	}
+	writeJSON(w, http.StatusOK, toRepositoryResponse(repo))
+}
+
+// deleteRepo reserves the URL space for repository deletion. The actual
+// delete pipeline (cascade across collaboration tables, schedule git-plane
+// deprovision) is tracked under a follow-up issue; until then this returns
+// 501 with the documented internal-class code.
+func (h *reposHandlers) deleteRepo(w http.ResponseWriter, r *http.Request) {
+	if _, err := uuid.Parse(r.PathValue("id")); err != nil {
+		writeError(w, r, http.StatusBadRequest, CodeValidationFailed, "id is not a UUID")
+		return
+	}
+	if h.logger != nil {
+		h.logger.WarnContext(r.Context(), "rest_api: DELETE /v1/repos is not implemented; tracked as follow-up")
+	}
+	writeError(w, r, http.StatusNotImplemented, CodeInternal, "repository deletion not implemented")
+}
+
+func (h *reposHandlers) listOrgRepos(w http.ResponseWriter, r *http.Request) {
+	orgID, err := uuid.Parse(r.PathValue("org"))
+	if err != nil {
+		writeError(w, r, http.StatusBadRequest, CodeValidationFailed, "org is not a UUID")
+		return
+	}
+	cursor, err := DecodeCursor(r.URL.Query().Get("cursor"))
+	if err != nil {
+		writeError(w, r, http.StatusBadRequest, CodeValidationFailed, "invalid cursor")
+		return
+	}
+	limit := 20
+	if v := r.URL.Query().Get("limit"); v != "" {
+		n, perr := strconv.Atoi(v)
+		if perr != nil || n <= 0 {
+			writeError(w, r, http.StatusBadRequest, CodeValidationFailed, "limit must be a positive integer")
+			return
+		}
+		limit = n
+	}
+	rows, next, err := h.svc.ListByOrg(r.Context(), orgID, cursor, limit)
+	if err != nil {
+		status, code, msg := mapErr(r.Context(), h.logger, err)
+		writeError(w, r, status, code, msg)
+		return
+	}
+	resp := listResponse{Items: make([]repositoryResponse, 0, len(rows))}
+	for i := range rows {
+		resp.Items = append(resp.Items, toRepositoryResponse(&rows[i]))
+	}
+	if next != nil {
+		resp.NextCursor = EncodeCursor(*next)
+	}
+	writeJSON(w, http.StatusOK, resp)
+}
+

--- a/plane/application/restapi/resolver.go
+++ b/plane/application/restapi/resolver.go
@@ -1,0 +1,64 @@
+package restapi
+
+import (
+	"context"
+	"errors"
+
+	"github.com/gitscale-platform/gitscale/plane/data/store"
+	"github.com/google/uuid"
+)
+
+// identityLookuper is the subset of store.IdentityReader the production
+// resolver needs. It is a separate interface so tests can substitute a
+// minimal stub without pulling identity.Service.
+type identityLookuper interface {
+	LookupIdentityForCache(ctx context.Context, principalID uuid.UUID) (*store.IdentityCacheEntry, error)
+	GetAgentByID(ctx context.Context, id uuid.UUID) (*store.AgentIdentity, error)
+}
+
+// IdentityResolver maps a UUID-shaped bearer token to a Principal via
+// store.IdentityReader. The bearer-token format is intentionally minimal in
+// this iteration (raw UUID); a signed-JWT path lands with ADR-010 hardening
+// in the edge plane.
+type IdentityResolver struct {
+	store identityLookuper
+}
+
+// NewIdentityResolver wires the production resolver onto an
+// IdentityReader (typically obtained via store.MetadataStore.Identity()).
+func NewIdentityResolver(reader identityLookuper) *IdentityResolver {
+	return &IdentityResolver{store: reader}
+}
+
+// Resolve parses the bearer as a UUID and looks up the principal kind.
+// Unknown principals → ErrInvalidToken; agent principals are decorated
+// with their parent_user_id so authorisation rules in handlers can use it
+// without an extra round-trip.
+func (r *IdentityResolver) Resolve(ctx context.Context, bearer string) (Principal, error) {
+	id, err := uuid.Parse(bearer)
+	if err != nil {
+		return nil, ErrInvalidToken
+	}
+	entry, err := r.store.LookupIdentityForCache(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	if entry == nil {
+		return nil, ErrInvalidToken
+	}
+	switch entry.Kind {
+	case "human":
+		return HumanPrincipal{UserID: entry.PrincipalID}, nil
+	case "agent":
+		agent, err := r.store.GetAgentByID(ctx, id)
+		if err != nil {
+			return nil, err
+		}
+		if agent == nil {
+			return nil, ErrInvalidToken
+		}
+		return AgentPrincipal{AgentID: agent.ID, ParentUserID: agent.ParentUserID}, nil
+	default:
+		return nil, errors.New("restapi: unknown principal kind " + entry.Kind)
+	}
+}

--- a/plane/application/restapi/router.go
+++ b/plane/application/restapi/router.go
@@ -1,0 +1,65 @@
+package restapi
+
+import (
+	"log/slog"
+	"net/http"
+
+	"github.com/gitscale-platform/gitscale/plane/application/identity"
+	"github.com/gitscale-platform/gitscale/plane/application/repositories"
+	"github.com/gitscale-platform/gitscale/plane/data/ratelimit"
+)
+
+// Deps bundles the inputs to NewRouter. All fields are required except
+// Logger (defaulted to slog.Default()).
+type Deps struct {
+	Identity     identity.Service
+	Repositories repositories.Service
+	Resolver     PrincipalResolver
+	Limiter      ratelimit.RateLimiter
+	RateConfig   RateConfig
+	Logger       *slog.Logger
+}
+
+// NewRouter composes the HTTP handler tree.
+//
+// Middleware order (outer → inner): RequestID → Auth → RateLimit → mux.
+//
+// Why: request-id is needed in the very first log line a handler may emit,
+// including auth-failure logs. Auth runs before rate-limit so an
+// unauthenticated request never consumes a real principal's token bucket
+// (the bucket key is derived from the resolved principal id; without auth
+// there is no principal to charge against).
+func NewRouter(d Deps) http.Handler {
+	logger := d.Logger
+	if logger == nil {
+		logger = slog.Default()
+	}
+
+	mux := http.NewServeMux()
+
+	idH := &identityHandlers{svc: d.Identity, logger: logger}
+	repoH := &reposHandlers{svc: d.Repositories, logger: logger}
+
+	mux.HandleFunc("POST /v1/users", idH.createUser)
+	mux.HandleFunc("GET /v1/users/{id}", idH.getUser)
+	mux.HandleFunc("POST /v1/agents", idH.createAgent)
+	mux.HandleFunc("GET /v1/agents/{id}", idH.getAgent)
+	mux.HandleFunc("DELETE /v1/agents/{id}", idH.revokeAgent)
+	mux.HandleFunc("PATCH /v1/agents/{id}/permissions", idH.updatePerms)
+
+	mux.HandleFunc("POST /v1/repos", repoH.createRepo)
+	mux.HandleFunc("GET /v1/repos/{id}", repoH.getRepo)
+	mux.HandleFunc("DELETE /v1/repos/{id}", repoH.deleteRepo)
+	mux.HandleFunc("GET /v1/orgs/{org}/repos", repoH.listOrgRepos)
+
+	mux.HandleFunc("GET /healthz", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	})
+
+	var handler http.Handler = mux
+	handler = rateLimitMiddleware(d.Limiter, d.RateConfig)(handler)
+	handler = authMiddleware(d.Resolver)(handler)
+	handler = requestID(handler)
+	return handler
+}

--- a/plane/application/restapi/router_test.go
+++ b/plane/application/restapi/router_test.go
@@ -1,0 +1,374 @@
+package restapi
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/gitscale-platform/gitscale/plane/application/identity"
+	"github.com/gitscale-platform/gitscale/plane/application/repositories"
+	"github.com/gitscale-platform/gitscale/plane/data/ratelimit"
+	"github.com/gitscale-platform/gitscale/plane/data/store/stub"
+	"github.com/google/uuid"
+)
+
+// fixedResolver maps tokens → principals for tests. Unknown tokens fail.
+type fixedResolver struct {
+	m map[string]Principal
+}
+
+func (f *fixedResolver) Resolve(_ context.Context, bearer string) (Principal, error) {
+	if p, ok := f.m[bearer]; ok {
+		return p, nil
+	}
+	return nil, ErrInvalidToken
+}
+
+// memLimiter is a tiny in-memory bucket for tests. We don't reuse
+// ratelimit.MemoryLimiter to keep the test free of timing assumptions —
+// tokens never refill, they're pre-loaded.
+type memLimiter struct {
+	mu      sync.Mutex
+	buckets map[string]float64
+}
+
+func newMemLimiter() *memLimiter { return &memLimiter{buckets: map[string]float64{}} }
+
+func (l *memLimiter) Take(_ context.Context, key string, capacity, _, n float64) (bool, float64, error) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	cur, ok := l.buckets[key]
+	if !ok {
+		cur = capacity
+	}
+	if cur < n {
+		l.buckets[key] = cur
+		return false, cur, nil
+	}
+	cur -= n
+	l.buckets[key] = cur
+	return true, cur, nil
+}
+
+// brokenLimiter always errors so we can prove the middleware fails closed.
+type brokenLimiter struct{}
+
+func (brokenLimiter) Take(_ context.Context, _ string, _, _, _ float64) (bool, float64, error) {
+	return false, 0, errors.New("limiter exploded")
+}
+
+func newTestRouter(t *testing.T, l ratelimit.RateLimiter, cfg RateConfig, principals map[string]Principal) (*httptest.Server, identity.Service, repositories.Service) {
+	t.Helper()
+	store := stub.New()
+	identitySvc := identity.NewStubService()
+	// repositories.Service uses the same backing stub.Store so writes are
+	// observable across services. We re-use the stub's MetadataStore handle.
+	reposSvc := repositories.NewService(store)
+	resolver := &fixedResolver{m: principals}
+	r := NewRouter(Deps{
+		Identity:     identitySvc,
+		Repositories: reposSvc,
+		Resolver:     resolver,
+		Limiter:      l,
+		RateConfig:   cfg,
+	})
+	srv := httptest.NewServer(r)
+	t.Cleanup(srv.Close)
+	return srv, identitySvc, reposSvc
+}
+
+func mustJSON(t *testing.T, v any) *bytes.Buffer {
+	t.Helper()
+	b, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	return bytes.NewBuffer(b)
+}
+
+func doReq(t *testing.T, method, url, token string, body io.Reader) *http.Response {
+	t.Helper()
+	req, err := http.NewRequest(method, url, body)
+	if err != nil {
+		t.Fatalf("new req: %v", err)
+	}
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("do: %v", err)
+	}
+	return resp
+}
+
+func TestHealthz_skipsAuth(t *testing.T) {
+	srv, _, _ := newTestRouter(t, newMemLimiter(), RateConfig{}, nil)
+	resp := doReq(t, "GET", srv.URL+"/healthz", "", nil)
+	if resp.StatusCode != 200 {
+		t.Fatalf("status: %d", resp.StatusCode)
+	}
+}
+
+func TestAuth_missingBearer_401(t *testing.T) {
+	srv, _, _ := newTestRouter(t, newMemLimiter(), RateConfig{}, nil)
+	resp := doReq(t, "GET", srv.URL+"/v1/users/"+uuid.NewString(), "", nil)
+	if resp.StatusCode != 401 {
+		t.Fatalf("status: %d", resp.StatusCode)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	if !strings.Contains(string(body), `"unauthenticated"`) {
+		t.Errorf("body missing code: %s", body)
+	}
+	// Even a 401 must echo a request id.
+	if resp.Header.Get(requestIDHeader) == "" {
+		t.Error("X-Request-Id missing on 401")
+	}
+}
+
+func TestAuth_invalidToken_401(t *testing.T) {
+	srv, _, _ := newTestRouter(t, newMemLimiter(), RateConfig{}, nil)
+	resp := doReq(t, "GET", srv.URL+"/v1/users/"+uuid.NewString(), "garbage", nil)
+	if resp.StatusCode != 401 {
+		t.Fatalf("status: %d", resp.StatusCode)
+	}
+}
+
+func TestAuth_humanGetMissingUser_404(t *testing.T) {
+	humanID := uuid.New()
+	srv, _, _ := newTestRouter(t, newMemLimiter(), RateConfig{}, map[string]Principal{
+		"tok-human": HumanPrincipal{UserID: humanID},
+	})
+	resp := doReq(t, "GET", srv.URL+"/v1/users/"+uuid.NewString(), "tok-human", nil)
+	if resp.StatusCode != 404 {
+		t.Fatalf("status: %d", resp.StatusCode)
+	}
+}
+
+func TestCreateUser_201_andLocation(t *testing.T) {
+	humanID := uuid.New()
+	srv, _, _ := newTestRouter(t, newMemLimiter(), RateConfig{}, map[string]Principal{
+		"tok-human": HumanPrincipal{UserID: humanID},
+	})
+	body := mustJSON(t, map[string]string{"email": "alice@example.com", "credential": "S3cret!1234"})
+	resp := doReq(t, "POST", srv.URL+"/v1/users", "tok-human", body)
+	if resp.StatusCode != 201 {
+		dump, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status: %d body=%s", resp.StatusCode, dump)
+	}
+	if loc := resp.Header.Get("Location"); !strings.HasPrefix(loc, "/v1/users/") {
+		t.Errorf("Location header missing/bad: %q", loc)
+	}
+}
+
+func TestCreateUser_byAgent_403(t *testing.T) {
+	agentID := uuid.New()
+	srv, _, _ := newTestRouter(t, newMemLimiter(), RateConfig{}, map[string]Principal{
+		"tok-agent": AgentPrincipal{AgentID: agentID, ParentUserID: uuid.New()},
+	})
+	body := mustJSON(t, map[string]string{"email": "x@y.z", "credential": "pw"})
+	resp := doReq(t, "POST", srv.URL+"/v1/users", "tok-agent", body)
+	if resp.StatusCode != 403 {
+		t.Fatalf("status: %d", resp.StatusCode)
+	}
+}
+
+func TestCreateAgent_byOtherUser_403(t *testing.T) {
+	humanA := uuid.New()
+	srv, _, _ := newTestRouter(t, newMemLimiter(), RateConfig{}, map[string]Principal{
+		"tok-a": HumanPrincipal{UserID: humanA},
+	})
+	body := mustJSON(t, map[string]any{
+		"parent_user_id":   uuid.NewString(), // not humanA
+		"display_name":     "x",
+		"permission_scope": []string{"repo:read"},
+	})
+	resp := doReq(t, "POST", srv.URL+"/v1/agents", "tok-a", body)
+	if resp.StatusCode != 403 {
+		t.Fatalf("status: %d", resp.StatusCode)
+	}
+}
+
+func TestRateLimit_429_andRetryAfter(t *testing.T) {
+	humanID := uuid.New()
+	limiter := newMemLimiter()
+	cfg := RateConfig{HumanCapacity: 1, HumanRefillPerSec: 0}
+	srv, _, _ := newTestRouter(t, limiter, cfg, map[string]Principal{
+		"tok": HumanPrincipal{UserID: humanID},
+	})
+	// First call consumes the only token.
+	r1 := doReq(t, "GET", srv.URL+"/v1/users/"+uuid.NewString(), "tok", nil)
+	if r1.StatusCode != 404 { // user not found is fine; rate-limit allowed
+		t.Fatalf("expected 404 got %d", r1.StatusCode)
+	}
+	r2 := doReq(t, "GET", srv.URL+"/v1/users/"+uuid.NewString(), "tok", nil)
+	if r2.StatusCode != 429 {
+		t.Fatalf("expected 429 got %d", r2.StatusCode)
+	}
+	if r2.Header.Get("Retry-After") == "" {
+		t.Error("Retry-After missing")
+	}
+}
+
+func TestRateLimit_failsClosedOnBackendError(t *testing.T) {
+	humanID := uuid.New()
+	cfg := RateConfig{HumanCapacity: 10, HumanRefillPerSec: 1}
+	srv, _, _ := newTestRouter(t, brokenLimiter{}, cfg, map[string]Principal{
+		"tok": HumanPrincipal{UserID: humanID},
+	})
+	resp := doReq(t, "GET", srv.URL+"/v1/users/"+uuid.NewString(), "tok", nil)
+	if resp.StatusCode != 500 {
+		t.Fatalf("expected 500 got %d", resp.StatusCode)
+	}
+}
+
+func TestRequestID_passthrough(t *testing.T) {
+	humanID := uuid.New()
+	srv, _, _ := newTestRouter(t, newMemLimiter(), RateConfig{}, map[string]Principal{
+		"tok": HumanPrincipal{UserID: humanID},
+	})
+	want := uuid.NewString()
+	req, _ := http.NewRequest("GET", srv.URL+"/healthz", nil)
+	req.Header.Set("X-Request-Id", want)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("do: %v", err)
+	}
+	if resp.Header.Get(requestIDHeader) != want {
+		t.Errorf("X-Request-Id: got %q want %q", resp.Header.Get(requestIDHeader), want)
+	}
+}
+
+func TestRequestID_garbageInputReplaced(t *testing.T) {
+	srv, _, _ := newTestRouter(t, newMemLimiter(), RateConfig{}, nil)
+	req, _ := http.NewRequest("GET", srv.URL+"/healthz", nil)
+	req.Header.Set("X-Request-Id", "<script>alert(1)</script>")
+	resp, _ := http.DefaultClient.Do(req)
+	got := resp.Header.Get(requestIDHeader)
+	if got == "<script>alert(1)</script>" {
+		t.Errorf("garbage X-Request-Id was not replaced: %q", got)
+	}
+	if _, err := uuid.Parse(got); err != nil {
+		t.Errorf("X-Request-Id should be UUID, got %q (%v)", got, err)
+	}
+}
+
+func TestDeleteRepo_501(t *testing.T) {
+	humanID := uuid.New()
+	srv, _, _ := newTestRouter(t, newMemLimiter(), RateConfig{}, map[string]Principal{
+		"tok": HumanPrincipal{UserID: humanID},
+	})
+	resp := doReq(t, "DELETE", srv.URL+"/v1/repos/"+uuid.NewString(), "tok", nil)
+	if resp.StatusCode != 501 {
+		t.Fatalf("status: %d", resp.StatusCode)
+	}
+}
+
+func TestCreateAndGetRepo_HumanFlow(t *testing.T) {
+	humanID := uuid.New()
+	srv, _, _ := newTestRouter(t, newMemLimiter(), RateConfig{}, map[string]Principal{
+		"tok": HumanPrincipal{UserID: humanID},
+	})
+	orgID := uuid.New()
+	body := mustJSON(t, map[string]string{
+		"org_id":     orgID.String(),
+		"slug":       "demo-repo",
+		"name":       "Demo Repo",
+		"visibility": "private",
+	})
+	resp := doReq(t, "POST", srv.URL+"/v1/repos", "tok", body)
+	if resp.StatusCode != 201 {
+		dump, _ := io.ReadAll(resp.Body)
+		t.Fatalf("create status: %d body=%s", resp.StatusCode, dump)
+	}
+	var created repositoryResponse
+	_ = json.NewDecoder(resp.Body).Decode(&created)
+	_ = resp.Body.Close()
+
+	resp = doReq(t, "GET", srv.URL+"/v1/repos/"+created.ID, "tok", nil)
+	if resp.StatusCode != 200 {
+		t.Fatalf("get status: %d", resp.StatusCode)
+	}
+	var got repositoryResponse
+	_ = json.NewDecoder(resp.Body).Decode(&got)
+	if got.ID != created.ID || got.Slug != "demo-repo" {
+		t.Errorf("round-trip mismatch: %+v", got)
+	}
+}
+
+func TestCreateRepo_byAgent_403(t *testing.T) {
+	agentID := uuid.New()
+	srv, _, _ := newTestRouter(t, newMemLimiter(), RateConfig{}, map[string]Principal{
+		"tok": AgentPrincipal{AgentID: agentID, ParentUserID: uuid.New()},
+	})
+	body := mustJSON(t, map[string]string{
+		"org_id": uuid.NewString(), "slug": "x", "name": "X",
+	})
+	resp := doReq(t, "POST", srv.URL+"/v1/repos", "tok", body)
+	if resp.StatusCode != 403 {
+		t.Fatalf("status: %d", resp.StatusCode)
+	}
+}
+
+func TestListOrgRepos_paginates(t *testing.T) {
+	humanID := uuid.New()
+	srv, _, repoSvc := newTestRouter(t, newMemLimiter(), RateConfig{}, map[string]Principal{
+		"tok": HumanPrincipal{UserID: humanID},
+	})
+	orgID := uuid.New()
+	const total = 25
+	for i := 0; i < total; i++ {
+		_, err := repoSvc.CreateRepository(context.Background(), repositories.CreateInput{
+			OrgID:   orgID,
+			OwnerID: humanID,
+			Slug:    "repo-" + strings.Repeat("a", 1) + uuid.NewString()[:8],
+			Name:    "n",
+		})
+		if err != nil {
+			t.Fatalf("seed %d: %v", i, err)
+		}
+	}
+	seen := map[string]struct{}{}
+	cursor := ""
+	const pageSize = 10
+	pages := 0
+	for {
+		url := srv.URL + "/v1/orgs/" + orgID.String() + "/repos?limit=10"
+		if cursor != "" {
+			url += "&cursor=" + cursor
+		}
+		resp := doReq(t, "GET", url, "tok", nil)
+		if resp.StatusCode != 200 {
+			body, _ := io.ReadAll(resp.Body)
+			t.Fatalf("page %d status: %d body=%s", pages, resp.StatusCode, body)
+		}
+		var lr listResponse
+		_ = json.NewDecoder(resp.Body).Decode(&lr)
+		_ = resp.Body.Close()
+		for _, it := range lr.Items {
+			if _, dup := seen[it.ID]; dup {
+				t.Errorf("duplicate id across pages: %s", it.ID)
+			}
+			seen[it.ID] = struct{}{}
+		}
+		pages++
+		if lr.NextCursor == "" {
+			break
+		}
+		cursor = lr.NextCursor
+		if pages > total {
+			t.Fatal("pagination did not terminate")
+		}
+		_ = pageSize
+	}
+	if len(seen) != total {
+		t.Errorf("seen %d items, want %d", len(seen), total)
+	}
+}

--- a/plane/data/compliance/metadatastore.go
+++ b/plane/data/compliance/metadatastore.go
@@ -341,21 +341,26 @@ func RunMetadataStoreCompliance(t *testing.T, factory MetadataStoreFactory, opts
 		}
 	})
 
-	t.Run("Domain_reader_stubs_return_sentinel", func(t *testing.T) {
+	t.Run("RepositoryReader_unknown_id_returns_nil_no_error", func(t *testing.T) {
 		s, _, cleanup := factory(t)
 		defer cleanup()
 		ctx := context.Background()
 
-		// RepositoryReader methods are not implemented in #14; they must return
-		// a non-nil error and not panic.
+		// RepositoryReader gained a working implementation in issue #111
+		// (REST API HTTP layer). The not-found contract is (nil, nil): the
+		// caller distinguishes existence from error rather than overloading
+		// a sentinel. Implementations must not panic.
 		defer func() {
 			if r := recover(); r != nil {
 				t.Errorf("RepositoryReader.GetByID panicked: %v", r)
 			}
 		}()
-		_, err := s.Repositories().GetByID(ctx, uuid.New())
-		if err == nil {
-			t.Error("expected RepositoryReader.GetByID to return sentinel error")
+		got, err := s.Repositories().GetByID(ctx, uuid.New())
+		if err != nil {
+			t.Errorf("unknown id should not error, got %v", err)
+		}
+		if got != nil {
+			t.Errorf("unknown id should yield nil, got %+v", got)
 		}
 	})
 }

--- a/plane/data/events/repositories/repositories.repository_created.schema.json
+++ b/plane/data/events/repositories/repositories.repository_created.schema.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://gitscale.io/events/repositories/repositories.repository_created.schema.json",
+  "title": "repositories.repository_created",
+  "description": "Emitted when a row is inserted into repositories.repositories. Payload of the repositories_outbox row whose event_type = 'repositories.repository_created'.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "repository_id",
+    "org_id",
+    "owner_id",
+    "slug",
+    "name",
+    "default_branch",
+    "visibility",
+    "created_at",
+    "_envelope_version"
+  ],
+  "properties": {
+    "repository_id": { "type": "string", "format": "uuid" },
+    "org_id":        { "type": "string", "format": "uuid" },
+    "owner_id":      { "type": "string", "format": "uuid" },
+    "slug":          { "type": "string", "minLength": 1, "maxLength": 100 },
+    "name":          { "type": "string", "minLength": 1 },
+    "default_branch":{ "type": "string", "minLength": 1 },
+    "visibility":    { "type": "string", "enum": ["public", "private", "internal"] },
+    "created_at":    { "type": "string", "format": "date-time" },
+    "_envelope_version": { "type": "integer", "minimum": 1 }
+  }
+}

--- a/plane/data/events/repositories/repositories.repository_created.testdata/basic.json
+++ b/plane/data/events/repositories/repositories.repository_created.testdata/basic.json
@@ -1,0 +1,11 @@
+{
+  "repository_id": "01931a4b-9c10-7000-8000-000000000010",
+  "org_id":        "01931a4b-9c10-7000-8000-000000000020",
+  "owner_id":      "01931a4b-9c10-7000-8000-000000000030",
+  "slug":          "demo-repo",
+  "name":          "Demo Repo",
+  "default_branch":"main",
+  "visibility":    "private",
+  "created_at":    "2026-05-09T08:00:00.000000Z",
+  "_envelope_version": 1
+}

--- a/plane/data/migrations/010_repositories_keyset_index.sql
+++ b/plane/data/migrations/010_repositories_keyset_index.sql
@@ -1,0 +1,10 @@
+-- Issue #111 — REST API HTTP layer.
+--
+-- Adds the keyset-pagination index for GET /v1/orgs/{org}/repos which
+-- runs `WHERE org_id = $1 AND (created_at, id) > ($2, $3) ORDER BY
+-- created_at, id LIMIT $4`. The composite (org_id, created_at, id) is
+-- the minimum index that supports both the equality on org_id and the
+-- row-value comparison on (created_at, id) without a sort step.
+
+CREATE INDEX IF NOT EXISTS idx_repositories_org_keyset
+  ON repositories.repositories (org_id, created_at, id);

--- a/plane/data/store/metadata.go
+++ b/plane/data/store/metadata.go
@@ -132,23 +132,43 @@ type IdentityWriter interface {
 }
 
 // Repository is the repositories.repositories row model (minimal projection).
+//
+// Name + OwnerID + Visibility are required by the underlying SQL schema
+// (see migrations/002_repositories.sql); they were added to this struct in
+// the REST API layer (issue #111) which needs to round-trip them.
 type Repository struct {
 	ID            uuid.UUID
-	Slug          string
 	OrgID         uuid.UUID
+	Name          string
+	Slug          string
+	OwnerID       uuid.UUID
+	DefaultBranch string
+	Visibility    string
 	ReplicaSetID  string
 	HomeRegion    string
 	CreatedAt     time.Time
+	UpdatedAt     time.Time
 }
 
 // RepositoryReader exposes read-only queries against the repositories domain.
 type RepositoryReader interface {
 	GetByID(ctx context.Context, id uuid.UUID) (*Repository, error)
 	GetBySlug(ctx context.Context, slug string) (*Repository, error)
+	// ListByOrg returns repositories belonging to orgID with stable
+	// (created_at, id) ordering, starting strictly after the supplied
+	// cursor (nil cursors mean start). limit is the maximum number of rows
+	// returned; the caller is responsible for capping it (REST handler
+	// caps at 100 per ADR-017 cost analysis).
+	ListByOrg(
+		ctx context.Context,
+		orgID uuid.UUID,
+		afterCreatedAt *time.Time,
+		afterID *uuid.UUID,
+		limit int,
+	) ([]Repository, error)
 }
 
 // RepositoryWriter exposes write operations against the repositories domain.
-// Not implemented in #14; bodies return errNotImplemented.
 type RepositoryWriter interface {
 	RepositoryReader
 	Insert(ctx context.Context, r Repository) error

--- a/plane/data/store/postgres/compliance_test.go
+++ b/plane/data/store/postgres/compliance_test.go
@@ -57,6 +57,7 @@ func TestPostgresMetadataStoreCompliance(t *testing.T) {
 			"007_billing_partition_archives.sql",
 			"008_updated_at_triggers.sql",
 			"009_identity_temporal_columns.sql",
+			"010_repositories_keyset_index.sql",
 		} {
 			sql, err := os.ReadFile(filepath.Join(migrationsDir, f))
 			if err != nil {

--- a/plane/data/store/postgres/repository.go
+++ b/plane/data/store/postgres/repository.go
@@ -2,31 +2,165 @@ package postgres
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"time"
 
 	"github.com/gitscale-platform/gitscale/plane/data/store"
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
 )
 
 type repositoryReader struct {
 	q querier
 }
 
-func (r *repositoryReader) GetByID(_ context.Context, _ uuid.UUID) (*store.Repository, error) {
-	return nil, errNotImplemented
+func (r *repositoryReader) GetByID(ctx context.Context, id uuid.UUID) (*store.Repository, error) {
+	const q = `
+		SELECT id, org_id, name, slug, owner_id, default_branch, visibility,
+		       replica_set_id, home_region, created_at, updated_at
+		FROM repositories.repositories WHERE id = $1`
+	out := &store.Repository{}
+	var replicaSet, homeRegion *string
+	err := r.q.QueryRow(ctx, q, id).Scan(
+		&out.ID, &out.OrgID, &out.Name, &out.Slug, &out.OwnerID,
+		&out.DefaultBranch, &out.Visibility,
+		&replicaSet, &homeRegion, &out.CreatedAt, &out.UpdatedAt,
+	)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("postgres: GetByID: %w", err)
+	}
+	if replicaSet != nil {
+		out.ReplicaSetID = *replicaSet
+	}
+	if homeRegion != nil {
+		out.HomeRegion = *homeRegion
+	}
+	return out, nil
 }
 
-func (r *repositoryReader) GetBySlug(_ context.Context, _ string) (*store.Repository, error) {
-	return nil, errNotImplemented
+func (r *repositoryReader) GetBySlug(ctx context.Context, slug string) (*store.Repository, error) {
+	const q = `
+		SELECT id, org_id, name, slug, owner_id, default_branch, visibility,
+		       replica_set_id, home_region, created_at, updated_at
+		FROM repositories.repositories WHERE slug = $1
+		ORDER BY created_at, id LIMIT 1`
+	out := &store.Repository{}
+	var replicaSet, homeRegion *string
+	err := r.q.QueryRow(ctx, q, slug).Scan(
+		&out.ID, &out.OrgID, &out.Name, &out.Slug, &out.OwnerID,
+		&out.DefaultBranch, &out.Visibility,
+		&replicaSet, &homeRegion, &out.CreatedAt, &out.UpdatedAt,
+	)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("postgres: GetBySlug: %w", err)
+	}
+	if replicaSet != nil {
+		out.ReplicaSetID = *replicaSet
+	}
+	if homeRegion != nil {
+		out.HomeRegion = *homeRegion
+	}
+	return out, nil
+}
+
+// ListByOrg implements keyset pagination on (created_at, id). When both
+// afterCreatedAt and afterID are non-nil the WHERE clause uses the row-value
+// comparison `(created_at, id) > ($2, $3)`. nil cursors fall through the
+// equivalent `IS NULL` branch which returns the first page.
+func (r *repositoryReader) ListByOrg(
+	ctx context.Context,
+	orgID uuid.UUID,
+	afterCreatedAt *time.Time,
+	afterID *uuid.UUID,
+	limit int,
+) ([]store.Repository, error) {
+	if limit <= 0 {
+		return nil, nil
+	}
+	const q = `
+		SELECT id, org_id, name, slug, owner_id, default_branch, visibility,
+		       replica_set_id, home_region, created_at, updated_at
+		FROM repositories.repositories
+		WHERE org_id = $1
+		  AND ($2::timestamptz IS NULL OR (created_at, id) > ($2, $3))
+		ORDER BY created_at, id
+		LIMIT $4`
+	rows, err := r.q.Query(ctx, q, orgID, afterCreatedAt, afterID, limit)
+	if err != nil {
+		return nil, fmt.Errorf("postgres: ListByOrg: %w", err)
+	}
+	defer rows.Close()
+
+	var out []store.Repository
+	for rows.Next() {
+		var rep store.Repository
+		var replicaSet, homeRegion *string
+		if err := rows.Scan(
+			&rep.ID, &rep.OrgID, &rep.Name, &rep.Slug, &rep.OwnerID,
+			&rep.DefaultBranch, &rep.Visibility,
+			&replicaSet, &homeRegion, &rep.CreatedAt, &rep.UpdatedAt,
+		); err != nil {
+			return nil, fmt.Errorf("postgres: ListByOrg scan: %w", err)
+		}
+		if replicaSet != nil {
+			rep.ReplicaSetID = *replicaSet
+		}
+		if homeRegion != nil {
+			rep.HomeRegion = *homeRegion
+		}
+		out = append(out, rep)
+	}
+	return out, rows.Err()
 }
 
 type repositoryWriter struct {
 	repositoryReader
 }
 
-func (w *repositoryWriter) Insert(_ context.Context, _ store.Repository) error {
-	return errNotImplemented
+// Insert writes a row to repositories.repositories. The caller has already
+// generated r.ID and is expected to be inside a Tx; the same Tx must also
+// write the outbox row (ADR-008).
+func (w *repositoryWriter) Insert(ctx context.Context, r store.Repository) error {
+	const q = `
+		INSERT INTO repositories.repositories
+		  (id, org_id, name, slug, owner_id, default_branch, visibility,
+		   replica_set_id, home_region)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)`
+	visibility := r.Visibility
+	if visibility == "" {
+		visibility = "private"
+	}
+	defaultBranch := r.DefaultBranch
+	if defaultBranch == "" {
+		defaultBranch = "main"
+	}
+	var replicaSet, homeRegion *string
+	if r.ReplicaSetID != "" {
+		s := r.ReplicaSetID
+		replicaSet = &s
+	}
+	if r.HomeRegion != "" {
+		s := r.HomeRegion
+		homeRegion = &s
+	}
+	if _, err := w.q.Exec(ctx, q,
+		r.ID, r.OrgID, r.Name, r.Slug, r.OwnerID,
+		defaultBranch, visibility, replicaSet, homeRegion,
+	); err != nil {
+		return fmt.Errorf("postgres: Insert repository: %w", err)
+	}
+	return nil
 }
 
+// UpdatePermissions is intentionally a no-op stub awaiting issue #112-permissions.
+// The REST API does not expose this surface in #111.
 func (w *repositoryWriter) UpdatePermissions(_ context.Context, _ uuid.UUID, _ string) error {
 	return errNotImplemented
 }

--- a/plane/data/store/stub/metadata.go
+++ b/plane/data/store/stub/metadata.go
@@ -7,13 +7,13 @@ package stub
 import (
 	"context"
 	"errors"
+	"sort"
 	"sync"
+	"time"
 
 	"github.com/gitscale-platform/gitscale/plane/data/store"
 	"github.com/google/uuid"
 )
-
-var errNotImplemented = errors.New("stub: not implemented")
 
 // OutboxRecord captures one WriteOutbox call for test assertions.
 type OutboxRecord struct {
@@ -30,6 +30,7 @@ type Store struct {
 	mu                sync.Mutex
 	users             map[uuid.UUID]*store.HumanUser
 	agents            map[uuid.UUID]*store.AgentIdentity
+	repositories      map[uuid.UUID]*store.Repository
 	partitionArchives map[string]store.PartitionArchive
 	outbox            []OutboxRecord
 }
@@ -39,6 +40,7 @@ func New() *Store {
 	return &Store{
 		users:             make(map[uuid.UUID]*store.HumanUser),
 		agents:            make(map[uuid.UUID]*store.AgentIdentity),
+		repositories:      make(map[uuid.UUID]*store.Repository),
 		partitionArchives: make(map[string]store.PartitionArchive),
 	}
 }
@@ -68,6 +70,9 @@ func (s *Store) Transact(_ context.Context, fn func(store.Tx) error) error {
 	for id, a := range tx.pendingAgents {
 		s.agents[id] = a
 	}
+	for id, r := range tx.pendingRepositories {
+		s.repositories[id] = r
+	}
 	for k, pa := range tx.pendingPartitionArchives {
 		// First-writer-wins on commit: do not overwrite an existing row.
 		// The Tx.Billing() writer already returns the existing id on
@@ -87,7 +92,7 @@ func (s *Store) Identity() store.IdentityReader {
 
 // Repositories returns a stub repository reader.
 func (s *Store) Repositories() store.RepositoryReader {
-	return &stubRepositoryReader{}
+	return &stubRepositoryReader{store: s}
 }
 
 // stubTx is the transaction handle passed to Transact callbacks.
@@ -95,6 +100,7 @@ type stubTx struct {
 	store                    *Store
 	pendingUsers             map[uuid.UUID]*store.HumanUser
 	pendingAgents            map[uuid.UUID]*store.AgentIdentity
+	pendingRepositories      map[uuid.UUID]*store.Repository
 	pendingPartitionArchives map[string]store.PartitionArchive
 	pendingOutbox            []OutboxRecord
 }
@@ -106,6 +112,9 @@ func (t *stubTx) lazyInit() {
 	if t.pendingAgents == nil {
 		t.pendingAgents = make(map[uuid.UUID]*store.AgentIdentity)
 	}
+	if t.pendingRepositories == nil {
+		t.pendingRepositories = make(map[uuid.UUID]*store.Repository)
+	}
 }
 
 func (t *stubTx) Identity() store.IdentityWriter {
@@ -113,7 +122,7 @@ func (t *stubTx) Identity() store.IdentityWriter {
 }
 
 func (t *stubTx) Repositories() store.RepositoryWriter {
-	return &stubRepositoryWriter{}
+	return &stubRepositoryWriter{tx: t, reader: &stubRepositoryReader{store: t.store}}
 }
 
 func (t *stubTx) WriteOutbox(
@@ -343,22 +352,120 @@ func (w *stubIdentityWriter) RemoveOrgMember(_ context.Context, _, _ uuid.UUID) 
 	return nil
 }
 
-type stubRepositoryReader struct{}
-
-func (r *stubRepositoryReader) GetByID(_ context.Context, _ uuid.UUID) (*store.Repository, error) {
-	return nil, errNotImplemented
+type stubRepositoryReader struct {
+	store *Store
 }
 
-func (r *stubRepositoryReader) GetBySlug(_ context.Context, _ string) (*store.Repository, error) {
-	return nil, errNotImplemented
+func (r *stubRepositoryReader) GetByID(_ context.Context, id uuid.UUID) (*store.Repository, error) {
+	r.store.mu.Lock()
+	defer r.store.mu.Unlock()
+	rep := r.store.repositories[id]
+	if rep == nil {
+		return nil, nil
+	}
+	cp := *rep
+	return &cp, nil
 }
 
-type stubRepositoryWriter struct{ stubRepositoryReader }
+func (r *stubRepositoryReader) GetBySlug(_ context.Context, slug string) (*store.Repository, error) {
+	r.store.mu.Lock()
+	defer r.store.mu.Unlock()
+	for _, rep := range r.store.repositories {
+		if rep.Slug == slug {
+			cp := *rep
+			return &cp, nil
+		}
+	}
+	return nil, nil
+}
 
-func (w *stubRepositoryWriter) Insert(_ context.Context, _ store.Repository) error {
-	return errNotImplemented
+func (r *stubRepositoryReader) ListByOrg(
+	_ context.Context,
+	orgID uuid.UUID,
+	afterCreatedAt *time.Time,
+	afterID *uuid.UUID,
+	limit int,
+) ([]store.Repository, error) {
+	if limit <= 0 {
+		return nil, nil
+	}
+	r.store.mu.Lock()
+	defer r.store.mu.Unlock()
+
+	var all []store.Repository
+	for _, rep := range r.store.repositories {
+		if rep.OrgID != orgID {
+			continue
+		}
+		all = append(all, *rep)
+	}
+	sort.Slice(all, func(i, j int) bool {
+		if !all[i].CreatedAt.Equal(all[j].CreatedAt) {
+			return all[i].CreatedAt.Before(all[j].CreatedAt)
+		}
+		return all[i].ID.String() < all[j].ID.String()
+	})
+
+	out := make([]store.Repository, 0, limit)
+	for _, rep := range all {
+		if afterCreatedAt != nil && afterID != nil {
+			if rep.CreatedAt.Before(*afterCreatedAt) {
+				continue
+			}
+			if rep.CreatedAt.Equal(*afterCreatedAt) && rep.ID.String() <= afterID.String() {
+				continue
+			}
+		}
+		out = append(out, rep)
+		if len(out) >= limit {
+			break
+		}
+	}
+	return out, nil
+}
+
+type stubRepositoryWriter struct {
+	tx     *stubTx
+	reader *stubRepositoryReader
+}
+
+func (w *stubRepositoryWriter) GetByID(ctx context.Context, id uuid.UUID) (*store.Repository, error) {
+	w.tx.lazyInit()
+	if r, ok := w.tx.pendingRepositories[id]; ok {
+		cp := *r
+		return &cp, nil
+	}
+	return w.reader.GetByID(ctx, id)
+}
+
+func (w *stubRepositoryWriter) GetBySlug(ctx context.Context, slug string) (*store.Repository, error) {
+	w.tx.lazyInit()
+	for _, r := range w.tx.pendingRepositories {
+		if r.Slug == slug {
+			cp := *r
+			return &cp, nil
+		}
+	}
+	return w.reader.GetBySlug(ctx, slug)
+}
+
+func (w *stubRepositoryWriter) ListByOrg(
+	ctx context.Context,
+	orgID uuid.UUID,
+	afterCreatedAt *time.Time,
+	afterID *uuid.UUID,
+	limit int,
+) ([]store.Repository, error) {
+	return w.reader.ListByOrg(ctx, orgID, afterCreatedAt, afterID, limit)
+}
+
+func (w *stubRepositoryWriter) Insert(_ context.Context, r store.Repository) error {
+	w.tx.lazyInit()
+	cp := r
+	w.tx.pendingRepositories[r.ID] = &cp
+	return nil
 }
 
 func (w *stubRepositoryWriter) UpdatePermissions(_ context.Context, _ uuid.UUID, _ string) error {
-	return errNotImplemented
+	return errors.New("stub: UpdatePermissions not implemented")
 }

--- a/plane/git/locator/locator_test.go
+++ b/plane/git/locator/locator_test.go
@@ -121,6 +121,10 @@ func (r *stubRepoReader) GetBySlug(_ context.Context, _ string) (*store.Reposito
 	return nil, nil
 }
 
+func (r *stubRepoReader) ListByOrg(_ context.Context, _ uuid.UUID, _ *time.Time, _ *uuid.UUID, _ int) ([]store.Repository, error) {
+	return nil, nil
+}
+
 func TestMetadataLocator_Found(t *testing.T) {
 	repoID := uuid.New()
 	mds := &stubMetadataStore{repos: map[uuid.UUID]store.Repository{


### PR DESCRIPTION
## Summary

- Adds `plane/application/restapi`: stdlib `net/http` ServeMux mounted at `/v1/`, gated by `RequestID -> Auth -> RateLimit` middleware with closed-enum JSON error envelope (`unauthenticated | forbidden | not_found | validation_failed | conflict | rate_limited | internal`).
- Adds `plane/application/repositories` Service that pairs source row + outbox row in the same Tx (ADR-008) emitting `repositories.repository_created`; fills in the previously-stubbed postgres and stub `RepositoryWriter` impls.
- Adds keyset pagination (`GET /v1/orgs/{org}/repos`) backed by a new `RepositoryReader.ListByOrg(ctx, orgID, afterCreatedAt, afterID, limit)` and migration `010_repositories_keyset_index.sql` covering `(org_id, created_at, id)`.
- New `cmd/rest-api` binary wires postgres + memory rate-limiter (Redis pluggable later via the `ratelimit.RateLimiter` swap surface, ADR-009/ADR-017).

## ADR-impact

Conforming. ADR-008 outbox: source + outbox in same Tx for `repositories.repository_created`. ADR-009/ADR-017: Service depends only on `MetadataStore`, `RateLimiter`, `PrincipalResolver` interfaces. ADR-019 plane boundary: package imports neither `plane/git` nor `plane/workflow`.

## Test plan

- [x] `go build ./... && go vet ./...` clean
- [x] `golangci-lint run ./...` clean
- [x] `go test -race ./plane/application/... ./plane/data/store/... ./cmd/rest-api/...` green (unit + handler + middleware + outbox tests)
- [x] `make lint-events` green (new `repositories.repository_created` schema + fixture validate)
- [x] `make lint-determinism` green
- [ ] Integration tests (`-tags integration`) require Docker; gated to CI runners with testcontainers Postgres

## Out of scope (follow-ups)

- `DELETE /v1/repos/{id}` returns documented `501 internal` until a cascade-delete + git-plane deprovision pipeline lands; URL space reserved.
- JWT-SVID bearer format (ADR-010) — current resolver accepts a UUID-shaped opaque token; signed-token path lands with edge-plane wiring.
- Redis-backed rate limiter binding for `cmd/rest-api` — currently boots `MemoryLimiter`; swap is a constructor change.

## Cross-links

- Spec: `docs/superpowers/specs/2026-05-09-issue-111-rest-api-http-layer-design.md`
- Plan: `docs/superpowers/plans/2026-05-09-issue-111-rest-api-http-layer-plan.md`

Closes #111

<details>
<summary>Self-review battery</summary>

Self-reviewed against pr-review-toolkit (code-reviewer, silent-failure-hunter, pr-test-analyzer), adr-historian, and gitscale-{adr-guard,outbox-check,plane-boundary,go-conventions,event-schema} skills.

- mapErr is exhaustive over identity + repositories sentinels with a logged default case (no silent 500 fallthrough).
- Rate-limit middleware fails closed on backend error (covered by `TestRateLimit_failsClosedOnBackendError`).
- Auth runs before rate-limit so anonymous traffic cannot drain a real principal's bucket; documented in `router.go`.
- `repositories.Service.CreateRepository` writes outbox in the same Tx as the source row; `TestCreateRepository_writesSourceAndOutboxInSameTx` asserts the pairing.
- New event `repositories.repository_created` has schema + fixture under `plane/data/events/repositories/`; `make lint-events` validates.
- No `plane/git` or `plane/workflow` imports inside `plane/application/restapi` or `plane/application/repositories`.

</details>

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>