### PR TITLE
[Application/Workflow] Plan-approval full policy DSL + escalation (ADR-019)

### DIFF
--- a/plane/application/policy/audit.go
+++ b/plane/application/policy/audit.go
@@ -1,0 +1,220 @@
+package policy
+
+import (
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// AuditEventKind enumerates the categories of audit events. Strings are the
+// canonical wire encoding and match the values stored in
+// application.policy_audit.event_kind.
+type AuditEventKind string
+
+const (
+	AuditEventSubmitted          AuditEventKind = "submitted"
+	AuditEventApproved           AuditEventKind = "approved"
+	AuditEventRejected           AuditEventKind = "rejected"
+	AuditEventEscalated          AuditEventKind = "escalated"
+	AuditEventExpired            AuditEventKind = "expired"
+	AuditEventAutoApprovedNoRule AuditEventKind = "auto_approved_no_rule"
+	AuditEventAutoDenied         AuditEventKind = "auto_denied"
+)
+
+// IsValid reports whether k is one of the closed enum values.
+func (k AuditEventKind) IsValid() bool {
+	switch k {
+	case AuditEventSubmitted, AuditEventApproved, AuditEventRejected,
+		AuditEventEscalated, AuditEventExpired,
+		AuditEventAutoApprovedNoRule, AuditEventAutoDenied:
+		return true
+	}
+	return false
+}
+
+// ActorKind enumerates the principal types that can author an audit event.
+type ActorKind string
+
+const (
+	ActorKindHuman   ActorKind = "human"
+	ActorKindAgent   ActorKind = "agent"
+	ActorKindService ActorKind = "service"
+	ActorKindSystem  ActorKind = "system" // for system-emitted events (no actor_id)
+)
+
+// IsValid reports whether k is one of the closed enum values.
+func (k ActorKind) IsValid() bool {
+	switch k {
+	case ActorKindHuman, ActorKindAgent, ActorKindService, ActorKindSystem:
+		return true
+	}
+	return false
+}
+
+// AuditRow is one row of the per-policy Merkle-chained audit log. Genesis
+// row carries PrevHash = 32 zero bytes; subsequent rows carry the previous
+// row's RowHash. Tampering with any payload field invalidates RowHash on
+// re-computation, which the verification routine surfaces.
+type AuditRow struct {
+	ID         int64           // bigserial; assigned by the DB
+	PolicyID   uuid.UUID
+	PlanID     *uuid.UUID
+	EventKind  AuditEventKind
+	ActorID    *uuid.UUID      // nil for ActorKindSystem
+	ActorKind  ActorKind
+	Payload    json.RawMessage // canonicalised JSON payload
+	PrevHash   [32]byte
+	RowHash    [32]byte
+	CreatedAt  time.Time
+}
+
+// GenesisHash is the conventional 32-byte zero PrevHash for the first row
+// of a policy's audit chain. Stored explicitly rather than implicitly so
+// off-line replays can detect a missing first row.
+var GenesisHash = [32]byte{}
+
+// CanonicalPayload re-emits payload as canonical JSON: top-level object
+// keys sorted, no whitespace. Required for stable hashing across writers
+// that may serialise maps in different orders. Returns the bytes plus an
+// error if the payload is not a valid JSON object or array.
+func CanonicalPayload(payload json.RawMessage) ([]byte, error) {
+	if len(payload) == 0 {
+		return []byte("null"), nil
+	}
+	var v any
+	if err := json.Unmarshal(payload, &v); err != nil {
+		return nil, fmt.Errorf("policy: audit payload not valid JSON: %w", err)
+	}
+	return canonicalize(v)
+}
+
+// canonicalize emits any JSON value with sorted object keys and no
+// whitespace. Recursive on maps and slices.
+func canonicalize(v any) ([]byte, error) {
+	switch t := v.(type) {
+	case map[string]any:
+		keys := make([]string, 0, len(t))
+		for k := range t {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		var buf []byte
+		buf = append(buf, '{')
+		for i, k := range keys {
+			if i > 0 {
+				buf = append(buf, ',')
+			}
+			kj, err := json.Marshal(k)
+			if err != nil {
+				return nil, err
+			}
+			buf = append(buf, kj...)
+			buf = append(buf, ':')
+			vj, err := canonicalize(t[k])
+			if err != nil {
+				return nil, err
+			}
+			buf = append(buf, vj...)
+		}
+		buf = append(buf, '}')
+		return buf, nil
+	case []any:
+		var buf []byte
+		buf = append(buf, '[')
+		for i, e := range t {
+			if i > 0 {
+				buf = append(buf, ',')
+			}
+			ej, err := canonicalize(e)
+			if err != nil {
+				return nil, err
+			}
+			buf = append(buf, ej...)
+		}
+		buf = append(buf, ']')
+		return buf, nil
+	default:
+		// Scalars (string, float64, bool, nil) — json.Marshal already
+		// emits canonical form.
+		return json.Marshal(v)
+	}
+}
+
+// ComputeRowHash returns the Merkle hash of a row given its predecessor
+// hash. The hash covers (prev_hash || canonical(payload) || actor_kind ||
+// event_kind || actor_id_or_zero || created_at_unix_nano). Order is fixed;
+// adding fields requires a chain version bump and migration.
+func ComputeRowHash(prev [32]byte, r AuditRow) ([32]byte, error) {
+	canon, err := CanonicalPayload(r.Payload)
+	if err != nil {
+		return [32]byte{}, err
+	}
+	h := sha256.New()
+	_, _ = h.Write(prev[:])
+	_, _ = h.Write(canon)
+	_, _ = h.Write([]byte(r.ActorKind))
+	_, _ = h.Write([]byte{0x1f}) // unit separator to avoid kind/event_kind collision
+	_, _ = h.Write([]byte(r.EventKind))
+	_, _ = h.Write([]byte{0x1f})
+	if r.ActorID != nil {
+		id := *r.ActorID
+		_, _ = h.Write(id[:])
+	} else {
+		var zero [16]byte
+		_, _ = h.Write(zero[:])
+	}
+	var ts [8]byte
+	nano := r.CreatedAt.UTC().UnixNano()
+	for i := 0; i < 8; i++ {
+		ts[7-i] = byte(nano >> (8 * i))
+	}
+	_, _ = h.Write(ts[:])
+	var out [32]byte
+	copy(out[:], h.Sum(nil))
+	return out, nil
+}
+
+// VerifyChain replays rows in slice order and reports the first row whose
+// stored RowHash does not match the recomputed value, or whose PrevHash
+// does not match the predecessor's RowHash. Returns (-1, nil) on success.
+//
+// rows must be ordered by ascending ID. The first row's PrevHash MUST equal
+// GenesisHash; otherwise the genesis violation is surfaced as breakIndex=0.
+func VerifyChain(rows []AuditRow) (int, error) {
+	prev := GenesisHash
+	for i, r := range rows {
+		if r.PrevHash != prev {
+			return i, fmt.Errorf("policy: row %d prev_hash mismatch", i)
+		}
+		got, err := ComputeRowHash(prev, r)
+		if err != nil {
+			return i, err
+		}
+		if got != r.RowHash {
+			return i, fmt.Errorf("policy: row %d row_hash mismatch (tampering detected)", i)
+		}
+		prev = got
+	}
+	return -1, nil
+}
+
+// AppendRow stamps PrevHash and RowHash on r in place using the supplied
+// predecessor hash. Callers persist r inside a Tx that has already taken
+// the per-policy SELECT … FOR UPDATE on the latest row to serialise
+// concurrent appends (avoids hash forks).
+func AppendRow(prev [32]byte, r *AuditRow) error {
+	r.PrevHash = prev
+	if r.CreatedAt.IsZero() {
+		r.CreatedAt = time.Now().UTC()
+	}
+	hash, err := ComputeRowHash(prev, *r)
+	if err != nil {
+		return err
+	}
+	r.RowHash = hash
+	return nil
+}

--- a/plane/application/policy/audit_test.go
+++ b/plane/application/policy/audit_test.go
@@ -1,0 +1,140 @@
+package policy
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// buildChain produces n linked audit rows for tests. CreatedAt is monotone
+// so determinism doesn't depend on time.Now resolution.
+func buildChain(t *testing.T, n int) []AuditRow {
+	t.Helper()
+	policyID := uuid.New()
+	rows := make([]AuditRow, n)
+	prev := GenesisHash
+	base := time.Date(2026, 5, 9, 0, 0, 0, 0, time.UTC)
+	for i := 0; i < n; i++ {
+		actor := uuid.New()
+		payload, _ := json.Marshal(map[string]any{"i": i, "label": "evt"})
+		rows[i] = AuditRow{
+			ID:        int64(i + 1),
+			PolicyID:  policyID,
+			EventKind: AuditEventSubmitted,
+			ActorID:   &actor,
+			ActorKind: ActorKindAgent,
+			Payload:   payload,
+			CreatedAt: base.Add(time.Duration(i) * time.Second),
+		}
+		if err := AppendRow(prev, &rows[i]); err != nil {
+			t.Fatal(err)
+		}
+		prev = rows[i].RowHash
+	}
+	return rows
+}
+
+func TestAuditChain_GenesisVerifies(t *testing.T) {
+	rows := buildChain(t, 1)
+	if rows[0].PrevHash != GenesisHash {
+		t.Fatalf("genesis prev_hash must be all zero, got %x", rows[0].PrevHash)
+	}
+	idx, err := VerifyChain(rows)
+	if err != nil {
+		t.Fatalf("verify: %v", err)
+	}
+	if idx != -1 {
+		t.Errorf("want -1, got %d", idx)
+	}
+}
+
+func TestAuditChain_VerifyN(t *testing.T) {
+	for _, n := range []int{1, 100, 1000} {
+		rows := buildChain(t, n)
+		idx, err := VerifyChain(rows)
+		if err != nil {
+			t.Errorf("n=%d verify error: %v", n, err)
+		}
+		if idx != -1 {
+			t.Errorf("n=%d want -1, got %d", n, idx)
+		}
+	}
+}
+
+func TestAuditChain_PayloadTamperDetected(t *testing.T) {
+	rows := buildChain(t, 5)
+	// Mutate row 2's payload (in JSON form). The recompute will produce a
+	// different RowHash; VerifyChain must surface row 2.
+	rows[2].Payload = json.RawMessage(`{"i":99,"label":"tampered"}`)
+	idx, err := VerifyChain(rows)
+	if idx != 2 || err == nil {
+		t.Errorf("tamper not detected: idx=%d err=%v", idx, err)
+	}
+}
+
+func TestAuditChain_PrevHashTamperDetected(t *testing.T) {
+	rows := buildChain(t, 5)
+	rows[3].PrevHash[0] ^= 0xff
+	idx, err := VerifyChain(rows)
+	if idx != 3 || err == nil {
+		t.Errorf("prev_hash tamper not detected: idx=%d err=%v", idx, err)
+	}
+}
+
+func TestAuditChain_ActorKindTamperDetected(t *testing.T) {
+	rows := buildChain(t, 3)
+	rows[1].ActorKind = ActorKindHuman // was ActorKindAgent
+	idx, err := VerifyChain(rows)
+	if idx != 1 || err == nil {
+		t.Errorf("actor_kind tamper not detected: idx=%d err=%v", idx, err)
+	}
+}
+
+func TestCanonicalPayload_StableAcrossKeyOrder(t *testing.T) {
+	a := json.RawMessage(`{"b":2,"a":1,"c":{"y":2,"x":1}}`)
+	b := json.RawMessage(`{"a":1,"c":{"x":1,"y":2},"b":2}`)
+	ca, err := CanonicalPayload(a)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cb, err := CanonicalPayload(b)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(ca) != string(cb) {
+		t.Errorf("canonical not stable: %s vs %s", ca, cb)
+	}
+}
+
+func TestCanonicalPayload_RejectsInvalidJSON(t *testing.T) {
+	_, err := CanonicalPayload(json.RawMessage(`{not-json`))
+	if err == nil {
+		t.Fatal("expected error on invalid JSON")
+	}
+}
+
+func TestAuditEventKind_IsValid(t *testing.T) {
+	for _, k := range []AuditEventKind{AuditEventSubmitted, AuditEventApproved,
+		AuditEventRejected, AuditEventEscalated, AuditEventExpired,
+		AuditEventAutoApprovedNoRule, AuditEventAutoDenied} {
+		if !k.IsValid() {
+			t.Errorf("expected %q valid", k)
+		}
+	}
+	if AuditEventKind("nope").IsValid() {
+		t.Error("garbage kind reported valid")
+	}
+}
+
+func TestActorKind_IsValid(t *testing.T) {
+	for _, k := range []ActorKind{ActorKindHuman, ActorKindAgent, ActorKindService, ActorKindSystem} {
+		if !k.IsValid() {
+			t.Errorf("expected %q valid", k)
+		}
+	}
+	if ActorKind("nope").IsValid() {
+		t.Error("garbage actor_kind reported valid")
+	}
+}

--- a/plane/application/policy/doc.go
+++ b/plane/application/policy/doc.go
@@ -1,0 +1,20 @@
+// Package policy is the application-plane plan-approval policy engine. It
+// defines the Policy DSL, evaluates policy predicates against agent-proposed
+// plans, records decisions on a Merkle-chained audit log, and exposes the
+// Engine interface that gates state-mutating actions behind the
+// human-oversight ladder configured per org and repo.
+//
+// The package is the safety boundary between agent autonomy and human
+// oversight described in ADR-015. Every Policy mutation, every Plan status
+// transition, and every audit append must occur in a single SQL transaction
+// alongside the corresponding outbox row (ADR-008). Workflow-plane callers
+// reach the Engine over gRPC; in-process callers (REST handlers) inject the
+// Engine concrete and call its methods directly.
+//
+// PredicateKind is a closed enum. Adding a kind requires a migration plus an
+// ADR amendment — see ADR-015 for the rule-based-only constraint.
+//
+// HumanUser is the only principal kind allowed in an ApproverGroup
+// (ADR-015): agents cannot approve plans, even on policies that nominally
+// allow agent-decision approvers.
+package policy

--- a/plane/application/policy/dsl.go
+++ b/plane/application/policy/dsl.go
@@ -1,0 +1,126 @@
+package policy
+
+import (
+	"github.com/google/uuid"
+)
+
+// PredicateKind enumerates the predicate matchers the Engine knows how to
+// evaluate. The set is closed: adding a kind requires a migration and an
+// ADR-015 amendment. The string form is the canonical wire encoding inside
+// Policy.Rules[].Kind and is what consumers index on.
+type PredicateKind string
+
+const (
+	// PredicatePRMerge matches PR-merge actions. The Match key "branch" is
+	// compared (exact, case-sensitive) to the action's target branch.
+	PredicatePRMerge PredicateKind = "pr_merge"
+
+	// PredicateForcePush matches a force-push to a ref. The Match key
+	// "ref_pattern" is treated as a glob and compared to the ref name.
+	PredicateForcePush PredicateKind = "force_push"
+
+	// PredicateProductionDeploy matches a production-tier deployment. The
+	// Match key "environment" is compared (exact) to the action's
+	// environment field. ADR-015 designates this kind as the security
+	// class with the 4-hour default approval expiry.
+	PredicateProductionDeploy PredicateKind = "production_deploy"
+
+	// PredicateBulkAction matches when an action set's cardinality meets or
+	// exceeds Rule.Threshold. Used to gate fan-out operations (e.g. closing
+	// >=N issues in one batch).
+	PredicateBulkAction PredicateKind = "bulk_action"
+
+	// PredicateAgentDefault is the catch-all for AGENTS.md "ask first" hints.
+	// It matches any agent-proposed plan when no earlier rule fires; per
+	// first-match-wins semantics it must be the LAST rule in the list, or it
+	// will pre-empt more specific rules.
+	PredicateAgentDefault PredicateKind = "agent_default"
+)
+
+// AllPredicateKinds returns the closed set of predicate kinds the engine
+// understands. Validation uses this set; any kind not present here is
+// rejected as policy_invalid_predicate_kind.
+func AllPredicateKinds() []PredicateKind {
+	return []PredicateKind{
+		PredicatePRMerge,
+		PredicateForcePush,
+		PredicateProductionDeploy,
+		PredicateBulkAction,
+		PredicateAgentDefault,
+	}
+}
+
+// IsValid reports whether k is one of the closed enum values.
+func (k PredicateKind) IsValid() bool {
+	for _, v := range AllPredicateKinds() {
+		if v == k {
+			return true
+		}
+	}
+	return false
+}
+
+// OnTimeout enumerates the disposition of an unresolved escalation rung when
+// its SLA elapses without a quorum decision.
+type OnTimeout string
+
+const (
+	// OnTimeoutNotifyNext escalates to the next rung.
+	OnTimeoutNotifyNext OnTimeout = "notify_next"
+	// OnTimeoutAutoDeny rejects the plan when this rung's SLA elapses.
+	OnTimeoutAutoDeny OnTimeout = "auto_deny"
+	// OnTimeoutFallBack returns to the previous rung. Only valid for rungs
+	// after the first; the first rung cannot fall back.
+	OnTimeoutFallBack OnTimeout = "fall_back"
+)
+
+// IsValid reports whether o is one of the closed enum values.
+func (o OnTimeout) IsValid() bool {
+	switch o {
+	case OnTimeoutNotifyNext, OnTimeoutAutoDeny, OnTimeoutFallBack:
+		return true
+	}
+	return false
+}
+
+// Policy is the org/repo-scoped, signed, versioned plan-approval policy.
+// Rules are evaluated in slice order with first-match-wins semantics.
+// ApproverGroups are referenced by name from each rung's GroupName.
+type Policy struct {
+	ID             uuid.UUID                `json:"id"`
+	OrgID          uuid.UUID                `json:"org_id"`
+	RepoID         *uuid.UUID               `json:"repo_id,omitempty"`
+	Name           string                   `json:"name"`
+	Version        int                      `json:"version"`
+	Rules          []Rule                   `json:"rules"`
+	ApproverGroups map[string]ApproverGroup `json:"approver_groups"`
+}
+
+// Rule pairs a predicate matcher with the escalation ladder that fires when
+// the predicate matches. ExpirySeconds bounds how long a granted approval
+// remains valid; a plan whose hash mutates after approval re-opens the
+// approval cycle (ADR-015 plan-hash binding).
+type Rule struct {
+	Kind          PredicateKind     `json:"kind"`
+	Match         map[string]string `json:"match,omitempty"`
+	Threshold     *int              `json:"threshold,omitempty"`
+	Ladder        []EscalationRung  `json:"ladder"`
+	ExpirySeconds int               `json:"expiry_seconds"`
+}
+
+// ApproverGroup is a k-of-n named group of HumanUser principals. ADR-015
+// forbids non-human approvers; validation enforces this at the type level.
+type ApproverGroup struct {
+	Name          string      `json:"name"`
+	HumanUserIDs  []uuid.UUID `json:"human_user_ids"`
+	RequiredCount int         `json:"required_count"`
+}
+
+// EscalationRung is one step of a Rule's ladder. GroupName must reference a
+// key in the parent Policy.ApproverGroups map. SLASeconds bounds the wait at
+// this rung before OnTimeout fires.
+type EscalationRung struct {
+	GroupName  string    `json:"group_name"`
+	SLASeconds int       `json:"sla_seconds"`
+	OnTimeout  OnTimeout `json:"on_timeout"`
+}

--- a/plane/application/policy/engine.go
+++ b/plane/application/policy/engine.go
@@ -1,0 +1,125 @@
+package policy
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/google/uuid"
+)
+
+// Engine evaluates submitted plans against a Policy and returns a Decision.
+// It is the in-process API exposed to the gRPC service and to in-process
+// callers; the persistence concern (writing the source row + outbox) is
+// pushed below into PlanRecorder.
+//
+// The Engine itself performs no I/O directly: it loads a Policy via
+// PolicyLoader, evaluates predicates, and records the decision via
+// PlanRecorder. All three injection points are interfaces (ADR-017) so
+// tests can drive the engine without standing up a database.
+type Engine struct {
+	loader   PolicyLoader
+	recorder PlanRecorder
+}
+
+// PolicyLoader returns the Policy applicable to the given org/repo pair.
+// Implementations resolve repo-level policies before falling back to
+// org-level (RepoID = nil).
+type PolicyLoader interface {
+	LoadPolicy(ctx context.Context, orgID uuid.UUID, repoID *uuid.UUID) (*Policy, error)
+}
+
+// PlanRecorder persists a Plan and an audit row recording the engine's
+// decision. Implementations MUST write both rows in the same SQL
+// transaction along with the appropriate outbox row (ADR-008). The
+// in-memory implementation used in tests is a no-op recorder.
+type PlanRecorder interface {
+	// RecordSubmission persists plan with status pending|auto_approved_no_rule
+	// and writes the policy_audit row corresponding to the engine decision.
+	// The same Tx writes the outbox event(s) per ADR-008.
+	RecordSubmission(ctx context.Context, plan *Plan, decision Decision) error
+}
+
+// NewEngine wires loader and recorder into an Engine. Both are required;
+// pass a stub recorder when only evaluation (not persistence) is needed.
+func NewEngine(loader PolicyLoader, recorder PlanRecorder) *Engine {
+	return &Engine{loader: loader, recorder: recorder}
+}
+
+// ErrPolicyNotFound is returned when no policy is configured for the
+// (org_id, repo_id) pair. Callers map this to a 404 / NOT_FOUND. ADR-015
+// forbids implicit auto-approve for missing policies; absence of a policy
+// means the org has not yet onboarded the engine and submissions must
+// fail rather than silently pass.
+var ErrPolicyNotFound = errors.New("policy: no policy configured for org/repo")
+
+// SubmitPlan evaluates plan against the applicable Policy and persists the
+// resulting decision. Returns the Decision the caller should act on (route
+// through the ladder, or treat as auto-admitted).
+//
+// Algorithm (ADR-015):
+//  1. Load Policy by (OrgID, RepoID).
+//  2. Validate the policy structurally (defence-in-depth).
+//  3. Stamp PlanHash via ComputePlanHash.
+//  4. Walk Rules in slice order; first match wins.
+//  5. On match: persist plan with status=pending, decision carries the rung
+//     ladder + expiry.
+//  6. On no match: persist plan with status=auto_approved_no_rule, decision
+//     carries AutoApproved=true. Audit row event_kind="auto_approved_no_rule"
+//     emitted by the recorder. Ops dashboards alert when this rate exceeds
+//     5%/hour (signal of mis-configuration).
+func (e *Engine) SubmitPlan(ctx context.Context, plan *Plan) (Decision, error) {
+	if plan == nil {
+		return Decision{}, errors.New("policy: nil plan")
+	}
+	if !plan.ProposerKind.IsValid() {
+		return Decision{}, fmt.Errorf("policy: invalid proposer_kind %q", plan.ProposerKind)
+	}
+	pol, err := e.loader.LoadPolicy(ctx, plan.OrgID, plan.RepoID)
+	if err != nil {
+		return Decision{}, err
+	}
+	if pol == nil {
+		return Decision{}, ErrPolicyNotFound
+	}
+	if err := Validate(pol); err != nil {
+		return Decision{}, fmt.Errorf("policy: loaded policy fails validation: %w", err)
+	}
+	plan.PolicyID = pol.ID
+	if err := ComputePlanHash(plan); err != nil {
+		return Decision{}, err
+	}
+	if plan.ID == uuid.Nil {
+		plan.ID = uuid.New()
+	}
+
+	for i, r := range pol.Rules {
+		if matchRule(r, plan.Actions, plan.ProposerKind) {
+			d := Decision{
+				PlanID:           plan.ID,
+				Status:           PlanStatusPending,
+				AutoApproved:     false,
+				MatchedRuleIndex: i,
+				Ladder:           append([]EscalationRung(nil), r.Ladder...),
+				ExpirySeconds:    r.ExpirySeconds,
+			}
+			if err := e.recorder.RecordSubmission(ctx, plan, d); err != nil {
+				return Decision{}, err
+			}
+			return d, nil
+		}
+	}
+
+	// No rule matched. ADR-015 forbids silent admission: emit an explicit
+	// auto_approved_no_rule audit row. Operators alert on the rate.
+	d := Decision{
+		PlanID:           plan.ID,
+		Status:           PlanStatusAutoApprovedNoRule,
+		AutoApproved:     true,
+		MatchedRuleIndex: -1,
+	}
+	if err := e.recorder.RecordSubmission(ctx, plan, d); err != nil {
+		return Decision{}, err
+	}
+	return d, nil
+}

--- a/plane/application/policy/engine_test.go
+++ b/plane/application/policy/engine_test.go
@@ -1,0 +1,317 @@
+package policy
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+// stubLoader returns a fixed policy or error.
+type stubLoader struct {
+	policy *Policy
+	err    error
+}
+
+func (s *stubLoader) LoadPolicy(_ context.Context, _ uuid.UUID, _ *uuid.UUID) (*Policy, error) {
+	return s.policy, s.err
+}
+
+// captureRecorder records the last RecordSubmission call.
+type captureRecorder struct {
+	plan     *Plan
+	decision Decision
+	calls    int
+	failWith error
+}
+
+func (c *captureRecorder) RecordSubmission(_ context.Context, plan *Plan, d Decision) error {
+	c.calls++
+	c.plan = plan
+	c.decision = d
+	return c.failWith
+}
+
+// engineWith returns an Engine wired to a fresh policy and capture recorder.
+func engineWith(t *testing.T, p *Policy) (*Engine, *captureRecorder) {
+	t.Helper()
+	rec := &captureRecorder{}
+	return NewEngine(&stubLoader{policy: p}, rec), rec
+}
+
+func TestSubmitPlan_PRMergeMatch(t *testing.T) {
+	e, rec := engineWith(t, validPolicy())
+	d, err := e.SubmitPlan(context.Background(), &Plan{
+		OrgID:        uuid.New(),
+		ProposerID:   uuid.New(),
+		ProposerKind: ProposerKindAgent,
+		Actions:      []Action{{Kind: "pr_merge", Fields: map[string]string{"branch": "main"}}},
+	})
+	if err != nil {
+		t.Fatalf("submit: %v", err)
+	}
+	if d.MatchedRuleIndex != 0 {
+		t.Errorf("want rule[0] match, got %d", d.MatchedRuleIndex)
+	}
+	if d.Status != PlanStatusPending {
+		t.Errorf("want pending, got %s", d.Status)
+	}
+	if d.AutoApproved {
+		t.Error("PR-merge match must not auto-approve")
+	}
+	if rec.calls != 1 {
+		t.Errorf("recorder calls: want 1 got %d", rec.calls)
+	}
+}
+
+func TestSubmitPlan_PRMergeNonMatchingBranch(t *testing.T) {
+	e, _ := engineWith(t, validPolicy())
+	d, err := e.SubmitPlan(context.Background(), &Plan{
+		OrgID:        uuid.New(),
+		ProposerKind: ProposerKindService,
+		ProposerID:   uuid.New(),
+		Actions:      []Action{{Kind: "pr_merge", Fields: map[string]string{"branch": "feature-x"}}},
+	})
+	if err != nil {
+		t.Fatalf("submit: %v", err)
+	}
+	// Service proposer + non-main branch + no agent_default rule → no match.
+	if !d.AutoApproved {
+		t.Errorf("want auto-approved-no-rule, got %+v", d)
+	}
+	if d.Status != PlanStatusAutoApprovedNoRule {
+		t.Errorf("want auto_approved_no_rule, got %s", d.Status)
+	}
+	if d.MatchedRuleIndex != -1 {
+		t.Errorf("want -1, got %d", d.MatchedRuleIndex)
+	}
+}
+
+func TestSubmitPlan_BulkActionThreshold(t *testing.T) {
+	e, _ := engineWith(t, validPolicy())
+	actions := make([]Action, 60)
+	for i := range actions {
+		actions[i] = Action{Kind: "issue_close"}
+	}
+	d, err := e.SubmitPlan(context.Background(), &Plan{
+		OrgID:        uuid.New(),
+		ProposerKind: ProposerKindAgent,
+		ProposerID:   uuid.New(),
+		Actions:      actions,
+	})
+	if err != nil {
+		t.Fatalf("submit: %v", err)
+	}
+	if d.MatchedRuleIndex != 1 {
+		t.Errorf("want rule[1] (bulk_action), got %d", d.MatchedRuleIndex)
+	}
+}
+
+func TestSubmitPlan_AgentDefaultLastResort(t *testing.T) {
+	p := validPolicy()
+	// Append agent_default catch-all so an agent-proposed unrelated action
+	// still gets gated.
+	p.Rules = append(p.Rules, Rule{
+		Kind:          PredicateAgentDefault,
+		ExpirySeconds: 86400,
+		Ladder: []EscalationRung{
+			{GroupName: "oncall", SLASeconds: 3600, OnTimeout: OnTimeoutAutoDeny},
+		},
+	})
+	e, _ := engineWith(t, p)
+	d, err := e.SubmitPlan(context.Background(), &Plan{
+		OrgID:        uuid.New(),
+		ProposerKind: ProposerKindAgent,
+		ProposerID:   uuid.New(),
+		Actions:      []Action{{Kind: "rename_file"}},
+	})
+	if err != nil {
+		t.Fatalf("submit: %v", err)
+	}
+	if d.MatchedRuleIndex != 2 {
+		t.Errorf("want rule[2] (agent_default), got %d", d.MatchedRuleIndex)
+	}
+	if d.AutoApproved {
+		t.Error("agent_default match must NOT auto-approve")
+	}
+}
+
+func TestSubmitPlan_AgentDefaultIgnoresService(t *testing.T) {
+	p := validPolicy()
+	p.Rules = append(p.Rules, Rule{
+		Kind:          PredicateAgentDefault,
+		ExpirySeconds: 86400,
+		Ladder: []EscalationRung{
+			{GroupName: "oncall", SLASeconds: 3600, OnTimeout: OnTimeoutAutoDeny},
+		},
+	})
+	e, _ := engineWith(t, p)
+	// Service proposer with no matching kinds: agent_default must not fire.
+	d, err := e.SubmitPlan(context.Background(), &Plan{
+		OrgID:        uuid.New(),
+		ProposerKind: ProposerKindService,
+		ProposerID:   uuid.New(),
+		Actions:      []Action{{Kind: "rename_file"}},
+	})
+	if err != nil {
+		t.Fatalf("submit: %v", err)
+	}
+	if !d.AutoApproved {
+		t.Errorf("service proposer + no match → expected auto-approved-no-rule, got %+v", d)
+	}
+}
+
+func TestSubmitPlan_FirstMatchWins(t *testing.T) {
+	// Build a policy where rule[0] is pr_merge main and rule[1] is agent_default.
+	// An agent proposing pr_merge to main must hit rule[0] (more specific).
+	p := validPolicy()
+	p.Rules = append(p.Rules, Rule{
+		Kind:          PredicateAgentDefault,
+		ExpirySeconds: 86400,
+		Ladder: []EscalationRung{
+			{GroupName: "oncall", SLASeconds: 3600, OnTimeout: OnTimeoutAutoDeny},
+		},
+	})
+	e, _ := engineWith(t, p)
+	d, err := e.SubmitPlan(context.Background(), &Plan{
+		OrgID:        uuid.New(),
+		ProposerKind: ProposerKindAgent,
+		ProposerID:   uuid.New(),
+		Actions:      []Action{{Kind: "pr_merge", Fields: map[string]string{"branch": "main"}}},
+	})
+	if err != nil {
+		t.Fatalf("submit: %v", err)
+	}
+	if d.MatchedRuleIndex != 0 {
+		t.Errorf("first-match-wins broken: want 0, got %d", d.MatchedRuleIndex)
+	}
+}
+
+func TestSubmitPlan_ForcePushPattern(t *testing.T) {
+	p := &Policy{
+		ID:    uuid.New(),
+		OrgID: uuid.New(),
+		Name:  "force",
+		ApproverGroups: map[string]ApproverGroup{
+			"oncall": {Name: "oncall", HumanUserIDs: []uuid.UUID{uuid.New()}, RequiredCount: 1},
+		},
+		Rules: []Rule{
+			{
+				Kind:          PredicateForcePush,
+				Match:         map[string]string{"ref_pattern": "refs/heads/release/*"},
+				ExpirySeconds: 86400,
+				Ladder: []EscalationRung{
+					{GroupName: "oncall", SLASeconds: 60, OnTimeout: OnTimeoutAutoDeny},
+				},
+			},
+		},
+	}
+	e, _ := engineWith(t, p)
+	d, err := e.SubmitPlan(context.Background(), &Plan{
+		OrgID:        p.OrgID,
+		ProposerKind: ProposerKindAgent,
+		ProposerID:   uuid.New(),
+		Actions:      []Action{{Kind: "force_push", Fields: map[string]string{"ref": "refs/heads/release/v1"}}},
+	})
+	if err != nil {
+		t.Fatalf("submit: %v", err)
+	}
+	if d.MatchedRuleIndex != 0 {
+		t.Errorf("force_push glob did not match: %+v", d)
+	}
+}
+
+func TestSubmitPlan_ProductionDeploy(t *testing.T) {
+	p := &Policy{
+		ID:    uuid.New(),
+		OrgID: uuid.New(),
+		Name:  "prod",
+		ApproverGroups: map[string]ApproverGroup{
+			"sec": {Name: "sec", HumanUserIDs: []uuid.UUID{uuid.New(), uuid.New()}, RequiredCount: 2},
+		},
+		Rules: []Rule{{
+			Kind:          PredicateProductionDeploy,
+			Match:         map[string]string{"environment": "prod"},
+			ExpirySeconds: 14400,
+			Ladder: []EscalationRung{
+				{GroupName: "sec", SLASeconds: 14400, OnTimeout: OnTimeoutAutoDeny},
+			},
+		}},
+	}
+	e, _ := engineWith(t, p)
+	d, err := e.SubmitPlan(context.Background(), &Plan{
+		OrgID:        p.OrgID,
+		ProposerKind: ProposerKindService,
+		ProposerID:   uuid.New(),
+		Actions:      []Action{{Kind: "production_deploy", Fields: map[string]string{"environment": "prod"}}},
+	})
+	if err != nil {
+		t.Fatalf("submit: %v", err)
+	}
+	if d.MatchedRuleIndex != 0 || d.ExpirySeconds != 14400 {
+		t.Errorf("expected 4h prod gate, got %+v", d)
+	}
+}
+
+func TestSubmitPlan_NoPolicyConfigured(t *testing.T) {
+	e := NewEngine(&stubLoader{policy: nil}, &captureRecorder{})
+	_, err := e.SubmitPlan(context.Background(), &Plan{
+		OrgID:        uuid.New(),
+		ProposerKind: ProposerKindAgent,
+		ProposerID:   uuid.New(),
+	})
+	if !errors.Is(err, ErrPolicyNotFound) {
+		t.Fatalf("want ErrPolicyNotFound, got %v", err)
+	}
+}
+
+func TestSubmitPlan_RecorderError(t *testing.T) {
+	rec := &captureRecorder{failWith: errors.New("db down")}
+	e := NewEngine(&stubLoader{policy: validPolicy()}, rec)
+	_, err := e.SubmitPlan(context.Background(), &Plan{
+		OrgID:        uuid.New(),
+		ProposerKind: ProposerKindAgent,
+		ProposerID:   uuid.New(),
+		Actions:      []Action{{Kind: "pr_merge", Fields: map[string]string{"branch": "main"}}},
+	})
+	if err == nil {
+		t.Fatal("expected error from recorder, got nil")
+	}
+}
+
+func TestSubmitPlan_InvalidProposerKind(t *testing.T) {
+	e := NewEngine(&stubLoader{policy: validPolicy()}, &captureRecorder{})
+	_, err := e.SubmitPlan(context.Background(), &Plan{
+		OrgID:        uuid.New(),
+		ProposerKind: ProposerKind("alien"),
+		ProposerID:   uuid.New(),
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid proposer_kind")
+	}
+}
+
+func TestComputePlanHash_StableAcrossFieldOrder(t *testing.T) {
+	a := &Plan{Actions: []Action{{Kind: "pr_merge", Fields: map[string]string{"branch": "main", "repo": "r1"}}}}
+	b := &Plan{Actions: []Action{{Kind: "pr_merge", Fields: map[string]string{"repo": "r1", "branch": "main"}}}}
+	if err := ComputePlanHash(a); err != nil {
+		t.Fatal(err)
+	}
+	if err := ComputePlanHash(b); err != nil {
+		t.Fatal(err)
+	}
+	if a.PlanHash != b.PlanHash {
+		t.Errorf("hash should be stable across map iteration order, got %x vs %x", a.PlanHash, b.PlanHash)
+	}
+}
+
+func TestComputePlanHash_DiffersOnMutation(t *testing.T) {
+	a := &Plan{Actions: []Action{{Kind: "pr_merge", Fields: map[string]string{"branch": "main"}}}}
+	b := &Plan{Actions: []Action{{Kind: "pr_merge", Fields: map[string]string{"branch": "develop"}}}}
+	_ = ComputePlanHash(a)
+	_ = ComputePlanHash(b)
+	if a.PlanHash == b.PlanHash {
+		t.Error("hash must change when actions change")
+	}
+}

--- a/plane/application/policy/memservice.go
+++ b/plane/application/policy/memservice.go
@@ -1,0 +1,368 @@
+package policy
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// MemService is an in-memory ApprovalService used in tests and as the
+// reference implementation for the PG-backed service that follows in a
+// later issue. It threads the engine, plan store, and audit chain through
+// a single mutex; production reaches the same call shape via SQL Tx.
+//
+// Concurrency: every method takes the mutex for its full duration. This is
+// not the production threading model — the PG impl uses Tx isolation —
+// but it is sufficient for unit and ApprovalActivity tests in this issue.
+type MemService struct {
+	mu       sync.Mutex
+	policies map[uuid.UUID]*Policy
+	plans    map[uuid.UUID]*memPlan
+	audit    map[uuid.UUID][]AuditRow // policyID → rows
+	clock    func() time.Time
+}
+
+type memPlan struct {
+	plan        Plan
+	status      PlanStatus
+	currentRung int
+	approvals   map[int]map[uuid.UUID]bool // rung → approver → approved
+	rejections  map[int]map[uuid.UUID]bool
+	ladder      []EscalationRung
+	policy      *Policy
+	expiresAt   time.Time
+}
+
+// NewMemService returns an empty in-memory ApprovalService. clock is
+// optional; nil falls back to time.Now (UTC).
+func NewMemService(clock func() time.Time) *MemService {
+	if clock == nil {
+		clock = func() time.Time { return time.Now().UTC() }
+	}
+	return &MemService{
+		policies: map[uuid.UUID]*Policy{},
+		plans:    map[uuid.UUID]*memPlan{},
+		audit:    map[uuid.UUID][]AuditRow{},
+		clock:    clock,
+	}
+}
+
+// RegisterPolicy seeds a policy. The PG impl persists via Tx.
+func (s *MemService) RegisterPolicy(p *Policy) error {
+	if err := Validate(p); err != nil {
+		return err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.policies[p.OrgID] = p
+	return nil
+}
+
+// LoadPolicy implements PolicyLoader.
+func (s *MemService) LoadPolicy(_ context.Context, orgID uuid.UUID, _ *uuid.UUID) (*Policy, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	p, ok := s.policies[orgID]
+	if !ok {
+		return nil, nil
+	}
+	return p, nil
+}
+
+// RecordSubmission implements PlanRecorder. It is called by the engine
+// inside SubmitPlan with the mutex already taken (see SubmitPlan below),
+// so we do not re-take it here.
+func (s *MemService) RecordSubmission(_ context.Context, plan *Plan, d Decision) error {
+	pol := s.policies[plan.OrgID]
+	if pol == nil {
+		return ErrPolicyNotFound
+	}
+	now := s.clock()
+	mp := &memPlan{
+		plan:        *plan,
+		status:      d.Status,
+		currentRung: 0,
+		approvals:   map[int]map[uuid.UUID]bool{},
+		rejections:  map[int]map[uuid.UUID]bool{},
+		ladder:      d.Ladder,
+		policy:      pol,
+	}
+	if d.ExpirySeconds > 0 {
+		mp.expiresAt = now.Add(time.Duration(d.ExpirySeconds) * time.Second)
+	}
+	s.plans[plan.ID] = mp
+
+	kind := AuditEventSubmitted
+	if d.AutoApproved {
+		kind = AuditEventAutoApprovedNoRule
+	}
+	payload, _ := json.Marshal(map[string]any{
+		"plan_id":            plan.ID.String(),
+		"matched_rule_index": d.MatchedRuleIndex,
+		"plan_hash":          fmt.Sprintf("%x", plan.PlanHash),
+		"proposer_kind":      string(plan.ProposerKind),
+	})
+	return s.appendAuditLocked(pol.ID, &plan.ID, kind, &plan.ProposerID, actorKindFromProposer(plan.ProposerKind), payload, now)
+}
+
+// SubmitPlan implements ApprovalService.
+func (s *MemService) SubmitPlan(ctx context.Context, plan *Plan) (Decision, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	// Engine.SubmitPlan calls back into LoadPolicy and RecordSubmission;
+	// to avoid mutex re-entry we inline a minimal evaluation that mirrors
+	// engine semantics and shares the predicate logic via matchRule.
+	if plan == nil {
+		return Decision{}, fmt.Errorf("policy: nil plan")
+	}
+	if !plan.ProposerKind.IsValid() {
+		return Decision{}, fmt.Errorf("policy: invalid proposer_kind %q", plan.ProposerKind)
+	}
+	pol, ok := s.policies[plan.OrgID]
+	if !ok {
+		return Decision{}, ErrPolicyNotFound
+	}
+	if err := Validate(pol); err != nil {
+		return Decision{}, err
+	}
+	plan.PolicyID = pol.ID
+	if err := ComputePlanHash(plan); err != nil {
+		return Decision{}, err
+	}
+	if plan.ID == uuid.Nil {
+		plan.ID = uuid.New()
+	}
+	for i, r := range pol.Rules {
+		if matchRule(r, plan.Actions, plan.ProposerKind) {
+			d := Decision{
+				PlanID:           plan.ID,
+				Status:           PlanStatusPending,
+				MatchedRuleIndex: i,
+				Ladder:           append([]EscalationRung(nil), r.Ladder...),
+				ExpirySeconds:    r.ExpirySeconds,
+			}
+			if err := s.RecordSubmission(ctx, plan, d); err != nil {
+				return Decision{}, err
+			}
+			return d, nil
+		}
+	}
+	d := Decision{
+		PlanID:           plan.ID,
+		Status:           PlanStatusAutoApprovedNoRule,
+		AutoApproved:     true,
+		MatchedRuleIndex: -1,
+	}
+	if err := s.RecordSubmission(ctx, plan, d); err != nil {
+		return Decision{}, err
+	}
+	return d, nil
+}
+
+// RecordDecision implements ApprovalService.
+func (s *MemService) RecordDecision(_ context.Context, in DecisionInput) (DecisionOutcome, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	mp, ok := s.plans[in.PlanID]
+	if !ok {
+		return DecisionOutcome{}, NewAPIError(CodePlanNotFound, "no such plan")
+	}
+	if mp.status != PlanStatusPending {
+		return DecisionOutcome{}, NewAPIError(CodePlanAlreadyDecided, fmt.Sprintf("status=%s", mp.status))
+	}
+	now := s.clock()
+	if !mp.expiresAt.IsZero() && now.After(mp.expiresAt) {
+		mp.status = PlanStatusExpired
+		_ = s.appendAuditLocked(mp.policy.ID, &mp.plan.ID, AuditEventExpired, nil, ActorKindSystem,
+			rawJSON(map[string]any{"reason": "expiry_window_elapsed"}), now)
+		return DecisionOutcome{}, NewAPIError(CodePlanExpired, "approval window elapsed")
+	}
+	if in.RungIndex < 0 || in.RungIndex >= len(mp.ladder) {
+		return DecisionOutcome{}, NewAPIError(CodeRungOutOfRange, fmt.Sprintf("rung=%d", in.RungIndex))
+	}
+	if in.RungIndex != mp.currentRung {
+		return DecisionOutcome{}, NewAPIError(CodeRungOutOfRange,
+			fmt.Sprintf("decision rung %d != current rung %d", in.RungIndex, mp.currentRung))
+	}
+	rung := mp.ladder[mp.currentRung]
+	group, ok := mp.policy.ApproverGroups[rung.GroupName]
+	if !ok {
+		return DecisionOutcome{}, NewAPIError(CodeDecisionUnauthorized, "rung group missing")
+	}
+	if !contains(group.HumanUserIDs, in.ActorID) {
+		return DecisionOutcome{}, NewAPIError(CodeDecisionUnauthorized, "actor not in approver group")
+	}
+	if in.Approve {
+		if mp.approvals[in.RungIndex] == nil {
+			mp.approvals[in.RungIndex] = map[uuid.UUID]bool{}
+		}
+		mp.approvals[in.RungIndex][in.ActorID] = true
+	} else {
+		if in.Reason == "" {
+			return DecisionOutcome{}, NewAPIError(CodeDecisionUnauthorized, "reject requires reason")
+		}
+		if mp.rejections[in.RungIndex] == nil {
+			mp.rejections[in.RungIndex] = map[uuid.UUID]bool{}
+		}
+		mp.rejections[in.RungIndex][in.ActorID] = true
+	}
+	approvals := len(mp.approvals[in.RungIndex])
+	rejections := len(mp.rejections[in.RungIndex])
+	out := DecisionOutcome{
+		Approvals:  approvals,
+		Rejections: rejections,
+	}
+	// Reject as soon as any rejection appears — single rejection at any
+	// rung blocks the plan (ADR-015 conservative posture).
+	if rejections > 0 {
+		mp.status = PlanStatusRejected
+		out.Status = PlanStatusRejected
+		actor := in.ActorID
+		_ = s.appendAuditLocked(mp.policy.ID, &mp.plan.ID, AuditEventRejected, &actor, ActorKindHuman,
+			rawJSON(map[string]any{"rung": in.RungIndex, "reason": in.Reason}), now)
+		return out, nil
+	}
+	if approvals >= group.RequiredCount {
+		mp.status = PlanStatusApproved
+		out.Status = PlanStatusApproved
+		out.QuorumMet = true
+		actor := in.ActorID
+		_ = s.appendAuditLocked(mp.policy.ID, &mp.plan.ID, AuditEventApproved, &actor, ActorKindHuman,
+			rawJSON(map[string]any{"rung": in.RungIndex, "approvals": approvals}), now)
+		return out, nil
+	}
+	out.Status = PlanStatusPending
+	actor := in.ActorID
+	_ = s.appendAuditLocked(mp.policy.ID, &mp.plan.ID, AuditEventSubmitted, &actor, ActorKindHuman,
+		rawJSON(map[string]any{"rung": in.RungIndex, "vote": "approve_partial", "approvals": approvals}), now)
+	return out, nil
+}
+
+// Escalate implements ApprovalService.
+func (s *MemService) Escalate(_ context.Context, in EscalateInput) (EscalateOutcome, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	mp, ok := s.plans[in.PlanID]
+	if !ok {
+		return EscalateOutcome{}, NewAPIError(CodePlanNotFound, "no such plan")
+	}
+	if mp.status != PlanStatusPending {
+		return EscalateOutcome{}, NewAPIError(CodePlanAlreadyDecided, fmt.Sprintf("status=%s", mp.status))
+	}
+	if in.FromRung != mp.currentRung {
+		return EscalateOutcome{}, NewAPIError(CodeRungOutOfRange,
+			fmt.Sprintf("escalate from %d but current is %d", in.FromRung, mp.currentRung))
+	}
+	rung := mp.ladder[mp.currentRung]
+	now := s.clock()
+	out := EscalateOutcome{OnTimeout: rung.OnTimeout}
+	switch rung.OnTimeout {
+	case OnTimeoutAutoDeny:
+		mp.status = PlanStatusAutoDenied
+		out.NewRung = mp.currentRung
+		out.FinalRung = true
+		_ = s.appendAuditLocked(mp.policy.ID, &mp.plan.ID, AuditEventAutoDenied, nil, ActorKindSystem,
+			rawJSON(map[string]any{"rung": mp.currentRung, "reason": in.Reason}), now)
+	case OnTimeoutFallBack:
+		// fall_back is invalid on rung 0 (validation rejects), so this is safe.
+		mp.currentRung--
+		out.NewRung = mp.currentRung
+		_ = s.appendAuditLocked(mp.policy.ID, &mp.plan.ID, AuditEventEscalated, nil, ActorKindSystem,
+			rawJSON(map[string]any{"from_rung": in.FromRung, "to_rung": mp.currentRung, "kind": "fall_back"}), now)
+	case OnTimeoutNotifyNext:
+		next := mp.currentRung + 1
+		if next >= len(mp.ladder) {
+			// Final rung exhausted with notify_next semantics: ADR-015
+			// requires explicit final disposition. Treat as auto_denied
+			// — the operator should configure auto_deny on the final
+			// rung; we surface FinalRung=true so the caller can act.
+			mp.status = PlanStatusAutoDenied
+			out.NewRung = mp.currentRung
+			out.FinalRung = true
+			_ = s.appendAuditLocked(mp.policy.ID, &mp.plan.ID, AuditEventAutoDenied, nil, ActorKindSystem,
+				rawJSON(map[string]any{"rung": mp.currentRung, "reason": "ladder_exhausted"}), now)
+		} else {
+			mp.currentRung = next
+			mp.status = PlanStatusPending // remain pending
+			out.NewRung = next
+			_ = s.appendAuditLocked(mp.policy.ID, &mp.plan.ID, AuditEventEscalated, nil, ActorKindSystem,
+				rawJSON(map[string]any{"from_rung": in.FromRung, "to_rung": next, "kind": "notify_next"}), now)
+		}
+	}
+	return out, nil
+}
+
+// GetPlanStatus implements ApprovalService.
+func (s *MemService) GetPlanStatus(_ context.Context, planID uuid.UUID) (PlanStatus, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	mp, ok := s.plans[planID]
+	if !ok {
+		return "", NewAPIError(CodePlanNotFound, "no such plan")
+	}
+	return mp.status, nil
+}
+
+// AuditChain returns the audit rows for a policy in append order. Test-only
+// access; production callers go through a dedicated read API.
+func (s *MemService) AuditChain(policyID uuid.UUID) []AuditRow {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]AuditRow, len(s.audit[policyID]))
+	copy(out, s.audit[policyID])
+	return out
+}
+
+// appendAuditLocked appends an audit row under the assumption that mu is
+// already held by the caller.
+func (s *MemService) appendAuditLocked(policyID uuid.UUID, planID *uuid.UUID, kind AuditEventKind, actorID *uuid.UUID, actorKind ActorKind, payload []byte, now time.Time) error {
+	prev := GenesisHash
+	if rows := s.audit[policyID]; len(rows) > 0 {
+		prev = rows[len(rows)-1].RowHash
+	}
+	row := AuditRow{
+		ID:        int64(len(s.audit[policyID]) + 1),
+		PolicyID:  policyID,
+		PlanID:    planID,
+		EventKind: kind,
+		ActorID:   actorID,
+		ActorKind: actorKind,
+		Payload:   payload,
+		CreatedAt: now,
+	}
+	if err := AppendRow(prev, &row); err != nil {
+		return err
+	}
+	s.audit[policyID] = append(s.audit[policyID], row)
+	return nil
+}
+
+// rawJSON serialises v ignoring errors. Audit payloads are simple maps; the
+// test helper stays terse to keep call sites readable.
+func rawJSON(v any) []byte {
+	b, _ := json.Marshal(v)
+	return b
+}
+
+func contains(haystack []uuid.UUID, needle uuid.UUID) bool {
+	for _, id := range haystack {
+		if id == needle {
+			return true
+		}
+	}
+	return false
+}
+
+func actorKindFromProposer(p ProposerKind) ActorKind {
+	switch p {
+	case ProposerKindAgent:
+		return ActorKindAgent
+	case ProposerKindService:
+		return ActorKindService
+	}
+	return ActorKindSystem
+}

--- a/plane/application/policy/memservice_test.go
+++ b/plane/application/policy/memservice_test.go
@@ -1,0 +1,262 @@
+package policy
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// makeService builds a MemService seeded with a 2-rung policy on org X
+// requiring 1 approval at rung 0 (sla 60s, notify_next), and 2 approvals
+// at rung 1 (sla 30s, auto_deny).
+func makeService(t *testing.T, clock func() time.Time) (*MemService, *Policy, []uuid.UUID) {
+	t.Helper()
+	approver1 := uuid.New()
+	approver2 := uuid.New()
+	approver3 := uuid.New()
+	p := &Policy{
+		ID:    uuid.New(),
+		OrgID: uuid.New(),
+		Name:  "default",
+		ApproverGroups: map[string]ApproverGroup{
+			"oncall":   {Name: "oncall", HumanUserIDs: []uuid.UUID{approver1}, RequiredCount: 1},
+			"security": {Name: "security", HumanUserIDs: []uuid.UUID{approver2, approver3}, RequiredCount: 2},
+		},
+		Rules: []Rule{
+			{
+				Kind:          PredicatePRMerge,
+				Match:         map[string]string{"branch": "main"},
+				ExpirySeconds: 86400,
+				Ladder: []EscalationRung{
+					{GroupName: "oncall", SLASeconds: 60, OnTimeout: OnTimeoutNotifyNext},
+					{GroupName: "security", SLASeconds: 30, OnTimeout: OnTimeoutAutoDeny},
+				},
+			},
+		},
+	}
+	svc := NewMemService(clock)
+	if err := svc.RegisterPolicy(p); err != nil {
+		t.Fatal(err)
+	}
+	return svc, p, []uuid.UUID{approver1, approver2, approver3}
+}
+
+func TestMem_SubmitThenApproveRung0(t *testing.T) {
+	svc, p, approvers := makeService(t, nil)
+	d, err := svc.SubmitPlan(context.Background(), &Plan{
+		OrgID:        p.OrgID,
+		ProposerKind: ProposerKindAgent,
+		ProposerID:   uuid.New(),
+		Actions:      []Action{{Kind: "pr_merge", Fields: map[string]string{"branch": "main"}}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if d.Status != PlanStatusPending {
+		t.Fatalf("want pending, got %s", d.Status)
+	}
+	out, err := svc.RecordDecision(context.Background(), DecisionInput{
+		PlanID:    d.PlanID,
+		ActorID:   approvers[0],
+		Approve:   true,
+		RungIndex: 0,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out.Status != PlanStatusApproved || !out.QuorumMet {
+		t.Errorf("want approved+quorum, got %+v", out)
+	}
+	st, err := svc.GetPlanStatus(context.Background(), d.PlanID)
+	if err != nil || st != PlanStatusApproved {
+		t.Errorf("status: want approved, got %s err=%v", st, err)
+	}
+	// Audit chain: submitted + approved (genesis chain length 2).
+	rows := svc.AuditChain(p.ID)
+	if len(rows) != 2 {
+		t.Fatalf("want 2 audit rows, got %d", len(rows))
+	}
+	if idx, err := VerifyChain(rows); idx != -1 || err != nil {
+		t.Errorf("audit chain: idx=%d err=%v", idx, err)
+	}
+}
+
+func TestMem_EscalateThenAutoDeny(t *testing.T) {
+	svc, p, approvers := makeService(t, nil)
+	d, err := svc.SubmitPlan(context.Background(), &Plan{
+		OrgID:        p.OrgID,
+		ProposerKind: ProposerKindAgent,
+		ProposerID:   uuid.New(),
+		Actions:      []Action{{Kind: "pr_merge", Fields: map[string]string{"branch": "main"}}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// First rung notify_next → escalate to rung 1
+	out, err := svc.Escalate(context.Background(), EscalateInput{PlanID: d.PlanID, FromRung: 0, Reason: "sla_breach"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out.NewRung != 1 || out.FinalRung {
+		t.Errorf("want rung=1 not-final, got %+v", out)
+	}
+	// Decision at rung 1 needs 2 approvals (k-of-n = 2-of-2). One approval = still pending.
+	if _, err := svc.RecordDecision(context.Background(), DecisionInput{
+		PlanID: d.PlanID, ActorID: approvers[1], Approve: true, RungIndex: 1,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	st, _ := svc.GetPlanStatus(context.Background(), d.PlanID)
+	if st != PlanStatusPending {
+		t.Errorf("after 1 approval at rung 1: want pending, got %s", st)
+	}
+	// Now escalate from rung 1 with auto_deny.
+	out, err = svc.Escalate(context.Background(), EscalateInput{PlanID: d.PlanID, FromRung: 1, Reason: "sla_breach"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !out.FinalRung || out.OnTimeout != OnTimeoutAutoDeny {
+		t.Errorf("want final auto_deny, got %+v", out)
+	}
+	st, _ = svc.GetPlanStatus(context.Background(), d.PlanID)
+	if st != PlanStatusAutoDenied {
+		t.Errorf("status: want auto_denied, got %s", st)
+	}
+}
+
+func TestMem_RejectionShortCircuits(t *testing.T) {
+	svc, p, approvers := makeService(t, nil)
+	d, _ := svc.SubmitPlan(context.Background(), &Plan{
+		OrgID:        p.OrgID,
+		ProposerKind: ProposerKindAgent,
+		ProposerID:   uuid.New(),
+		Actions:      []Action{{Kind: "pr_merge", Fields: map[string]string{"branch": "main"}}},
+	})
+	out, err := svc.RecordDecision(context.Background(), DecisionInput{
+		PlanID: d.PlanID, ActorID: approvers[0], Approve: false, Reason: "looks risky", RungIndex: 0,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out.Status != PlanStatusRejected {
+		t.Errorf("want rejected, got %s", out.Status)
+	}
+}
+
+func TestMem_RejectRequiresReason(t *testing.T) {
+	svc, p, approvers := makeService(t, nil)
+	d, _ := svc.SubmitPlan(context.Background(), &Plan{
+		OrgID:        p.OrgID,
+		ProposerKind: ProposerKindAgent,
+		ProposerID:   uuid.New(),
+		Actions:      []Action{{Kind: "pr_merge", Fields: map[string]string{"branch": "main"}}},
+	})
+	_, err := svc.RecordDecision(context.Background(), DecisionInput{
+		PlanID: d.PlanID, ActorID: approvers[0], Approve: false, RungIndex: 0,
+	})
+	if !IsAPICode(err, CodeDecisionUnauthorized) {
+		t.Errorf("want CodeDecisionUnauthorized, got %v", err)
+	}
+}
+
+func TestMem_NonApproverDecisionUnauthorized(t *testing.T) {
+	svc, p, _ := makeService(t, nil)
+	d, _ := svc.SubmitPlan(context.Background(), &Plan{
+		OrgID:        p.OrgID,
+		ProposerKind: ProposerKindAgent,
+		ProposerID:   uuid.New(),
+		Actions:      []Action{{Kind: "pr_merge", Fields: map[string]string{"branch": "main"}}},
+	})
+	stranger := uuid.New()
+	_, err := svc.RecordDecision(context.Background(), DecisionInput{
+		PlanID: d.PlanID, ActorID: stranger, Approve: true, RungIndex: 0,
+	})
+	if !IsAPICode(err, CodeDecisionUnauthorized) {
+		t.Errorf("want CodeDecisionUnauthorized, got %v", err)
+	}
+}
+
+func TestMem_PlanAlreadyDecidedAfterApproval(t *testing.T) {
+	svc, p, approvers := makeService(t, nil)
+	d, _ := svc.SubmitPlan(context.Background(), &Plan{
+		OrgID:        p.OrgID,
+		ProposerKind: ProposerKindAgent,
+		ProposerID:   uuid.New(),
+		Actions:      []Action{{Kind: "pr_merge", Fields: map[string]string{"branch": "main"}}},
+	})
+	if _, err := svc.RecordDecision(context.Background(), DecisionInput{
+		PlanID: d.PlanID, ActorID: approvers[0], Approve: true, RungIndex: 0,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	_, err := svc.RecordDecision(context.Background(), DecisionInput{
+		PlanID: d.PlanID, ActorID: approvers[0], Approve: true, RungIndex: 0,
+	})
+	if !IsAPICode(err, CodePlanAlreadyDecided) {
+		t.Errorf("want CodePlanAlreadyDecided, got %v", err)
+	}
+}
+
+func TestMem_PlanExpiry(t *testing.T) {
+	now := time.Date(2026, 5, 9, 12, 0, 0, 0, time.UTC)
+	cur := now
+	svc, p, approvers := makeService(t, func() time.Time { return cur })
+	d, _ := svc.SubmitPlan(context.Background(), &Plan{
+		OrgID:        p.OrgID,
+		ProposerKind: ProposerKindAgent,
+		ProposerID:   uuid.New(),
+		Actions:      []Action{{Kind: "pr_merge", Fields: map[string]string{"branch": "main"}}},
+	})
+	// Advance the clock past expiry (24h).
+	cur = now.Add(25 * time.Hour)
+	_, err := svc.RecordDecision(context.Background(), DecisionInput{
+		PlanID: d.PlanID, ActorID: approvers[0], Approve: true, RungIndex: 0,
+	})
+	if !IsAPICode(err, CodePlanExpired) {
+		t.Errorf("want CodePlanExpired, got %v", err)
+	}
+}
+
+func TestMem_AutoApprovedNoRule_AuditEmitted(t *testing.T) {
+	svc, p, _ := makeService(t, nil)
+	// Service proposer + non-main branch + no agent_default → no rule fires.
+	d, err := svc.SubmitPlan(context.Background(), &Plan{
+		OrgID:        p.OrgID,
+		ProposerKind: ProposerKindService,
+		ProposerID:   uuid.New(),
+		Actions:      []Action{{Kind: "pr_merge", Fields: map[string]string{"branch": "feature-x"}}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !d.AutoApproved {
+		t.Fatalf("expected auto-approved, got %+v", d)
+	}
+	rows := svc.AuditChain(p.ID)
+	if len(rows) != 1 || rows[0].EventKind != AuditEventAutoApprovedNoRule {
+		t.Errorf("expected one auto_approved_no_rule audit row, got %+v", rows)
+	}
+}
+
+func TestMem_AuditChainGrowsWithDecisions(t *testing.T) {
+	svc, p, approvers := makeService(t, nil)
+	d, _ := svc.SubmitPlan(context.Background(), &Plan{
+		OrgID:        p.OrgID,
+		ProposerKind: ProposerKindAgent,
+		ProposerID:   uuid.New(),
+		Actions:      []Action{{Kind: "pr_merge", Fields: map[string]string{"branch": "main"}}},
+	})
+	_, _ = svc.Escalate(context.Background(), EscalateInput{PlanID: d.PlanID, FromRung: 0, Reason: "sla"})
+	_, _ = svc.RecordDecision(context.Background(), DecisionInput{PlanID: d.PlanID, ActorID: approvers[1], Approve: true, RungIndex: 1})
+	_, _ = svc.RecordDecision(context.Background(), DecisionInput{PlanID: d.PlanID, ActorID: approvers[2], Approve: true, RungIndex: 1})
+	rows := svc.AuditChain(p.ID)
+	// submit + escalate + partial-approval(rung1, 1/2) + final approval = 4 rows
+	if len(rows) != 4 {
+		t.Fatalf("want 4 audit rows, got %d: %+v", len(rows), rows)
+	}
+	if idx, err := VerifyChain(rows); idx != -1 || err != nil {
+		t.Errorf("chain verify: idx=%d err=%v", idx, err)
+	}
+}

--- a/plane/application/policy/plan.go
+++ b/plane/application/policy/plan.go
@@ -1,0 +1,126 @@
+package policy
+
+import (
+	"crypto/sha256"
+	"encoding/json"
+	"sort"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// ProposerKind is the closed enum identifying who submitted the plan. ADR-015
+// allows agents and services to submit; only HumanUsers may decide.
+type ProposerKind string
+
+const (
+	// ProposerKindAgent identifies an agent-proposed plan. AGENTS.md
+	// "ask first" hints surface as agent-proposed plans.
+	ProposerKindAgent ProposerKind = "agent"
+	// ProposerKindService identifies a service-proposed plan (e.g. CI
+	// pipeline requesting production-deploy approval).
+	ProposerKindService ProposerKind = "service"
+)
+
+// IsValid reports whether k is one of the closed enum values.
+func (k ProposerKind) IsValid() bool {
+	switch k {
+	case ProposerKindAgent, ProposerKindService:
+		return true
+	}
+	return false
+}
+
+// Action is one item in a submitted plan. Kind names the operation type
+// ("pr_merge", "force_push", "production_deploy", etc.) and Fields carries
+// kind-specific keys ("branch", "ref", "environment", ...). Both are part of
+// the canonical plan-hash; mutating either after approval re-opens the plan.
+type Action struct {
+	Kind   string            `json:"kind"`
+	Fields map[string]string `json:"fields,omitempty"`
+}
+
+// Plan is what an agent or service submits. The application plane stamps
+// the ID and ComputeHash fills PlanHash before persistence.
+type Plan struct {
+	ID           uuid.UUID    `json:"id"`
+	OrgID        uuid.UUID    `json:"org_id"`
+	RepoID       *uuid.UUID   `json:"repo_id,omitempty"`
+	PolicyID     uuid.UUID    `json:"policy_id"`
+	ProposerID   uuid.UUID    `json:"proposer_id"`
+	ProposerKind ProposerKind `json:"proposer_kind"`
+	Actions      []Action     `json:"actions"`
+	PlanHash     [32]byte     `json:"-"`
+	CreatedAt    time.Time    `json:"created_at"`
+}
+
+// PlanStatus enumerates the lifecycle states of a Plan. Each transition
+// emits an outbox row; consumers idempotent on event_id (ADR-008).
+type PlanStatus string
+
+const (
+	PlanStatusPending             PlanStatus = "pending"
+	PlanStatusApproved            PlanStatus = "approved"
+	PlanStatusRejected            PlanStatus = "rejected"
+	PlanStatusExpired             PlanStatus = "expired"
+	PlanStatusEscalated           PlanStatus = "escalated"
+	PlanStatusAutoApprovedNoRule  PlanStatus = "auto_approved_no_rule"
+	PlanStatusAutoDenied          PlanStatus = "auto_denied"
+)
+
+// Decision is the engine's verdict for a SubmitPlan call. When AutoApproved
+// is true, no human gating fired; the plan was admitted because no rule
+// matched. When MatchedRuleIndex >= 0, callers route the plan through the
+// EscalationLadder.
+type Decision struct {
+	PlanID           uuid.UUID
+	Status           PlanStatus
+	AutoApproved     bool
+	MatchedRuleIndex int  // -1 when no rule matched
+	Ladder           []EscalationRung
+	ExpirySeconds    int
+}
+
+// CanonicalActionsJSON returns a stable JSON encoding of actions for hashing.
+// Top-level actions slice order is preserved (caller-meaningful); within
+// each action, Fields keys are sorted to remove map-iteration nondeterminism.
+// The encoding rejects whitespace by using a custom emitter.
+func CanonicalActionsJSON(actions []Action) ([]byte, error) {
+	// Build a representation with sorted Fields per action.
+	type canonAction struct {
+		Kind   string            `json:"kind"`
+		Fields map[string]string `json:"fields,omitempty"`
+	}
+	out := make([]canonAction, len(actions))
+	for i, a := range actions {
+		var fields map[string]string
+		if len(a.Fields) > 0 {
+			// Re-emit in sorted-key order via an intermediate slice.
+			keys := make([]string, 0, len(a.Fields))
+			for k := range a.Fields {
+				keys = append(keys, k)
+			}
+			sort.Strings(keys)
+			fields = make(map[string]string, len(keys))
+			for _, k := range keys {
+				fields[k] = a.Fields[k]
+			}
+		}
+		out[i] = canonAction{Kind: a.Kind, Fields: fields}
+	}
+	// json.Marshal emits map keys in sorted order (encoding/json contract),
+	// so the emitted bytes are deterministic given the sorted-input map.
+	return json.Marshal(out)
+}
+
+// ComputePlanHash stamps PlanHash on p using the canonical encoding of
+// p.Actions. Any subsequent mutation to Actions is detectable by re-running
+// this function and comparing.
+func ComputePlanHash(p *Plan) error {
+	b, err := CanonicalActionsJSON(p.Actions)
+	if err != nil {
+		return err
+	}
+	p.PlanHash = sha256.Sum256(b)
+	return nil
+}

--- a/plane/application/policy/predicates.go
+++ b/plane/application/policy/predicates.go
@@ -1,0 +1,80 @@
+package policy
+
+import (
+	"path"
+	"strings"
+)
+
+// matchRule reports whether r fires against actions submitted by proposer.
+// A rule fires when at least one action satisfies the predicate-specific
+// criteria (or, for bulk_action, when the cardinality threshold is met, and
+// for agent_default, when the proposer is an agent and no earlier rule fired).
+//
+// The "no earlier rule fired" check is the caller's responsibility — the
+// engine evaluates rules in order and matchRule has no view of prior matches.
+// agent_default therefore matches purely on proposer_kind here; the first-
+// match-wins loop in Engine.SubmitPlan ensures the catch-all only wins when
+// nothing earlier did.
+func matchRule(r Rule, actions []Action, proposer ProposerKind) bool {
+	switch r.Kind {
+	case PredicatePRMerge:
+		return matchByField(actions, "pr_merge", "branch", r.Match["branch"])
+	case PredicateForcePush:
+		return matchByPattern(actions, "force_push", "ref", r.Match["ref_pattern"])
+	case PredicateProductionDeploy:
+		return matchByField(actions, "production_deploy", "environment", r.Match["environment"])
+	case PredicateBulkAction:
+		if r.Threshold == nil {
+			return false
+		}
+		return len(actions) >= *r.Threshold
+	case PredicateAgentDefault:
+		return proposer == ProposerKindAgent
+	}
+	return false
+}
+
+// matchByField reports whether any action of the given kind has a field
+// whose value equals want. An empty want matches any value (so a rule with
+// no Match constraint fires on every action of the kind).
+func matchByField(actions []Action, kind, field, want string) bool {
+	for _, a := range actions {
+		if a.Kind != kind {
+			continue
+		}
+		if want == "" {
+			return true
+		}
+		if a.Fields[field] == want {
+			return true
+		}
+	}
+	return false
+}
+
+// matchByPattern reports whether any action of kind has a field matching
+// the glob pattern. Patterns are filepath-style globs; an empty pattern
+// matches any value. Used by force_push for ref_pattern matching like
+// "refs/heads/release/*".
+func matchByPattern(actions []Action, kind, field, pattern string) bool {
+	for _, a := range actions {
+		if a.Kind != kind {
+			continue
+		}
+		v := a.Fields[field]
+		if pattern == "" {
+			return true
+		}
+		// path.Match returns ErrBadPattern only for malformed patterns; we
+		// treat that as a non-match and let validation surface upstream.
+		if ok, err := path.Match(pattern, v); err == nil && ok {
+			return true
+		}
+		// Convenience: trailing-slash and prefix matching for refs like
+		// "refs/heads/release/" matching "refs/heads/release/v1".
+		if strings.HasSuffix(pattern, "/*") && strings.HasPrefix(v, strings.TrimSuffix(pattern, "*")) {
+			return true
+		}
+	}
+	return false
+}

--- a/plane/application/policy/service.go
+++ b/plane/application/policy/service.go
@@ -1,0 +1,122 @@
+package policy
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/google/uuid"
+)
+
+// API error codes returned at the gRPC / REST boundary. Closed enum stable
+// across the wire surfaces; consumers map to user-facing copy.
+const (
+	CodePlanAlreadyDecided      = "plan_already_decided"
+	CodePlanExpired             = "plan_expired"
+	CodeDecisionUnauthorized    = "decision_unauthorized"
+	CodeDecisionQuorumAlreadyMet = "decision_quorum_already_met"
+	CodePlanNotFound            = "plan_not_found"
+	CodeRungOutOfRange          = "rung_out_of_range"
+	CodeFinalRungReached        = "final_rung_reached"
+)
+
+// APIError carries a closed-enum code and a contextual message. Mapped to
+// the appropriate gRPC status / HTTP status by the boundary handlers.
+type APIError struct {
+	Code    string
+	Message string
+}
+
+// Error implements error.
+func (e *APIError) Error() string {
+	return fmt.Sprintf("policy: %s: %s", e.Code, e.Message)
+}
+
+// IsAPICode reports whether err (or any wrapped error) is an APIError with
+// the given code. Used by boundary handlers and by tests.
+func IsAPICode(err error, code string) bool {
+	var ae *APIError
+	if !errors.As(err, &ae) {
+		return false
+	}
+	return ae.Code == code
+}
+
+// DecisionInput records a single human approver's verdict on a plan.
+// Approve=true means the approver has voted to approve; false means
+// reject. Reason is required for rejections (enforced by the service);
+// optional for approvals.
+type DecisionInput struct {
+	PlanID    uuid.UUID
+	ActorID   uuid.UUID  // HumanUser principal
+	Approve   bool
+	Reason    string
+	RungIndex int        // the rung this decision applies to
+}
+
+// DecisionOutcome reports the post-decision state of the plan.
+type DecisionOutcome struct {
+	Status     PlanStatus
+	QuorumMet  bool
+	Approvals  int
+	Rejections int
+}
+
+// EscalateInput moves the plan to the next rung when the current one's
+// SLA expired. Caller is the workflow plane (ApprovalActivity); the
+// service emits the corresponding outbox + audit row.
+type EscalateInput struct {
+	PlanID      uuid.UUID
+	FromRung    int
+	Reason      string // 'sla_breach' | 'fall_back'
+}
+
+// EscalateOutcome reports the next rung index and whether the ladder is
+// now exhausted (final_rung_reached → caller decides per OnTimeout).
+type EscalateOutcome struct {
+	NewRung      int
+	OnTimeout    OnTimeout // OnTimeout of the rung that just elapsed
+	FinalRung    bool      // true when no further rung exists
+}
+
+// ApprovalService is the application-plane API the workflow plane consumes.
+// In-process callers (REST handlers from #111 follow-up) and the gRPC
+// service surface both delegate here.
+//
+// Implementations MUST persist every state change inside a single SQL
+// transaction with the corresponding outbox row and (where applicable) a
+// policy_audit row chained off the latest row for the policy (ADR-008,
+// ADR-015 audit chain).
+type ApprovalService interface {
+	// SubmitPlan invokes the engine, persists the plan + audit row, and
+	// returns the Decision the workflow should act on.
+	SubmitPlan(ctx context.Context, plan *Plan) (Decision, error)
+
+	// RecordDecision records a single human approver's verdict on a plan.
+	// Returns the post-decision plan status. Caller's authorisation
+	// (membership in the rung's ApproverGroup) is the boundary handler's
+	// responsibility; the service trusts the ActorID claim presented to
+	// it (ADR-010 SVID).
+	RecordDecision(ctx context.Context, in DecisionInput) (DecisionOutcome, error)
+
+	// Escalate advances the plan to the next rung. Returns final_rung=true
+	// when no further rung exists; caller (ApprovalActivity) then applies
+	// the elapsed rung's OnTimeout.
+	Escalate(ctx context.Context, in EscalateInput) (EscalateOutcome, error)
+
+	// GetPlanStatus returns the current plan status. The workflow plane's
+	// ApprovalActivity polls this between escalations; in-process callers
+	// use it for read-after-write checks. Stateless; safe to call outside
+	// any Tx.
+	GetPlanStatus(ctx context.Context, planID uuid.UUID) (PlanStatus, error)
+}
+
+// AlreadyDecided is returned (wrapped in APIError{CodePlanAlreadyDecided})
+// when RecordDecision or Escalate observes a non-pending plan. ADR-015:
+// no double-decision once approved/rejected/expired/auto_*.
+var AlreadyDecided = errors.New("policy: plan already decided")
+
+// NewAPIError constructs an APIError. Convenience for service implementers.
+func NewAPIError(code, msg string) *APIError {
+	return &APIError{Code: code, Message: msg}
+}

--- a/plane/application/policy/service.go
+++ b/plane/application/policy/service.go
@@ -111,10 +111,10 @@ type ApprovalService interface {
 	GetPlanStatus(ctx context.Context, planID uuid.UUID) (PlanStatus, error)
 }
 
-// AlreadyDecided is returned (wrapped in APIError{CodePlanAlreadyDecided})
+// ErrAlreadyDecided is returned (wrapped in APIError{CodePlanAlreadyDecided})
 // when RecordDecision or Escalate observes a non-pending plan. ADR-015:
 // no double-decision once approved/rejected/expired/auto_*.
-var AlreadyDecided = errors.New("policy: plan already decided")
+var ErrAlreadyDecided = errors.New("policy: plan already decided")
 
 // NewAPIError constructs an APIError. Convenience for service implementers.
 func NewAPIError(code, msg string) *APIError {

--- a/plane/application/policy/service_test.go
+++ b/plane/application/policy/service_test.go
@@ -1,0 +1,30 @@
+package policy
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestAPIError_IsCode(t *testing.T) {
+	err := NewAPIError(CodePlanAlreadyDecided, "x")
+	if !IsAPICode(err, CodePlanAlreadyDecided) {
+		t.Fatal("IsAPICode should match")
+	}
+	if IsAPICode(err, CodePlanExpired) {
+		t.Fatal("IsAPICode false-positive")
+	}
+	if IsAPICode(errors.New("not an APIError"), CodePlanAlreadyDecided) {
+		t.Fatal("IsAPICode should not match plain error")
+	}
+	if IsAPICode(nil, CodePlanAlreadyDecided) {
+		t.Fatal("IsAPICode(nil) should be false")
+	}
+}
+
+func TestAPIError_ErrorMessage(t *testing.T) {
+	e := NewAPIError(CodeDecisionUnauthorized, "not in approver group")
+	want := "policy: decision_unauthorized: not in approver group"
+	if e.Error() != want {
+		t.Errorf("got %q want %q", e.Error(), want)
+	}
+}

--- a/plane/application/policy/validate.go
+++ b/plane/application/policy/validate.go
@@ -1,0 +1,160 @@
+package policy
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/google/uuid"
+)
+
+// Validation error codes. These are CLOSED enum strings stable across the
+// gRPC and REST surfaces; consumers map them to user-facing copy. Adding a
+// code requires updating the API error envelope spec in tandem.
+const (
+	CodeInvalidPredicateKind  = "policy_invalid_predicate_kind"
+	CodeEmptyLadder           = "policy_empty_ladder"
+	CodeUnknownApproverGroup  = "policy_unknown_approver_group"
+	CodeZeroRequiredCount     = "policy_zero_required_count"
+	CodeNonHumanApprover      = "policy_non_human_approver"
+	CodeInvalidOnTimeout      = "policy_invalid_on_timeout"
+	CodeBulkThresholdMissing  = "policy_bulk_threshold_missing"
+	CodeRequiredCountTooLarge = "policy_required_count_too_large"
+	CodeFallBackOnFirstRung   = "policy_fall_back_on_first_rung"
+	CodeEmptyName             = "policy_empty_name"
+	CodeNonPositiveExpiry     = "policy_non_positive_expiry"
+	CodeNonPositiveSLA        = "policy_non_positive_sla"
+	CodeNoRules               = "policy_no_rules"
+)
+
+// ValidationError carries a closed-enum Code and a contextual message. The
+// engine returns the first failure it observes; callers that need full
+// diagnostics should re-validate after fixing the first error.
+type ValidationError struct {
+	Code    string
+	Message string
+}
+
+// Error implements error.
+func (e *ValidationError) Error() string {
+	return fmt.Sprintf("policy: %s: %s", e.Code, e.Message)
+}
+
+// IsCode reports whether err (or any wrapped error) is a ValidationError
+// whose Code equals code. Useful in tests and at the gRPC error-mapping
+// layer.
+func IsCode(err error, code string) bool {
+	var ve *ValidationError
+	if !errors.As(err, &ve) {
+		return false
+	}
+	return ve.Code == code
+}
+
+// Validate runs the full set of structural checks on p. It does NOT verify
+// HMAC signatures (that lives in the store layer where the org KEK is in
+// scope) and does NOT confirm that referenced HumanUserIDs exist in the
+// identity domain (that is a defence-in-depth check at write time).
+//
+// A nil return means p is internally consistent and safe to pass to the
+// engine. The first error encountered is returned; ordering is stable.
+func Validate(p *Policy) error {
+	if p == nil {
+		return &ValidationError{Code: CodeEmptyName, Message: "policy is nil"}
+	}
+	if p.Name == "" {
+		return &ValidationError{Code: CodeEmptyName, Message: "policy.name is empty"}
+	}
+	if len(p.Rules) == 0 {
+		return &ValidationError{Code: CodeNoRules, Message: "policy.rules is empty"}
+	}
+
+	// Validate approver groups before rules so ladder cross-references
+	// resolve against a known-good map.
+	for name, g := range p.ApproverGroups {
+		if name != g.Name {
+			return &ValidationError{
+				Code:    CodeEmptyName,
+				Message: fmt.Sprintf("approver group key %q does not match group.Name %q", name, g.Name),
+			}
+		}
+		if g.RequiredCount <= 0 {
+			return &ValidationError{
+				Code:    CodeZeroRequiredCount,
+				Message: fmt.Sprintf("approver group %q has required_count <= 0", name),
+			}
+		}
+		if g.RequiredCount > len(g.HumanUserIDs) {
+			return &ValidationError{
+				Code:    CodeRequiredCountTooLarge,
+				Message: fmt.Sprintf("approver group %q required_count exceeds member count", name),
+			}
+		}
+		// ADR-015: every member must be a HumanUser. We can only check the
+		// shape of the slice (no nil UUIDs); identity-kind verification
+		// happens at write time when the identity reader is in scope.
+		for _, id := range g.HumanUserIDs {
+			if id == uuid.Nil {
+				return &ValidationError{
+					Code:    CodeNonHumanApprover,
+					Message: fmt.Sprintf("approver group %q contains a zero UUID", name),
+				}
+			}
+		}
+	}
+
+	// Validate each rule.
+	for i, r := range p.Rules {
+		if !r.Kind.IsValid() {
+			return &ValidationError{
+				Code:    CodeInvalidPredicateKind,
+				Message: fmt.Sprintf("rule[%d]: predicate kind %q is not in the closed enum", i, r.Kind),
+			}
+		}
+		if r.ExpirySeconds <= 0 {
+			return &ValidationError{
+				Code:    CodeNonPositiveExpiry,
+				Message: fmt.Sprintf("rule[%d]: expiry_seconds must be > 0", i),
+			}
+		}
+		if r.Kind == PredicateBulkAction && (r.Threshold == nil || *r.Threshold <= 0) {
+			return &ValidationError{
+				Code:    CodeBulkThresholdMissing,
+				Message: fmt.Sprintf("rule[%d]: bulk_action requires a positive threshold", i),
+			}
+		}
+		if len(r.Ladder) == 0 {
+			return &ValidationError{
+				Code:    CodeEmptyLadder,
+				Message: fmt.Sprintf("rule[%d]: ladder must contain at least one rung", i),
+			}
+		}
+		for j, rung := range r.Ladder {
+			if _, ok := p.ApproverGroups[rung.GroupName]; !ok {
+				return &ValidationError{
+					Code:    CodeUnknownApproverGroup,
+					Message: fmt.Sprintf("rule[%d].ladder[%d]: group %q not declared in approver_groups", i, j, rung.GroupName),
+				}
+			}
+			if rung.SLASeconds <= 0 {
+				return &ValidationError{
+					Code:    CodeNonPositiveSLA,
+					Message: fmt.Sprintf("rule[%d].ladder[%d]: sla_seconds must be > 0", i, j),
+				}
+			}
+			if !rung.OnTimeout.IsValid() {
+				return &ValidationError{
+					Code:    CodeInvalidOnTimeout,
+					Message: fmt.Sprintf("rule[%d].ladder[%d]: on_timeout %q is not in the closed enum", i, j, rung.OnTimeout),
+				}
+			}
+			if j == 0 && rung.OnTimeout == OnTimeoutFallBack {
+				return &ValidationError{
+					Code:    CodeFallBackOnFirstRung,
+					Message: fmt.Sprintf("rule[%d].ladder[0]: first rung cannot use on_timeout=fall_back", i),
+				}
+			}
+		}
+	}
+	return nil
+}
+

--- a/plane/application/policy/validate_test.go
+++ b/plane/application/policy/validate_test.go
@@ -1,0 +1,190 @@
+package policy
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+// validPolicy returns a baseline-valid Policy that individual tests mutate
+// to exercise a single failure path. Keeping the baseline isolated to a
+// helper means each test asserts exactly one root cause.
+func validPolicy() *Policy {
+	approver := uuid.New()
+	threshold := 50
+	return &Policy{
+		ID:      uuid.New(),
+		OrgID:   uuid.New(),
+		Name:    "default",
+		Version: 1,
+		ApproverGroups: map[string]ApproverGroup{
+			"oncall": {Name: "oncall", HumanUserIDs: []uuid.UUID{approver}, RequiredCount: 1},
+		},
+		Rules: []Rule{
+			{
+				Kind:          PredicatePRMerge,
+				Match:         map[string]string{"branch": "main"},
+				ExpirySeconds: 86400,
+				Ladder: []EscalationRung{
+					{GroupName: "oncall", SLASeconds: 3600, OnTimeout: OnTimeoutAutoDeny},
+				},
+			},
+			{
+				Kind:          PredicateBulkAction,
+				Threshold:     &threshold,
+				ExpirySeconds: 86400,
+				Ladder: []EscalationRung{
+					{GroupName: "oncall", SLASeconds: 3600, OnTimeout: OnTimeoutNotifyNext},
+					{GroupName: "oncall", SLASeconds: 1800, OnTimeout: OnTimeoutAutoDeny},
+				},
+			},
+		},
+	}
+}
+
+func TestValidate_Happy(t *testing.T) {
+	if err := Validate(validPolicy()); err != nil {
+		t.Fatalf("expected nil, got %v", err)
+	}
+}
+
+func TestValidate_NilPolicy(t *testing.T) {
+	if err := Validate(nil); !IsCode(err, CodeEmptyName) {
+		t.Fatalf("want CodeEmptyName, got %v", err)
+	}
+}
+
+func TestValidate_EmptyName(t *testing.T) {
+	p := validPolicy()
+	p.Name = ""
+	if err := Validate(p); !IsCode(err, CodeEmptyName) {
+		t.Fatalf("want CodeEmptyName, got %v", err)
+	}
+}
+
+func TestValidate_NoRules(t *testing.T) {
+	p := validPolicy()
+	p.Rules = nil
+	if err := Validate(p); !IsCode(err, CodeNoRules) {
+		t.Fatalf("want CodeNoRules, got %v", err)
+	}
+}
+
+func TestValidate_InvalidPredicateKind(t *testing.T) {
+	p := validPolicy()
+	p.Rules[0].Kind = PredicateKind("not_a_real_kind")
+	if err := Validate(p); !IsCode(err, CodeInvalidPredicateKind) {
+		t.Fatalf("want CodeInvalidPredicateKind, got %v", err)
+	}
+}
+
+func TestValidate_NonPositiveExpiry(t *testing.T) {
+	p := validPolicy()
+	p.Rules[0].ExpirySeconds = 0
+	if err := Validate(p); !IsCode(err, CodeNonPositiveExpiry) {
+		t.Fatalf("want CodeNonPositiveExpiry, got %v", err)
+	}
+}
+
+func TestValidate_BulkThresholdMissing(t *testing.T) {
+	p := validPolicy()
+	p.Rules[1].Threshold = nil
+	if err := Validate(p); !IsCode(err, CodeBulkThresholdMissing) {
+		t.Fatalf("want CodeBulkThresholdMissing, got %v", err)
+	}
+}
+
+func TestValidate_EmptyLadder(t *testing.T) {
+	p := validPolicy()
+	p.Rules[0].Ladder = nil
+	if err := Validate(p); !IsCode(err, CodeEmptyLadder) {
+		t.Fatalf("want CodeEmptyLadder, got %v", err)
+	}
+}
+
+func TestValidate_UnknownApproverGroup(t *testing.T) {
+	p := validPolicy()
+	p.Rules[0].Ladder[0].GroupName = "nope"
+	if err := Validate(p); !IsCode(err, CodeUnknownApproverGroup) {
+		t.Fatalf("want CodeUnknownApproverGroup, got %v", err)
+	}
+}
+
+func TestValidate_NonPositiveSLA(t *testing.T) {
+	p := validPolicy()
+	p.Rules[0].Ladder[0].SLASeconds = 0
+	if err := Validate(p); !IsCode(err, CodeNonPositiveSLA) {
+		t.Fatalf("want CodeNonPositiveSLA, got %v", err)
+	}
+}
+
+func TestValidate_InvalidOnTimeout(t *testing.T) {
+	p := validPolicy()
+	p.Rules[0].Ladder[0].OnTimeout = OnTimeout("explode")
+	if err := Validate(p); !IsCode(err, CodeInvalidOnTimeout) {
+		t.Fatalf("want CodeInvalidOnTimeout, got %v", err)
+	}
+}
+
+func TestValidate_FallBackOnFirstRung(t *testing.T) {
+	p := validPolicy()
+	p.Rules[0].Ladder[0].OnTimeout = OnTimeoutFallBack
+	if err := Validate(p); !IsCode(err, CodeFallBackOnFirstRung) {
+		t.Fatalf("want CodeFallBackOnFirstRung, got %v", err)
+	}
+}
+
+func TestValidate_ZeroRequiredCount(t *testing.T) {
+	p := validPolicy()
+	g := p.ApproverGroups["oncall"]
+	g.RequiredCount = 0
+	p.ApproverGroups["oncall"] = g
+	if err := Validate(p); !IsCode(err, CodeZeroRequiredCount) {
+		t.Fatalf("want CodeZeroRequiredCount, got %v", err)
+	}
+}
+
+func TestValidate_RequiredCountTooLarge(t *testing.T) {
+	p := validPolicy()
+	g := p.ApproverGroups["oncall"]
+	g.RequiredCount = 5 // only 1 member
+	p.ApproverGroups["oncall"] = g
+	if err := Validate(p); !IsCode(err, CodeRequiredCountTooLarge) {
+		t.Fatalf("want CodeRequiredCountTooLarge, got %v", err)
+	}
+}
+
+func TestValidate_NonHumanApprover_ZeroUUID(t *testing.T) {
+	p := validPolicy()
+	g := p.ApproverGroups["oncall"]
+	g.HumanUserIDs = []uuid.UUID{uuid.Nil}
+	p.ApproverGroups["oncall"] = g
+	if err := Validate(p); !IsCode(err, CodeNonHumanApprover) {
+		t.Fatalf("want CodeNonHumanApprover, got %v", err)
+	}
+}
+
+func TestPredicateKind_IsValid(t *testing.T) {
+	for _, k := range AllPredicateKinds() {
+		if !k.IsValid() {
+			t.Errorf("expected %q valid", k)
+		}
+	}
+	if PredicateKind("").IsValid() {
+		t.Error("empty kind reported valid")
+	}
+	if PredicateKind("nope").IsValid() {
+		t.Error("garbage kind reported valid")
+	}
+}
+
+func TestOnTimeout_IsValid(t *testing.T) {
+	for _, v := range []OnTimeout{OnTimeoutNotifyNext, OnTimeoutAutoDeny, OnTimeoutFallBack} {
+		if !v.IsValid() {
+			t.Errorf("expected %q valid", v)
+		}
+	}
+	if OnTimeout("").IsValid() {
+		t.Error("empty on_timeout reported valid")
+	}
+}

--- a/plane/workflow/appclient/policy.go
+++ b/plane/workflow/appclient/policy.go
@@ -1,0 +1,90 @@
+package appclient
+
+import (
+	"context"
+	"sync"
+
+	"github.com/google/uuid"
+
+	"github.com/gitscale-platform/gitscale/plane/application/policy"
+)
+
+// PolicyClient is the workflow-plane view of the application-plane policy
+// engine (ADR-019). The workflow plane MUST NOT call plane/data/store from
+// approval activities; every state change goes through this client which
+// fans out to plane/application/policy.ApprovalService.
+//
+// The interface mirrors policy.ApprovalService. Implementations: a real
+// gRPC client (filed as a follow-up) and StubPolicyClient (in-memory) for
+// workflow unit tests.
+type PolicyClient interface {
+	SubmitPlan(ctx context.Context, plan *policy.Plan) (policy.Decision, error)
+	RecordDecision(ctx context.Context, in policy.DecisionInput) (policy.DecisionOutcome, error)
+	Escalate(ctx context.Context, in policy.EscalateInput) (policy.EscalateOutcome, error)
+	GetPlanStatus(ctx context.Context, planID uuid.UUID) (policy.PlanStatus, error)
+}
+
+// StubPolicyClient records calls in memory and delegates to the supplied
+// service. Used by workflow unit tests; production wires the gRPC client.
+type StubPolicyClient struct {
+	mu      sync.Mutex
+	svc     policy.ApprovalService
+	submits []policy.Plan
+	escs    []policy.EscalateInput
+	polls   []uuid.UUID
+}
+
+// NewStubPolicyClient wraps svc.
+func NewStubPolicyClient(svc policy.ApprovalService) *StubPolicyClient {
+	return &StubPolicyClient{svc: svc}
+}
+
+// SubmitPlan delegates to the wrapped service.
+func (s *StubPolicyClient) SubmitPlan(ctx context.Context, plan *policy.Plan) (policy.Decision, error) {
+	s.mu.Lock()
+	s.submits = append(s.submits, *plan)
+	s.mu.Unlock()
+	return s.svc.SubmitPlan(ctx, plan)
+}
+
+// RecordDecision delegates to the wrapped service.
+func (s *StubPolicyClient) RecordDecision(ctx context.Context, in policy.DecisionInput) (policy.DecisionOutcome, error) {
+	return s.svc.RecordDecision(ctx, in)
+}
+
+// Escalate delegates to the wrapped service.
+func (s *StubPolicyClient) Escalate(ctx context.Context, in policy.EscalateInput) (policy.EscalateOutcome, error) {
+	s.mu.Lock()
+	s.escs = append(s.escs, in)
+	s.mu.Unlock()
+	return s.svc.Escalate(ctx, in)
+}
+
+// GetPlanStatus delegates to the wrapped service.
+func (s *StubPolicyClient) GetPlanStatus(ctx context.Context, planID uuid.UUID) (policy.PlanStatus, error) {
+	s.mu.Lock()
+	s.polls = append(s.polls, planID)
+	s.mu.Unlock()
+	return s.svc.GetPlanStatus(ctx, planID)
+}
+
+// SubmitCount returns the recorded SubmitPlan calls.
+func (s *StubPolicyClient) SubmitCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.submits)
+}
+
+// EscalateInputs returns a snapshot of all Escalate calls in order.
+func (s *StubPolicyClient) EscalateInputs() []policy.EscalateInput {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]policy.EscalateInput(nil), s.escs...)
+}
+
+// PollCount returns the number of GetPlanStatus calls.
+func (s *StubPolicyClient) PollCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.polls)
+}

--- a/plane/workflow/approval/activity.go
+++ b/plane/workflow/approval/activity.go
@@ -1,0 +1,163 @@
+package approval
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/gitscale-platform/gitscale/plane/application/policy"
+	"github.com/gitscale-platform/gitscale/plane/workflow/appclient"
+)
+
+// ActivityNameRequestApproval is the registered activity name. Stable so
+// workflow tests can dispatch by string without holding the activity
+// reference.
+const ActivityNameRequestApproval = "approval.RequestApproval"
+
+// PollInterval is how often the activity polls the application plane while
+// the plan is pending. Selected to balance load on the policy service
+// against decision latency. Production tuning is acceptable; the workflow
+// re-records the activity invocation across replays so changing this in
+// one deploy does not violate determinism.
+const PollInterval = 2 * time.Second
+
+// SLAJitter is added to each rung's SLA before the activity calls Escalate.
+// Prevents thundering-herd against the policy service when many activities
+// time out simultaneously.
+const SLAJitter = 5 * time.Second
+
+// Input is the activity parameter. The activity stamps the plan ID before
+// returning the result; callers receive the assigned ID via Result.PlanID.
+type Input struct {
+	OrgID        uuid.UUID
+	RepoID       *uuid.UUID
+	ProposerID   uuid.UUID
+	ProposerKind policy.ProposerKind
+	Actions      []policy.Action
+}
+
+// Result reports the final disposition of the approval cycle.
+type Result struct {
+	PlanID uuid.UUID
+	Status policy.PlanStatus
+}
+
+// Activity wraps a PolicyClient. Its single Execute method submits the
+// plan and long-polls the application plane until the plan is no longer
+// pending, escalating when the current rung's SLA elapses.
+type Activity struct {
+	client       appclient.PolicyClient
+	pollInterval time.Duration
+	slaJitter    time.Duration
+	now          func() time.Time
+}
+
+// NewActivity wraps client with default poll cadence.
+func NewActivity(client appclient.PolicyClient) *Activity {
+	return &Activity{
+		client:       client,
+		pollInterval: PollInterval,
+		slaJitter:    SLAJitter,
+		now:          func() time.Time { return time.Now().UTC() },
+	}
+}
+
+// SetTimingForTest overrides the poll interval, SLA jitter, and clock.
+// Used only by activity tests; production must not call this.
+func (a *Activity) SetTimingForTest(pollInterval, slaJitter time.Duration, now func() time.Time) {
+	a.pollInterval = pollInterval
+	a.slaJitter = slaJitter
+	if now != nil {
+		a.now = now
+	}
+}
+
+// Execute submits the plan via the application plane, then polls for the
+// decision. On SLA breach it calls Escalate; on a non-pending status it
+// returns. The activity returns an error only on transport faults — a
+// rejected/auto_denied plan is a successful execution that surfaces the
+// status to the workflow caller.
+func (a *Activity) Execute(ctx context.Context, in Input) (Result, error) {
+	if a.client == nil {
+		return Result{}, errors.New("approval: nil PolicyClient")
+	}
+	if !in.ProposerKind.IsValid() {
+		return Result{}, fmt.Errorf("approval: invalid proposer_kind %q", in.ProposerKind)
+	}
+	plan := &policy.Plan{
+		OrgID:        in.OrgID,
+		RepoID:       in.RepoID,
+		ProposerID:   in.ProposerID,
+		ProposerKind: in.ProposerKind,
+		Actions:      in.Actions,
+	}
+	d, err := a.client.SubmitPlan(ctx, plan)
+	if err != nil {
+		return Result{}, fmt.Errorf("approval: submit: %w", err)
+	}
+	// Auto-approve-no-rule and auto-denied are terminal at submission.
+	if d.AutoApproved || d.Status == policy.PlanStatusAutoApprovedNoRule {
+		return Result{PlanID: d.PlanID, Status: d.Status}, nil
+	}
+	if d.Status != policy.PlanStatusPending {
+		return Result{PlanID: d.PlanID, Status: d.Status}, nil
+	}
+
+	// Long-poll loop: poll every pollInterval; when the rung's SLA elapses,
+	// call Escalate. Loop exits when status leaves pending or context is
+	// canceled.
+	currentRung := 0
+	rungEnteredAt := a.now()
+	for {
+		// Honour cancellation; ctx.Err() takes precedence over poll errors.
+		if err := ctx.Err(); err != nil {
+			return Result{PlanID: d.PlanID, Status: policy.PlanStatusPending}, err
+		}
+
+		status, err := a.client.GetPlanStatus(ctx, d.PlanID)
+		if err != nil {
+			return Result{}, fmt.Errorf("approval: poll: %w", err)
+		}
+		if status != policy.PlanStatusPending {
+			return Result{PlanID: d.PlanID, Status: status}, nil
+		}
+
+		// SLA check uses the rung this activity entered into. The decision
+		// payload carries the full ladder; we pick the current rung from it.
+		if currentRung >= len(d.Ladder) {
+			// Defensive: ladder exhausted shouldn't happen in steady state
+			// because Escalate finalises with auto_denied. Surface as error.
+			return Result{}, errors.New("approval: ladder exhausted without decision")
+		}
+		rung := d.Ladder[currentRung]
+		deadline := rungEnteredAt.Add(time.Duration(rung.SLASeconds)*time.Second + a.slaJitter)
+		if a.now().After(deadline) {
+			out, err := a.client.Escalate(ctx, policy.EscalateInput{
+				PlanID:   d.PlanID,
+				FromRung: currentRung,
+				Reason:   "sla_breach",
+			})
+			if err != nil {
+				return Result{}, fmt.Errorf("approval: escalate: %w", err)
+			}
+			if out.FinalRung {
+				// Escalate already moved the plan to a terminal state; the
+				// next poll will see it and return.
+				continue
+			}
+			currentRung = out.NewRung
+			rungEnteredAt = a.now()
+			continue
+		}
+
+		// Sleep before next poll; honour cancellation during sleep.
+		select {
+		case <-ctx.Done():
+			return Result{PlanID: d.PlanID, Status: policy.PlanStatusPending}, ctx.Err()
+		case <-time.After(a.pollInterval):
+		}
+	}
+}

--- a/plane/workflow/approval/activity_test.go
+++ b/plane/workflow/approval/activity_test.go
@@ -1,0 +1,261 @@
+package approval
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/gitscale-platform/gitscale/plane/application/policy"
+	"github.com/gitscale-platform/gitscale/plane/workflow/appclient"
+)
+
+// makeServiceWithPolicy seeds a 2-rung policy on a fresh org and returns
+// the service, the org id, and the approver IDs.
+func makeServiceWithPolicy(t *testing.T) (*policy.MemService, uuid.UUID, []uuid.UUID) {
+	t.Helper()
+	a1, a2, a3 := uuid.New(), uuid.New(), uuid.New()
+	p := &policy.Policy{
+		ID:    uuid.New(),
+		OrgID: uuid.New(),
+		Name:  "test",
+		ApproverGroups: map[string]policy.ApproverGroup{
+			"oncall":   {Name: "oncall", HumanUserIDs: []uuid.UUID{a1}, RequiredCount: 1},
+			"security": {Name: "security", HumanUserIDs: []uuid.UUID{a2, a3}, RequiredCount: 2},
+		},
+		Rules: []policy.Rule{
+			{
+				Kind:          policy.PredicatePRMerge,
+				Match:         map[string]string{"branch": "main"},
+				ExpirySeconds: 86400,
+				Ladder: []policy.EscalationRung{
+					{GroupName: "oncall", SLASeconds: 1, OnTimeout: policy.OnTimeoutNotifyNext},
+					{GroupName: "security", SLASeconds: 1, OnTimeout: policy.OnTimeoutAutoDeny},
+				},
+			},
+		},
+	}
+	svc := policy.NewMemService(nil)
+	if err := svc.RegisterPolicy(p); err != nil {
+		t.Fatal(err)
+	}
+	return svc, p.OrgID, []uuid.UUID{a1, a2, a3}
+}
+
+// probeClient wraps a real PolicyClient and signals on every poll so the
+// test can react when the activity has submitted the plan.
+type probeClient struct {
+	inner    appclient.PolicyClient
+	planIDCh chan uuid.UUID
+	once     bool
+}
+
+func (p *probeClient) SubmitPlan(ctx context.Context, plan *policy.Plan) (policy.Decision, error) {
+	d, err := p.inner.SubmitPlan(ctx, plan)
+	if err == nil && !p.once {
+		p.once = true
+		// non-blocking send so the test can drop the channel.
+		select {
+		case p.planIDCh <- d.PlanID:
+		default:
+		}
+	}
+	return d, err
+}
+
+func (p *probeClient) RecordDecision(ctx context.Context, in policy.DecisionInput) (policy.DecisionOutcome, error) {
+	return p.inner.RecordDecision(ctx, in)
+}
+
+func (p *probeClient) Escalate(ctx context.Context, in policy.EscalateInput) (policy.EscalateOutcome, error) {
+	return p.inner.Escalate(ctx, in)
+}
+
+func (p *probeClient) GetPlanStatus(ctx context.Context, planID uuid.UUID) (policy.PlanStatus, error) {
+	return p.inner.GetPlanStatus(ctx, planID)
+}
+
+func TestActivity_ApprovesAtRung0_WithProbe(t *testing.T) {
+	svc, orgID, approvers := makeServiceWithPolicy(t)
+	probe := &probeClient{
+		inner:    appclient.NewStubPolicyClient(svc),
+		planIDCh: make(chan uuid.UUID, 1),
+	}
+	a := NewActivity(probe)
+	a.SetTimingForTest(20*time.Millisecond, 200*time.Millisecond, nil)
+
+	// Approver goroutine: wait for plan ID, then approve at rung 0.
+	go func() {
+		select {
+		case planID := <-probe.planIDCh:
+			time.Sleep(30 * time.Millisecond)
+			if _, err := svc.RecordDecision(context.Background(), policy.DecisionInput{
+				PlanID: planID, ActorID: approvers[0], Approve: true, RungIndex: 0,
+			}); err != nil {
+				t.Errorf("approver record: %v", err)
+			}
+		case <-time.After(2 * time.Second):
+			t.Error("never received plan ID")
+		}
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	res, err := a.Execute(ctx, Input{
+		OrgID:        orgID,
+		ProposerID:   uuid.New(),
+		ProposerKind: policy.ProposerKindAgent,
+		Actions:      []policy.Action{{Kind: "pr_merge", Fields: map[string]string{"branch": "main"}}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Status != policy.PlanStatusApproved {
+		t.Errorf("want approved, got %s", res.Status)
+	}
+}
+
+func TestActivity_AutoApprovedNoRule_TerminatesImmediately(t *testing.T) {
+	svc, orgID, _ := makeServiceWithPolicy(t)
+	client := appclient.NewStubPolicyClient(svc)
+	a := NewActivity(client)
+	a.SetTimingForTest(20*time.Millisecond, 50*time.Millisecond, nil)
+
+	// Service proposer + non-main branch + no agent_default → auto-approved
+	// at submission, no polling needed.
+	res, err := a.Execute(context.Background(), Input{
+		OrgID:        orgID,
+		ProposerID:   uuid.New(),
+		ProposerKind: policy.ProposerKindService,
+		Actions:      []policy.Action{{Kind: "pr_merge", Fields: map[string]string{"branch": "feature-x"}}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Status != policy.PlanStatusAutoApprovedNoRule {
+		t.Errorf("want auto_approved_no_rule, got %s", res.Status)
+	}
+	if client.PollCount() != 0 {
+		t.Errorf("auto-approved should not poll, got %d polls", client.PollCount())
+	}
+}
+
+func TestActivity_AllRungsExhausted_AutoDenied(t *testing.T) {
+	svc, orgID, _ := makeServiceWithPolicy(t)
+	client := appclient.NewStubPolicyClient(svc)
+	a := NewActivity(client)
+	// Tight timing: SLA of 1 second + jitter 0 → escalate as soon as the
+	// fake clock advances past the rung deadline. The clock is read via
+	// an atomic counter so there is no data race between the test
+	// goroutine advancing it and the activity reading it.
+	startNanos := time.Now().UTC().UnixNano()
+	var advance int64
+	clock := func() time.Time {
+		extra := atomic.LoadInt64(&advance)
+		return time.Unix(0, startNanos+extra).UTC()
+	}
+	a.SetTimingForTest(5*time.Millisecond, 0, clock)
+
+	// Goroutine: advance the fake clock past each SLA so the activity
+	// observes deadline elapsed and calls Escalate. After two escalations
+	// the second rung's auto_deny finalises the plan.
+	done := make(chan struct{})
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		atomic.StoreInt64(&advance, int64(2*time.Second))
+		time.Sleep(40 * time.Millisecond)
+		atomic.StoreInt64(&advance, int64(4*time.Second))
+		close(done)
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	res, err := a.Execute(ctx, Input{
+		OrgID:        orgID,
+		ProposerID:   uuid.New(),
+		ProposerKind: policy.ProposerKindAgent,
+		Actions:      []policy.Action{{Kind: "pr_merge", Fields: map[string]string{"branch": "main"}}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	<-done
+	if res.Status != policy.PlanStatusAutoDenied {
+		t.Errorf("want auto_denied, got %s", res.Status)
+	}
+}
+
+func TestActivity_NilClient(t *testing.T) {
+	a := &Activity{client: nil, pollInterval: PollInterval, slaJitter: SLAJitter, now: func() time.Time { return time.Now().UTC() }}
+	_, err := a.Execute(context.Background(), Input{
+		OrgID:        uuid.New(),
+		ProposerKind: policy.ProposerKindAgent,
+	})
+	if err == nil {
+		t.Fatal("expected error for nil client")
+	}
+}
+
+func TestActivity_InvalidProposerKind(t *testing.T) {
+	svc, orgID, _ := makeServiceWithPolicy(t)
+	client := appclient.NewStubPolicyClient(svc)
+	a := NewActivity(client)
+	_, err := a.Execute(context.Background(), Input{
+		OrgID:        orgID,
+		ProposerKind: policy.ProposerKind("alien"),
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid proposer_kind")
+	}
+}
+
+func TestActivity_SubmitTransportError(t *testing.T) {
+	failing := &failingClient{err: errors.New("grpc unavailable")}
+	a := NewActivity(failing)
+	_, err := a.Execute(context.Background(), Input{
+		OrgID:        uuid.New(),
+		ProposerKind: policy.ProposerKindAgent,
+		Actions:      []policy.Action{{Kind: "pr_merge"}},
+	})
+	if err == nil {
+		t.Fatal("expected error on submit failure")
+	}
+}
+
+func TestActivity_ContextCancelDuringPoll(t *testing.T) {
+	svc, orgID, _ := makeServiceWithPolicy(t)
+	client := appclient.NewStubPolicyClient(svc)
+	a := NewActivity(client)
+	a.SetTimingForTest(50*time.Millisecond, 1*time.Hour, nil) // never escalate
+
+	ctx, cancel := context.WithTimeout(context.Background(), 80*time.Millisecond)
+	defer cancel()
+	_, err := a.Execute(ctx, Input{
+		OrgID:        orgID,
+		ProposerID:   uuid.New(),
+		ProposerKind: policy.ProposerKindAgent,
+		Actions:      []policy.Action{{Kind: "pr_merge", Fields: map[string]string{"branch": "main"}}},
+	})
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Errorf("want DeadlineExceeded, got %v", err)
+	}
+}
+
+// failingClient returns err on every call.
+type failingClient struct{ err error }
+
+func (f *failingClient) SubmitPlan(_ context.Context, _ *policy.Plan) (policy.Decision, error) {
+	return policy.Decision{}, f.err
+}
+func (f *failingClient) RecordDecision(_ context.Context, _ policy.DecisionInput) (policy.DecisionOutcome, error) {
+	return policy.DecisionOutcome{}, f.err
+}
+func (f *failingClient) Escalate(_ context.Context, _ policy.EscalateInput) (policy.EscalateOutcome, error) {
+	return policy.EscalateOutcome{}, f.err
+}
+func (f *failingClient) GetPlanStatus(_ context.Context, _ uuid.UUID) (policy.PlanStatus, error) {
+	return "", f.err
+}

--- a/plane/workflow/approval/bundle.go
+++ b/plane/workflow/approval/bundle.go
@@ -1,0 +1,21 @@
+package approval
+
+import (
+	gswf "github.com/gitscale-platform/gitscale/plane/workflow"
+)
+
+// Bundle returns the activity-only registration set for the approval
+// activity. The bundle has no workflows: ApprovalActivity is invoked from
+// other workflows (CI, agent-session, etc.) on their own task queues. We
+// register on QueueAgentSessions because agent plans are the dominant
+// expected source; CI and billing workflows that need it can register the
+// same activity on their queues by composing this bundle.
+func Bundle(act *Activity) gswf.Bundle {
+	return gswf.Bundle{
+		TaskQueue: gswf.QueueAgentSessions,
+		Workflows: nil,
+		Activities: []any{
+			gswf.NamedActivity{Name: ActivityNameRequestApproval, Activity: act.Execute},
+		},
+	}
+}

--- a/plane/workflow/approval/doc.go
+++ b/plane/workflow/approval/doc.go
@@ -1,0 +1,18 @@
+// Package approval is the workflow-plane plan-approval activity. It wraps
+// appclient.PolicyClient as a Temporal activity so workflows can gate
+// state-mutating actions behind the application-plane plan-approval engine
+// (ADR-015, ADR-019).
+//
+// The activity is the only workflow-plane code allowed to interact with
+// plan approvals. It MUST NOT import plane/data/store directly: the static
+// architecture lint enforces that no Transact*/WriteOutbox*/Insert*/
+// Update*/Delete* call is reachable from this package. Every state change
+// goes through PolicyClient, which fans out to the application plane and
+// writes the source row + outbox row in a single SQL transaction.
+//
+// Determinism: this package contains an activity, not a workflow, so the
+// determinism lint (plane/workflow/lint) does not apply. The activity is
+// free to use time.Now, sleep, and context cancellation; workflow callers
+// invoke it via workflow.ExecuteActivity which preserves replay
+// determinism.
+package approval


### PR DESCRIPTION
## Summary

- Introduce the application-plane plan-approval policy engine: closed-enum DSL (Policy, Rule, PredicateKind, ApproverGroup, EscalationRung) with structural validation that returns closed-enum error codes, an Engine that evaluates predicates first-match-wins, and an ApprovalService interface that mirrors the eventual gRPC surface.
- Implement Merkle-chained audit log: AuditRow with prev_hash + row_hash chain anchored on a 32-byte genesis hash; canonical-JSON helper for stable hashing; tamper-detection via VerifyChain.
- Ship workflow-plane ApprovalActivity that calls appclient.PolicyClient exclusively (ADR-019); long-polls plan status, escalates on rung SLA breach, terminates on approved/rejected/auto_denied/auto_approved_no_rule.
- In-memory MemService is the reference ApprovalService used by activity tests; PG-backed impl + gRPC stubs + REST endpoints filed as follow-up issues per the plan.

## ADR impact

- **ADR-015** — conforming. PredicateKind closed enum (5 kinds); HumanUser-only approvers; no platform-default auto_approve (auto_approved_no_rule is an explicit audited disposition); plan-hash binding via ComputePlanHash; Merkle audit log with required fields; OnTimeout closed enum (notify_next/auto_deny/fall_back); first-rung fall_back rejected at validation.
- **ADR-019** — conforming. plane/workflow/approval imports only plane/application/policy types and plane/workflow/appclient — no plane/data/store reach. The activity is the only workflow-plane gate for approvals; workflows compose it on their own task queues.
- **ADR-008** — conforming. ApprovalService contract specifies same-Tx source-row + outbox-row + audit-row writes; the in-memory MemService preserves the call shape so PG impl is a drop-in.
- **ADR-017** — conforming. ApprovalService, PolicyLoader, PlanRecorder are interfaces; concrete in-memory impl is one of the conforming implementations.

## Scope notes

This PR delivers the load-bearing safety boundary: types, engine, audit chain, service interface, in-memory backend, and workflow activity. Items deferred to follow-up issues so the PR stays reviewable:

- PG-backed ApprovalService (requires new ``application`` schema domain in plane/data/store, migration, compliance suite).
- gRPC service + proto generation (proto/policy/v1; appclient gRPC binding).
- REST endpoints atop the plane/application/restapi router (depends on #111 landing first).
- Architecture-lint extension asserting plane/workflow/approval cannot reach Transact*/WriteOutbox*/Insert*/Update*/Delete* (depends on internal/architecture/ package landing).
- Migration of plane/workflow/billing/RequestOperatorApprovalActivity callers to the generic activity (deferred per plan §10).

The PR is the minimal cohesive slice that lets downstream issues fill in persistence + transport without re-litigating types or semantics.

## Test plan

- [x] DSL validation: one test per closed-enum error code (CodeInvalidPredicateKind, CodeEmptyLadder, CodeUnknownApproverGroup, CodeZeroRequiredCount, CodeRequiredCountTooLarge, CodeNonHumanApprover, CodeInvalidOnTimeout, CodeBulkThresholdMissing, CodeFallBackOnFirstRung, CodeNonPositiveExpiry, CodeNonPositiveSLA, CodeNoRules) plus happy-path.
- [x] Predicate matchers: one test per kind matching + non-matching; first-match-wins ordering test; agent_default ignores service proposers; force_push glob matching; production_deploy 4-hour expiry honoured.
- [x] Plan-hash stability across map iteration order; mutation detection.
- [x] Merkle audit chain: genesis verifies; chains of length 1, 100, 1000 verify; payload tamper, prev_hash tamper, actor_kind tamper all detected at correct row index.
- [x] In-memory ApprovalService: submit then approve at rung 0; escalate to rung 1 then auto_deny; rejection short-circuits; reject requires reason; non-approver decision returns decision_unauthorized; double-decision returns plan_already_decided; expiry returns plan_expired; auto_approved_no_rule emits explicit audit row; full audit chain verifies after multi-step decision flow.
- [x] ApprovalActivity: approves at rung 0 with probe client; auto_approved_no_rule terminates without polling; all rungs exhausted yields auto_denied with fake clock; nil client errors; invalid proposer_kind errors; submit transport error propagates; context cancellation during poll yields DeadlineExceeded.
- [x] ``go build ./...``, ``go vet ./...``, ``golangci-lint run ./...``, ``go test -race`` clean.
- [x] ``make lint-events``, ``make lint-determinism``, ``make lint-md`` clean.

## Cross-links

- Spec: ``docs/superpowers/specs/2026-05-09-issue-115-plan-approval-policy-dsl-design.md``
- Plan: ``docs/superpowers/plans/2026-05-09-issue-115-plan-approval-policy-dsl-plan.md``

Closes #115

<details>
<summary>Self-review battery</summary>

Reviewed against:

- gitscale-adr-guard: no cross-plane import violations; ADR-015/019/008/017 conformance recorded above.
- gitscale-go-conventions: golangci-lint clean (0 issues); idiomatic ``%w`` wrapping; closed-enum methods (IsValid) on every enum; doc comments on every exported symbol.
- gitscale-temporal-determinism: ApprovalActivity uses time.Now and time.After freely (activity, not workflow); determinism lint scans only workflow*.go and workflows/*.go and reports clean.
- gitscale-plane-boundary: plane/workflow/approval imports only plane/application/policy and plane/workflow/appclient; no plane/data/store reach.
- pr-review-toolkit:silent-failure-hunter: error returns wrapped with %w throughout; rejected plan with empty reason raises CodeDecisionUnauthorized rather than silently accepting; no swallowed errors except the deliberate unaudited writes inside MemService where the audit append cannot fail (in-memory map append).
- pr-review-toolkit:type-design-analyzer: closed enums (PredicateKind, OnTimeout, ProposerKind, PlanStatus, AuditEventKind, ActorKind) carry IsValid; APIError + ValidationError carry stable Code strings.
- pr-review-toolkit:pr-test-analyzer: every closed-enum code path has a dedicated test; race detector enabled; fake clock used for time-sensitive activity test to avoid flakes.

</details>

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>