### PR TITLE
docs(meta): spec + plan for issue #113 GraphQL API

### DIFF
--- a/docs/superpowers/plans/2026-05-09-issue-113-graphql-api-plan.md
+++ b/docs/superpowers/plans/2026-05-09-issue-113-graphql-api-plan.md
@@ -1,0 +1,299 @@
+# Issue #113 GraphQL API — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a field-stable GitHub-compat GraphQL surface mounted at `/graphql` and `/graphql/persisted/{hash}`, with pre-execution cost analysis (depth + complexity + agent-class multiplier), persisted-query path with cost discount, follower-read default, and SLO-backed GA gating. Mirrors `plane/application/restapi/` patterns.
+
+**Architecture:** `graph-gophers/graphql-go` schema-first runtime, single `schema.graphql` SDL source of truth, custom AST-walking cost analyzer, two-pool follower-read dispatch (`Primary` + `Reader` `MetadataStore` instances per ADR-017), persisted-query store backed by Postgres + `CacheStore` read-through, `ratelimit.RateLimiter` cost-as-tokens metering against `surface="graphql"`.
+
+**Tech Stack:** Go 1.22, `github.com/graph-gophers/graphql-go`, stdlib `net/http`, pgx/v5, testcontainers-go, google/uuid.
+
+**Spec:** `docs/superpowers/specs/2026-05-09-issue-113-graphql-api-design.md`
+
+**Branch:** `feat/application-graphql-api` (worktree: `../gitscale.worktrees/feat-application-graphql-api`)
+
+**ADR-impact:** conforming (ADR-017 swap surface, ADR-008 outbox by composition, ADR-019 plane boundary, ADR-010 SVID re-verify on admin mutations). No new ADR.
+
+---
+
+## File map
+
+### Create
+
+- `plane/application/graphql/doc.go` — package doc, ADR-017 quote, plane boundary statement
+- `plane/application/graphql/schema/schema.graphql` — SDL, single source of truth
+- `plane/application/graphql/schema/schema_test.go` — SDL parse + smoke
+- `plane/application/graphql/schema/github_subset_snapshot.graphql` — vendored named-subset snapshot from GitHub for diff
+- `plane/application/graphql/schema/compat_test.go` — diff named subset vs GitHub snapshot
+- `plane/application/graphql/cost/analyzer.go` — `Analyzer`, `Cost`, `Analyze(...)`
+- `plane/application/graphql/cost/analyzer_test.go` — table-driven
+- `plane/application/graphql/cost/directives.go` — `@cost`, `@liveRead` directive helpers
+- `plane/application/graphql/persisted/store.go` — `Store` interface
+- `plane/application/graphql/persisted/postgres_store.go` — PG-backed `Store`
+- `plane/application/graphql/persisted/postgres_store_test.go` — testcontainers
+- `plane/application/graphql/persisted/cached_store.go` — `CacheStore` read-through wrapper
+- `plane/application/graphql/persisted/cached_store_test.go`
+- `plane/application/graphql/resolvers/root.go` — `Query`, `Mutation` root resolvers
+- `plane/application/graphql/resolvers/repository.go`
+- `plane/application/graphql/resolvers/user.go`
+- `plane/application/graphql/resolvers/mutation.go`
+- `plane/application/graphql/resolvers/*_test.go`
+- `plane/application/graphql/middleware/auth.go` — adapter onto `restapi/middleware.PrincipalResolver`
+- `plane/application/graphql/middleware/auth_test.go`
+- `plane/application/graphql/middleware/cost_meter.go` — bucket charge, parse-cost on reject
+- `plane/application/graphql/middleware/cost_meter_test.go`
+- `plane/application/graphql/middleware/follower_read.go` — Primary vs Reader dispatch
+- `plane/application/graphql/middleware/follower_read_test.go`
+- `plane/application/graphql/errors.go` — `ErrorCode` enum, `mapErr`, gqlError envelope
+- `plane/application/graphql/errors_test.go`
+- `plane/application/graphql/router.go` — `NewHandler(Deps) http.Handler`, `Deps` struct
+- `plane/application/graphql/router_test.go`
+- `plane/application/graphql/integration_test.go` — testcontainers PG end-to-end
+- `cmd/graphql-api/main.go` — wires Reader + Primary pools, persisted store, deps
+- `cmd/graphql-api/integration_test.go` — binary smoke test
+- `plane/data/migrations/NNN_graphql_persisted_queries.sql` — `graphql.persisted_queries` table
+
+### Modify
+
+- `plane/data/store/metadata.go` — no method changes; verify `MetadataStore` exposes a connection knob suitable for replica-routing OR confirm it's already pool-agnostic and we wire two instances at `cmd/graphql-api/main.go` (recommended path; no interface change)
+- `plane/data/compliance/` — add `graphql.persisted_queries` to schema-existence assertions if the compliance suite enumerates tables
+- `Makefile` — add `lint-graphql` target invoking `graphql-schema-linter` and the GitHub-subset diff
+- `.github/workflows/ci.yml` — invoke `make lint-graphql` in the lint job
+- `go.mod` / `go.sum` — add `github.com/graph-gophers/graphql-go`
+
+### Untouched (out of scope)
+
+- REST surface (`plane/application/restapi/`) internals — only `middleware.PrincipalResolver` interface is reused
+- gRPC servers
+- MCP wiring (#112)
+- Webhook delivery
+- `pullrequests.Service` implementation (separate dep; resolver returns `NOT_IMPLEMENTED` until landed)
+- Subscriptions / WebSocket transport
+- Federation
+
+---
+
+## Pre-flight (do once before Task 1)
+
+- [ ] **Step P.1: Create worktree**
+
+```bash
+cd /home/mitta/clients/gitscale/repos/gitscale-platform/gitscale
+git fetch --all --prune
+mkdir -p /home/mitta/clients/gitscale/repos/gitscale.worktrees
+git worktree add -b feat/application-graphql-api \
+    /home/mitta/clients/gitscale/repos/gitscale.worktrees/feat-application-graphql-api \
+    origin/main
+cd /home/mitta/clients/gitscale/repos/gitscale.worktrees/feat-application-graphql-api
+git status --porcelain
+```
+
+- [ ] **Step P.2: Verify baseline**
+
+```bash
+go build ./...
+go vet ./...
+go test ./plane/application/restapi/... -count=1
+```
+
+If anything fails, stop — baseline is broken.
+
+- [ ] **Step P.3: Confirm Go toolchain ≥ 1.22 and #111 merged**
+
+```bash
+go version
+git log --oneline origin/main | grep -E "(REST API HTTP layer|#111)" | head -3
+```
+
+- [ ] **Step P.4: Vendor GitHub GraphQL schema snapshot**
+
+Download the public GitHub GraphQL schema (https://docs.github.com/en/graphql/overview/public-schema) and trim to the named subset (Query roots: `repository`, `user`, `agent`-stand-in, `pullRequest`, `organization` and the connection types they reach). Commit as `plane/application/graphql/schema/github_subset_snapshot.graphql`. Note: GitHub has no `agent` root — our `agent` is GitScale-specific, so the diff check excludes it.
+
+---
+
+## Task 1 — SDL + schema package
+
+- [ ] **1.1** Author `schema/schema.graphql` with the types listed in spec §Schema. Include `@cost`, `@liveRead`, `@deprecated(reason, removalDate)` directive declarations.
+- [ ] **1.2** Add `schema_test.go`: parse via `graphql.MustParseSchema` (graph-gophers); fail on parse error.
+- [ ] **1.3** Add `compat_test.go`: load `github_subset_snapshot.graphql`, walk the named subset (`Repository`, `User`, `PullRequest`, `Organization`, plus their connection types), assert every field name in the snapshot exists with the same name in our schema. Excludes `Agent` (GitScale-specific) and any field tagged `@gitscale:extension` in our schema.
+- [ ] **1.4** Add `Makefile` target `lint-graphql` running `graphql-schema-linter` (config in `.graphql-schema-linter.json`) and `go test ./plane/application/graphql/schema/...`.
+- [ ] **1.5** Wire `lint-graphql` into CI lint job.
+- [ ] **1.6** Acceptance: `make lint-graphql` green; deliberate field rename in the SDL fails the compat test.
+
+## Task 2 — Cost analyzer
+
+- [ ] **2.1** `cost/analyzer.go`:
+  ```go
+  type Cost struct{ Depth, Complexity int }
+  type PrincipalKind int
+
+  type Limits struct {
+      MaxDepth          map[PrincipalKind]int  // human=10, agent=8
+      MaxComplexity     map[PrincipalKind]int  // human=1000, agent=5000
+      PersistedDiscount float64                // 0.5
+      DefaultFirst      int                    // 20
+      MaxFirst          int                    // 100
+  }
+
+  type Analyzer struct {
+      schema *graphql.Schema
+      lim    Limits
+  }
+
+  func (a *Analyzer) Analyze(query string, op string, vars map[string]any,
+      kind PrincipalKind, persisted bool) (Cost, error)
+  ```
+- [ ] **2.2** Implementation walks parsed AST, tracks max depth, sums field weights × multiplier-arg values (capped at `MaxFirst`). Persisted: `Complexity = ⌈Complexity × PersistedDiscount⌉`. Returns typed `ErrDepthExceeded` / `ErrCostBudgetExceeded` carrying the cost details.
+- [ ] **2.3** `analyzer_test.go`: 30+ table-driven cases covering simple lookup (cost ~1), connection w/ first=50 (cost 100), nested 3-deep agent query (depth=3 ok), 11-deep human (depth-rejected), persisted discount path, missing `first` defaults to 20.
+- [ ] **2.4** Acceptance: `go test ./plane/application/graphql/cost/...` green.
+
+## Task 3 — Persisted-query store
+
+- [ ] **3.1** Migration `NNN_graphql_persisted_queries.sql`:
+  ```sql
+  CREATE SCHEMA IF NOT EXISTS graphql;
+
+  CREATE TABLE graphql.persisted_queries (
+    hash           TEXT PRIMARY KEY,            -- "sha256:" prefix + 64 hex
+    query          TEXT NOT NULL,
+    registered_by  UUID NOT NULL,
+    created_at     TIMESTAMPTZ NOT NULL DEFAULT now()
+  );
+  ```
+- [ ] **3.2** `persisted/store.go` interface:
+  ```go
+  type Store interface {
+      Get(ctx context.Context, hash string) (string, error) // ErrNotFound on miss
+      Put(ctx context.Context, hash, query string, registeredBy uuid.UUID) error // ErrHashConflict on body mismatch
+  }
+  ```
+- [ ] **3.3** `postgres_store.go`: `Get` is `SELECT query FROM graphql.persisted_queries WHERE hash = $1`. `Put` is `INSERT … ON CONFLICT (hash) DO NOTHING`; if conflict, `SELECT query`, compare; mismatch → `ErrHashConflict`.
+- [ ] **3.4** `cached_store.go`: read-through wrapping `Store` + `CacheStore`. Put writes through to underlying then `CacheStore.Set(hash, query, 24h)`.
+- [ ] **3.5** Tests: testcontainers PG for `postgres_store_test.go`; stub-cache for `cached_store_test.go`.
+- [ ] **3.6** Acceptance: `go test ./plane/application/graphql/persisted/... -tags integration` green.
+
+## Task 4 — Errors + middleware
+
+- [ ] **4.1** `errors.go`: closed `ErrorCode` enum from spec; `mapErr(error) (gqlError)` exhaustive on cost-analyzer sentinels, identity sentinels (`ErrAgentNotFound` → `NOT_FOUND` etc.), persisted `ErrNotFound` / `ErrHashConflict`, ratelimit, default `INTERNAL`.
+- [ ] **4.2** `middleware/auth.go`: thin adapter that calls `restapi/middleware.PrincipalResolver.Resolve` and injects `Principal` into `context.Context` under a `graphql`-package context key. Skip path: `GET /graphql` introspection (`__schema` only) is permitted unauthenticated for tooling discovery — explicit allowlist of `__schema`/`__type` operations.
+- [ ] **4.3** `middleware/cost_meter.go`:
+  ```go
+  type CostMeter struct { Limiter ratelimit.RateLimiter }
+  func (m *CostMeter) Charge(ctx context.Context, p Principal, c cost.Cost, accepted bool) error
+  ```
+  Surface key `"graphql"`. Accepted: charge `Complexity` tokens. Rejected: charge `parseCost = max(20, ⌈Complexity/10⌉)`. Bucket exhausted → `RATE_LIMITED` with `Retry-After`.
+- [ ] **4.4** `middleware/follower_read.go`:
+  ```go
+  type Pools struct { Reader, Primary store.MetadataStore }
+  func StoreFor(ctx context.Context, pools Pools, op ast.OperationType, fieldHasLiveRead bool) store.MetadataStore
+  ```
+  Mutation → Primary. Query with `@liveRead` anywhere on the operation → Primary. Else Reader.
+- [ ] **4.5** Tests for each middleware. Two-distinct-stub-stores test for follower_read confirming the right pool was hit.
+
+## Task 5 — Resolvers
+
+- [ ] **5.1** `resolvers/root.go`: `RootResolver` struct holding `Deps`; methods `Repository`, `User`, `Agent`, `PullRequest`, `Organization` for queries; field methods on each child resolver type.
+- [ ] **5.2** `resolvers/repository.go` etc.: each resolver pulls `MetadataStore` from context via `follower_read.StoreFor`, never imports `pgx` or `redis`.
+- [ ] **5.3** `resolvers/mutation.go`: `CreatePullRequest` returns `NOT_IMPLEMENTED` if `Deps.PullRequests` is nil; otherwise calls into the gRPC client. `CreateAgent` and `UpdateAgentPermissions` call `identity.Service` and require SVID re-verify (via `Deps.SVIDVerifier.ReVerify(ctx)`; ADR-010). On re-verify failure → `FORBIDDEN`.
+- [ ] **5.4** Per-resolver unit tests with `StubMetadataStore`, `StubIdentity`, fixed principal.
+
+## Task 6 — Router + Deps
+
+- [ ] **6.1** `router.go`:
+  ```go
+  type Deps struct {
+      Schema       *graphql.Schema
+      Pools        middleware.Pools          // Reader + Primary
+      Identity     identity.Service
+      PullRequests pullrequests.Service       // may be nil → resolver 501s
+      SVID         svid.ReVerifier
+      Persisted    persisted.Store
+      Resolver     restapi_mw.PrincipalResolver
+      Limiter      ratelimit.RateLimiter
+      Analyzer     *cost.Analyzer
+      Logger       *slog.Logger
+  }
+  func NewHandler(d Deps) http.Handler
+  ```
+- [ ] **6.2** Routes: `POST /graphql`, `POST /graphql/persisted/register`, `POST /graphql/persisted/{hash}`. Middleware order outer→inner: `RequestID → Auth → ParseQuery → CostAnalyze → CostMeter(charge) → ResolverDispatch`. Document why: ParseQuery before CostAnalyze (need AST); CostMeter charge after analyze so rejected queries pay parse_cost; auth before parse so unauthenticated never reaches the parser.
+- [ ] **6.3** `router_test.go` asserts middleware order via probe handlers.
+
+## Task 7 — Integration test
+
+- [ ] **7.1** `integration_test.go` boots testcontainers Postgres, runs migrations, constructs:
+  - real `identity.PostgresService`
+  - one `MetadataStore` pool (use as both Reader and Primary in tests; production wires distinct pools)
+  - real `MemoryLimiter`
+  - real `PostgresStore` for persisted
+  - fixed-resolver mapping bearer tokens → real principals
+- [ ] **7.2** Cases:
+  - Simple query: `{ user(login: "alice") { id name } }` → 200 with data.
+  - Cost rejection: 11-deep query → `extensions.code = "DEPTH_EXCEEDED"`, parse_cost charged.
+  - Persisted register + execute round-trip; second execute hits cache (assert via cache-instrumentation counter).
+  - Mutation: `createAgent` from human principal succeeds; `createAgent` from agent principal forbidden.
+  - Rate-limit: capacity=100 refill=0; query with cost=80 succeeds, second cost=80 query gets `RATE_LIMITED`.
+  - `@liveRead` directive routes to Primary (verified via follower-read middleware test).
+  - Schema-compat: introspection returns `__schema { queryType { fields { name } } }` matching the named subset.
+- [ ] **7.3** Build tag `integration`.
+
+## Task 8 — `cmd/graphql-api`
+
+- [ ] **8.1** `main.go`: parse env (`GRAPHQL_LISTEN`, `DATABASE_URL_PRIMARY`, `DATABASE_URL_READER`, `RATELIMIT_AGENT_CAPACITY`, `GRAPHQL_PREVIEW=true`); construct two `pgxpool` instances → two `MetadataStore` instances; build `Deps`; serve.
+- [ ] **8.2** Production resolver = `identity.Service.LookupIdentityForCache` adapter (re-used from `cmd/rest-api/main.go`).
+- [ ] **8.3** `integration_test.go`: build binary, listen on `:0`, `POST /graphql {"query":"{ __schema { queryType { name } } }"}` → 200.
+
+## Task 9 — Deprecation policy CI
+
+- [ ] **9.1** Extend `make lint-graphql` to assert: every `@deprecated` field carries a `removalDate: "YYYY-MM-DD"`; if `removalDate < today` and field still present, fail.
+- [ ] **9.2** Add a deliberately-deprecated test field `Repository.legacyName` with future `removalDate` to exercise the path; remove before final commit OR keep as a documented regression-test artefact.
+
+## Task 10 — SLO doc + GA gate
+
+- [ ] **10.1** Add `docs/slo/graphql.md` capturing the five SLOs verbatim from spec §SLO gating with measurement queries / Prometheus expressions. (This is a separate doc commit; not part of this issue's mandatory file map but the issue is GA-gated and the doc is the gate's contract — include in this PR.)
+- [ ] **10.2** Phase 1 ships with `GRAPHQL_PREVIEW=true` default and `GRAPHQL_DEFAULT=off`. Phase 2 GA flip is a follow-up issue (`chore/application-graphql-ga-flip`) opened before merge, not part of this PR.
+
+## Task 11 — ADR + plane-boundary checks
+
+- [ ] **11.1** Run `gitscale-adr-guard` — verify ADR-017 swap-surface invariant: no `pgx`/`redis` imports inside `plane/application/graphql/` (only via `Deps`).
+- [ ] **11.2** Run `gitscale-plane-boundary` — no `plane/git`/`plane/workflow`/`plane/edge` imports.
+- [ ] **11.3** Run `gitscale-go-conventions`.
+- [ ] **11.4** Run `gitscale-outbox-check` — no direct outbox writes; mutations forward to backing services.
+- [ ] **11.5** Run `gitscale-event-schema` — no new event types.
+- [ ] **11.6** Run `gitscale-agent-quota-check` — every accepted query and every rejected-pre-execution query is metered against `surface="graphql"`. Confirmed via `cost_meter` middleware.
+
+## Task 12 — Self-review battery + PR
+
+- [ ] **12.1** Open follow-up issues before PR:
+  - `feat(application): pullrequests.Service for GraphQL createPullRequest mutation`
+  - `chore(application): GraphQL Phase 2 GA flag flip + SLO sign-off`
+  - `chore(meta): GitHub GraphQL schema snapshot refresh cron`
+- [ ] **12.2** Pre-push gates:
+  ```bash
+  go build ./...
+  go vet ./...
+  golangci-lint run ./...
+  go test -race ./plane/application/graphql/... ./cmd/graphql-api/...
+  go test -tags integration ./plane/application/graphql/... ./cmd/graphql-api/...
+  make lint-graphql
+  make lint-md
+  make lint-events
+  make lint-determinism
+  ```
+- [ ] **12.3** Dispatch self-review battery in parallel: `pr-review-toolkit:code-reviewer`, `pr-review-toolkit:silent-failure-hunter`, `adr-historian`, `pr-review-toolkit:type-design-analyzer`, `pr-review-toolkit:pr-test-analyzer`. Resolve findings.
+- [ ] **12.4** Commit using Conventional Commits: `feat(application): GraphQL API — field-stable subset + cost analysis (#113)`.
+- [ ] **12.5** `gh pr create` with title `[Application] GraphQL API — field-stable GitHub-compat subset + cost analysis`, body referencing ADR-017, listing the three follow-up issues, including self-review block, co-author trailer, `Closes #113`.
+
+---
+
+## Acceptance criteria (mirror issue body)
+
+- [ ] Query cost analysis rejects an over-budget query with structured `extensions.code = "COST_BUDGET_EXCEEDED"` (or `DEPTH_EXCEEDED`) **before** any resolver executes; rejected query charges parse_cost.
+- [ ] Persisted-query path returns `extensions.persistedDiscount = 0.5` and `extensions.cost` reflecting the discount.
+- [ ] Follower reads execute against `Reader` `MetadataStore`; queries with `@liveRead` and all mutations execute against `Primary`. Verified by integration test asserting which pool was hit.
+- [ ] Schema field names match GitHub GraphQL for the named subset; CI compat-diff check is green and fails on deliberate rename.
+- [ ] Every `@deprecated` field carries `removalDate`; lint fails when a past-date deprecated field is still present.
+- [ ] Phase 1 ships behind `GRAPHQL_PREVIEW=true`; SLO doc committed defining the five GA gates.
+- [ ] Integration tests run against testcontainers PG; no mock-DB tests in `graphql` package.
+- [ ] `make test` and pre-push gates all green.
+- [ ] Self-review battery clean.
+- [ ] PR closes #113 and links the three follow-up issues.

--- a/docs/superpowers/specs/2026-05-09-issue-113-graphql-api-design.md
+++ b/docs/superpowers/specs/2026-05-09-issue-113-graphql-api-design.md
@@ -1,0 +1,290 @@
+# Spec — Issue #113 GraphQL API (field-stable GitHub-compat subset, cost analysis, SLO-backed GA)
+
+Date: 2026-05-09
+Issue: https://github.com/gitscale-platform/gitscale/issues/113
+Plane: application
+Priority: p2 (Wave 1)
+ADR-impact: conforming (ADR-017 swap-surface interfaces; ADR-008 outbox; ADR-019 plane boundary; ADR-010 SVID re-verify at high-risk boundaries)
+
+## Problem
+
+The application plane now exposes identity + repository over REST (`plane/application/restapi/`, #111). Agents and ecosystem tooling expect a GitHub-shaped GraphQL surface — `repository`, `user`, `agent`, `pullRequest`, `organization` — to read aggregated data in one round-trip. A naive GraphQL endpoint is the canonical hot-path DoS vector: an unbounded query `repository { pullRequests(first: 100) { commits(first: 100) { author { followers(first: 100) { ... } } } } }` will fan out into thousands of resolver calls and crater the metadata store. Without a cost budget enforced *before* resolution, agent traffic class breaks the cluster.
+
+## Goals
+
+1. Add a `plane/application/graphql/` package owning the schema, executor, cost analyser, persisted-query store, and resolvers, mounted at `/graphql` and `/graphql/persisted/{hash}`.
+2. Field-stable subset of GitHub's GraphQL schema: top-level roots (`repository`, `user`, `agent`, `pullRequest`, `organization`) and the most-used connection shapes (`pullRequests`, `issues`, `commits`, `members`). Field *names* match GitHub; field *semantics* are GitScale's.
+3. Pre-execution cost analysis: depth limit, complexity score, agent-class multiplier. Reject before any resolver runs when budget is exceeded.
+4. Persisted-query path: clients POST query text once with `sha256` to register; subsequent calls send the hash and receive a cost-multiplier discount documented in response `extensions`.
+5. Follower-read default: read resolvers route to a `MetadataStore` configured against the read replica unless the operation carries `@liveRead`.
+6. Mutations as thin wrappers over existing gRPC services: `createPullRequest`, `createAgent`, `updateAgentPermissions`. No outbox writes from GraphQL itself — every mutation forwards to an application-plane service that is already Tx + outbox correct (ADR-008).
+7. Deprecation contract: every `@deprecated` field carries an ISO-8601 `removalDate`; CI fails any schema change that removes a deprecated field before its date.
+8. Phase 1 ships behind a `graphql_preview` feature flag (no SLO). Phase 2 GA gating defined as concrete SLOs — see §SLO gating.
+9. Every resolver hop is metered through the same `ratelimit.RateLimiter` surface used by REST, with a separate surface key `graphql` and a per-query cost-as-tokens accounting model.
+
+## Non-goals
+
+- Subscriptions / WebSocket transport — out of scope for this issue. GraphQL over HTTP `POST` only.
+- File uploads (`Upload` scalar) — deferred.
+- Federation / Apollo Gateway — explicit non-goal; GitScale GraphQL is a single graph.
+- Full GitHub GraphQL parity — only the named subset. Unrecognised top-level fields return a stable `FIELD_NOT_SUPPORTED` error code in `extensions.code`.
+- Caching at the response level — `extensions.cacheControl` headers may be returned, but GitScale operates no GraphQL response cache in this PR.
+- Webhook delivery / CI pipeline mutations — out of scope.
+- Custom directives beyond `@liveRead` and the schema-builtin `@deprecated`.
+
+## ADR-017 fragments quoted
+
+> "Three Go interfaces are defined in `plane/data/`: `MetadataStore` (all SQL operations across the five schema domains), `CacheStore` (key-value, pub/sub, and TTL semantics needed by the edge and Git proxy), and `EventQueue` (outbox-to-Kafka publishing). Application code never imports a concrete driver; it receives a concrete implementation injected at startup."
+>
+> "Passing the compliance suite is the production-readiness bar for any implementation."
+
+GraphQL resolvers obey this verbatim: every resolver receives `MetadataStore` and `CacheStore` via the package `Deps` struct and never imports `pgx` or `redis` directly. The follower-read default is implemented by injecting **two** `MetadataStore` instances — `Reader` (replica) and `Primary` — chosen per-field based on the `@liveRead` directive and per-mutation operation. Both must pass the same `plane/data/compliance/` suite; the swap surface is preserved.
+
+The cost-analysis policy is layered on top of the swap surface, not embedded in it. Cost computation is pure (depends only on the parsed query AST + a static schema cost map), so it cannot be sidestepped by an alternative `MetadataStore` implementation.
+
+## Design decisions (defaults selected by supervisor)
+
+| Question | Choice | Rationale |
+|---|---|---|
+| GraphQL Go library | **`github.com/graph-gophers/graphql-go`** | Schema-first, no codegen step in build pipeline, AST is publicly inspectable for cost analysis, MIT-licensed. `gqlgen` requires a codegen step that complicates the agent-driven workflow; `99designs/gqlgen` deferred unless a measured perf gap appears. |
+| Schema source of truth | **Single `schema.graphql` SDL file** in `plane/application/graphql/schema/` checked into the repo | Reviewable diff for every field add / deprecation. CI lints SDL via `graphql-schema-linter`. |
+| Cost analysis algorithm | **Static + dynamic two-pass:** (1) parse, depth-check (max 10 for human, 8 for agent), (2) walk AST summing `@cost(weight: N)` directive values per field; connection fields cost `weight × first/last argument` (capped at 100). Reject before resolution if total > budget. | Mirrors GitHub's published model; small enough to implement in-house; AST walk is O(query size). |
+| Cost budget | Per-principal-kind: human=1000, agent=5000, persisted-query gets ×0.5 multiplier. Configurable via env. | Agents are primary traffic class — they need higher headroom; persisted queries are pre-vetted shapes so a discount aligns incentives. |
+| Persisted-query store | **PostgreSQL table `graphql.persisted_queries(hash PRIMARY KEY, query TEXT, registered_by UUID, created_at TIMESTAMPTZ)`** with Redis read-through cache via `CacheStore` | hash → text lookup on every persisted call; cache hit is the hot path. New schema domain `graphql` (or fold into `repositories` if domain count is capped — see Open questions). |
+| Follower-read implementation | `Deps` struct carries `Primary MetadataStore` and `Reader MetadataStore`. Resolver dispatcher inspects the operation: any field path containing `@liveRead` and all mutations route to `Primary`; everything else routes to `Reader`. | Two pgxpool connections, one per replica role. Re-uses the swap surface (ADR-017) — no new interface. |
+| Auth / principal | Re-uses `restapi/middleware.Auth` with a thin adapter; `Principal` injected into `context.Context` for resolvers. SVID re-verification is required only for `createAgent` and `updateAgentPermissions` (ADR-010 high-risk admin boundary). | Loose coupling — auth lives in one place; GraphQL imports the resolver-friendly bits, not the HTTP plumbing. |
+| Mutation routing | Thin resolver functions that call existing gRPC clients (`identity.Service`, future `pullrequests.Service` for `createPullRequest`). No direct DB writes from resolvers. | ADR-019 spirit applied within the application plane: each domain owns its writes; GraphQL composes. |
+| Error envelope | GraphQL standard `errors[]` array with `extensions.code` from a closed enum (`COST_BUDGET_EXCEEDED`, `DEPTH_EXCEEDED`, `PERSISTED_QUERY_NOT_FOUND`, `UNAUTHENTICATED`, `FORBIDDEN`, `RATE_LIMITED`, `FIELD_NOT_SUPPORTED`, `VALIDATION_FAILED`, `INTERNAL`). | Stable contract; mirrors GitHub's `extensions.code` shape. |
+| Metering | Cost-as-tokens: every accepted query consumes `cost` tokens from the per-principal `graphql` bucket; rejected-pre-execution queries consume the cheaper `parse_cost = max(20, ⌈cost/10⌉)` to deter probe-floods. | Aligns billing with capacity; pre-execution rejection is not free. |
+
+## Architecture
+
+### Package layout
+
+```
+plane/application/graphql/
+  doc.go                       package doc, ADR-017 quote, plane boundary
+  schema/
+    schema.graphql             SDL — single source of truth
+    schema_test.go             SDL parse + lint smoke test
+  cost/
+    analyzer.go                AST → Cost int; depth + complexity walk
+    analyzer_test.go           table-driven query → expected cost
+    directives.go              @cost, @liveRead directive defs
+  persisted/
+    store.go                   Store interface (Get, Put)
+    postgres_store.go          PG-backed impl
+    cached_store.go            CacheStore-backed read-through wrapper
+    integration_test.go
+  resolvers/
+    root.go                    Query, Mutation root resolvers
+    repository.go              Repository, PullRequest, Issue, Commit
+    user.go                    User, Agent, Organization
+    mutation.go                createPullRequest, createAgent, updateAgentPermissions
+    *_test.go                  per-resolver unit tests (StubMetadataStore)
+  middleware/
+    auth.go                    adapter onto restapi.PrincipalResolver
+    cost_meter.go              charges tokens against ratelimit.RateLimiter, surface="graphql"
+    follower_read.go           selects Primary vs Reader based on directive presence
+  errors.go                    ErrorCode enum, mapErr, gqlError envelope
+  router.go                    NewHandler(deps Deps) http.Handler
+  router_test.go
+  integration_test.go          testcontainers PG + httptest end-to-end
+cmd/graphql-api/
+  main.go                      wires Reader + Primary pools, persisted store, deps
+  integration_test.go          binary smoke test
+plane/data/migrations/
+  NNN_graphql_persisted_queries.sql
+```
+
+### Schema (SDL excerpt)
+
+```graphql
+directive @cost(weight: Int! = 1, multipliers: [String!]) on FIELD_DEFINITION
+directive @liveRead on FIELD | QUERY
+directive @deprecated(reason: String!, removalDate: String!) on FIELD_DEFINITION | ENUM_VALUE
+
+type Query {
+  repository(owner: String!, name: String!): Repository @cost(weight: 1)
+  user(login: String!):                      User       @cost(weight: 1)
+  agent(id: ID!):                            Agent      @cost(weight: 1)
+  pullRequest(id: ID!):                      PullRequest @cost(weight: 2)
+  organization(login: String!):              Organization @cost(weight: 1)
+}
+
+type Repository {
+  id: ID!
+  name: String!
+  owner: User!                                                  @cost(weight: 1)
+  pullRequests(first: Int, after: String, states: [PRState!]):
+      PullRequestConnection!                                    @cost(weight: 2, multipliers: ["first"])
+  issues(first: Int, after: String): IssueConnection!           @cost(weight: 2, multipliers: ["first"])
+  defaultBranch: Ref
+  createdAt: DateTime!
+}
+
+type Mutation {
+  createPullRequest(input: CreatePullRequestInput!): CreatePullRequestPayload!  @cost(weight: 10)
+  createAgent(input: CreateAgentInput!):             CreateAgentPayload!        @cost(weight: 10)
+  updateAgentPermissions(input: UpdateAgentPermissionsInput!):
+                                                     UpdateAgentPermissionsPayload! @cost(weight: 10)
+}
+```
+
+Field-name compatibility with GitHub GraphQL is asserted by a CI check that diffs a snapshot of the GitHub public schema against ours for the named subset; mismatches fail the build.
+
+### Cost analyzer
+
+```go
+type Cost struct {
+    Depth      int  // max query depth observed
+    Complexity int  // sum of weights × multipliers
+}
+
+type Analyzer struct {
+    schema       *graphql.Schema
+    maxDepth     map[PrincipalKind]int       // human=10, agent=8
+    maxComplexity map[PrincipalKind]int      // human=1000, agent=5000
+    persistedDiscount float64                // 0.5
+}
+
+func (a *Analyzer) Analyze(doc *ast.Document, op string, vars map[string]any, p Principal, persisted bool) (Cost, error)
+```
+
+- Depth limit fires first (cheap traversal). Returns `extensions.code = "DEPTH_EXCEEDED"`.
+- Complexity limit fires second. Returns `extensions.code = "COST_BUDGET_EXCEEDED"` with `extensions.cost` and `extensions.budget` populated.
+- `multipliers: ["first"]` means `weight × min(first_arg_value, 100)`. Missing `first` defaults to 20.
+- Persisted queries get `complexity *= persistedDiscount`. The discount is reflected in `extensions.persistedDiscount: 0.5`.
+
+### Persisted-query path
+
+`POST /graphql/persisted/register` body `{"query": "..."}` → returns `{"hash": "sha256:..."}`. Stores `(hash, query, registered_by=principal.ID, created_at)`. Idempotent — re-registering the same `(hash, query)` is a no-op; hash collision with a *different* query body is a 409 (impossible at SHA-256 unless byte-mismatch — return error to make the contract explicit).
+
+`POST /graphql/persisted/{hash}` body `{"variables": {...}, "operationName": "..."}` → executes the stored query.
+
+Read path: `CacheStore.Get(hash)` first; on miss, `PostgresStore.Get`, populate cache. TTL = 24h, invalidation on `Put`.
+
+### Follower-read directive
+
+`@liveRead` on a query field forces the dispatcher to swap the resolver context's `MetadataStore` from `Reader` to `Primary` for that field's subtree. The default policy is: read = `Reader`, mutation = `Primary`.
+
+The directive is enforced via a context-key swap performed during the field-resolution phase, not at AST level — it must respect operation type (`mutation` always primary, regardless of directive).
+
+### Metering (ADR-008 spirit + agent-quota)
+
+`cost_meter` middleware:
+
+1. Pre-execution: calls `Analyzer.Analyze`. On reject, charges `parse_cost = max(20, ⌈cost/10⌉)` against the `graphql` bucket.
+2. On accept: charges full `cost` against the bucket. If the bucket is exhausted, returns `extensions.code = "RATE_LIMITED"` with `Retry-After` (in `extensions.retryAfterSeconds`).
+3. Post-execution: writes a structured log entry with `request_id, principal_id, cost, depth, persisted, op_name, status` for the metering pipeline (#15-revocation reconciliation feeds this; webhook/billing consumers downstream are out of scope here).
+
+No outbox row is written by GraphQL directly. Mutations forward to gRPC services that already write source + outbox in the same Tx (ADR-008 conforming).
+
+### Mutation routing
+
+| Mutation | Backing service | High-risk SVID re-verify? |
+|---|---|---|
+| `createPullRequest` | `pullrequests.Service.CreatePullRequest` (gRPC) | no |
+| `createAgent` | `identity.Service.CreateAgent` | yes (ADR-010 §admin actions) |
+| `updateAgentPermissions` | `identity.Service.UpdateAgentPermissions` | yes |
+
+For `createPullRequest`: if the `pullrequests.Service` does not yet exist, this PR is **blocked** on it. Currently the spec assumes #111 ships and a thin `pullrequests.Service` ships in a separate dependency issue; if that issue is not landed, `createPullRequest` resolver returns `extensions.code = "NOT_IMPLEMENTED"` (501-equivalent at the GraphQL layer) with a follow-up issue link, mirroring the `DELETE /v1/repos/{id}` pattern from #111.
+
+### Error envelope
+
+```json
+{
+  "errors": [{
+    "message": "query exceeds cost budget",
+    "extensions": {
+      "code": "COST_BUDGET_EXCEEDED",
+      "cost": 12345,
+      "budget": 5000,
+      "request_id": "01JKW..."
+    }
+  }],
+  "data": null
+}
+```
+
+Closed `code` enum, exhaustive switch in `mapErr`, unit-tested.
+
+### SLO gating (Phase 2 GA)
+
+Phase 1 ships behind feature flag `graphql_preview=true`. Phase 2 GA flips the flag to default-on.
+
+GA blockers — measured continuously over a rolling 7-day window in pre-prod and 14-day window in prod-pilot:
+
+| SLO | Target | Measurement |
+|---|---|---|
+| **Availability** | 99.9% successful (`200` HTTP, `data` non-null OR `errors[].extensions.code` ∈ {VALIDATION_FAILED, FORBIDDEN, NOT_FOUND, COST_BUDGET_EXCEEDED, DEPTH_EXCEEDED, RATE_LIMITED}) | Prom counter `graphql_requests_total{result}` |
+| **Latency P95** | ≤ 250ms for persisted queries, ≤ 600ms for ad-hoc | Histogram `graphql_request_duration_seconds_bucket{persisted}` |
+| **Cost-rejection accuracy** | False-positive rate < 0.1% (rejected queries that would have completed under budget if executed) | Shadow-execute on 1% sample; counter `graphql_cost_false_positive_total` |
+| **Persisted-query hit rate** | ≥ 60% of agent traffic | `graphql_requests_total{persisted="true",principal_kind="agent"} / total{principal_kind="agent"}` |
+| **Schema-compat drift** | 0 unexpected GitHub-schema diffs in named subset | CI check; alert on first drift |
+
+GA decision: all five green for two consecutive measurement windows. The flip is a single env var change (`GRAPHQL_DEFAULT=on`); no schema migration. SLO definitions live in `docs/slo/graphql.md` (out of scope for this issue — created as a separate doc commit before flag flip).
+
+### Plane boundary (ADR-019, gitscale-plane-boundary)
+
+GraphQL is purely application-plane. It imports:
+
+- `plane/data/store.MetadataStore` (Reader + Primary, swap-surface per ADR-017)
+- `plane/data/cache.CacheStore` (persisted-query read-through)
+- `plane/data/ratelimit.RateLimiter` (cost metering)
+- `plane/application/identity.Service` (mutation backing)
+- `plane/application/restapi/middleware` (auth adapter, request-id) — sibling import inside application plane is permitted
+
+It does **not** import:
+
+- `plane/git/*`, `plane/workflow/*`, `plane/edge/*`
+- `pgx`, `go-redis`, or any concrete driver
+- Gitaly clients
+
+### Outbox
+
+GraphQL writes no outbox rows directly. Every mutation forwards to a gRPC service whose backing implementation writes source + outbox in the same Tx (ADR-008). `gitscale-outbox-check` therefore passes by composition, not by direct conformance.
+
+## Test plan
+
+| Layer | Test |
+|---|---|
+| Schema | `schema_test.go` parses SDL, lints with `graphql-schema-linter` (CI), diffs the named-subset against a vendored snapshot of GitHub's GraphQL schema |
+| Cost analyzer | Table-driven: 30+ queries → expected `(depth, complexity)`; depth-limit firing; multiplier on `first`; agent vs human budget |
+| Persisted store | Stub-cache tests for hit / miss / collision; testcontainers PG test for round-trip |
+| Resolvers (unit) | StubMetadataStore + StubIdentity; field-by-field correctness |
+| Cost meter middleware | Rejected query charges parse_cost; accepted query charges full cost; bucket exhausted returns RATE_LIMITED |
+| Follower read | Resolver routed to `Reader` by default; `@liveRead` flips to `Primary`; mutation always `Primary` (test with two distinct stub stores asserting which one was hit) |
+| Auth | Unauthenticated → `UNAUTHENTICATED`; agent attempting `createAgent` for someone else's parent → `FORBIDDEN` |
+| Integration | testcontainers PG + httptest. End-to-end query, persisted register + execute, mutation, cost-rejection. Mirrors `plane/application/restapi/integration_test.go` |
+| Binary | `cmd/graphql-api/integration_test.go` boots `main`, `POST /graphql {"query": "{ __schema { queryType { name } } }"}` → 200 |
+| Schema-compat | CI step diffs named-subset vs GitHub snapshot; deliberate breaking change (rename a field) must fail CI |
+| Deprecation | CI step parses SDL, asserts every `@deprecated` carries `removalDate`, fails if removalDate < today and the field still exists |
+
+All testcontainer tests gated by `//go:build integration`.
+
+## Risks / unknowns
+
+- **graph-gophers/graphql-go AST surface stability.** The library exposes `internal/query` AST types; if those are not stably exported, the cost analyzer must be implemented against a re-parsed AST via the public schema document. Mitigation: the cost analyzer parses the query string a second time using `graphql-go-tools` parser (zero-dep, stable AST) — small CPU overhead, isolates us from upstream churn.
+- **GitHub-schema snapshot freshness.** The compat-diff check uses a vendored snapshot. If GitHub renames a field, our check still passes against the old snapshot. Refresh cadence: monthly cron PR opened by a workflow (out of scope for this PR; tracked separately).
+- **Persisted-query schema-domain placement.** New `graphql` domain or fold into existing? Defer to data-plane review — see Open questions.
+- **`pullrequests.Service` non-existence at merge time.** `createPullRequest` resolver returns `NOT_IMPLEMENTED` until the dependency lands. Acceptance criteria for this issue lists `createPullRequest` as a route, not as a 2xx — the route is reserved.
+- **SLO measurement infrastructure.** Prometheus + histogram registration assumed already in place via existing `cmd/rest-api` patterns. If not, wire-up follows the same pattern; small risk.
+- **Cost-budget calibration drift.** Initial `human=1000, agent=5000` figures are best-guess. Phase 1 preview window is the calibration window; SLO §cost-rejection-accuracy gates the values before GA.
+
+## Open questions
+
+1. **`graphql` schema domain or fold into `repositories`?** ADR-006's five domains are identity / repositories / collaboration / ci / billing. Persisted queries are cross-domain by nature. Recommend: new `graphql` schema with one table; raises domain count to six. Decide with `data-plane`.
+2. **Schema diff CI step location.** Standalone CI job vs `make lint-graphql`. Recommend latter — keeps lint surface unified.
+3. **`@cost` directive on input types?** Out of scope for v1; revisit if a measured input-explosion attack surface appears.
+
+## References
+
+- ADR-017 (interface swap surface) — `docs/architecture.md §8`
+- ADR-008 (outbox) — `docs/architecture.md §8`
+- ADR-019 (plane boundary) — `docs/architecture.md §8`
+- ADR-010 (SVID re-verify at admin boundary) — `docs/architecture.md §8`
+- Sibling pattern: `plane/application/restapi/` (#111)
+- Backing services: `plane/application/identity/` (#15)
+- GitHub GraphQL public schema (snapshot in `vendor/github-graphql-schema/`)
+- `graph-gophers/graphql-go` — schema-first GraphQL Go runtime


### PR DESCRIPTION
Spec + implementation plan for [#113](https://github.com/gitscale-platform/gitscale/issues/113) — `[Application] GraphQL API`.

## Artifacts

- Spec: [`docs/superpowers/specs/2026-05-09-issue-113-graphql-api-design.md`](../blob/docs/meta-issue-113-graphql-api/docs/superpowers/specs/2026-05-09-issue-113-graphql-api-design.md)
- Plan: [`docs/superpowers/plans/2026-05-09-issue-113-graphql-api-plan.md`](../blob/docs/meta-issue-113-graphql-api/docs/superpowers/plans/2026-05-09-issue-113-graphql-api-plan.md)

## Summary

- Field-stable GitHub-compat subset for `repository`, `user`, `agent`, `pullRequest`, `organization` query roots; CI compat-diff vs vendored GitHub schema snapshot.
- Pre-execution cost analysis: depth limit (human=10, agent=8), complexity score with `multipliers: ["first"]` capped at 100, persisted-query 0.5x discount.
- Follower-read default via two `MetadataStore` instances (`Reader` + `Primary`) per ADR-017 swap surface; `@liveRead` directive and all mutations route to `Primary`.
- Cost-as-tokens metering against `surface="graphql"` via `ratelimit.RateLimiter`; rejected-pre-execution queries pay `parse_cost = max(20, ceil(cost/10))` to deter probe-floods.
- Mutations are thin wrappers over existing gRPC services — no direct DB writes, no direct outbox writes (ADR-008 conforming by composition). `createAgent` and `updateAgentPermissions` require SVID re-verify (ADR-010 high-risk admin).
- Phase 1 ships behind `GRAPHQL_PREVIEW=true`; Phase 2 GA gated on five concrete SLOs measured over 7-day pre-prod + 14-day prod-pilot windows.
- Plane boundary clean per `gitscale-plane-boundary`; agent-quota check satisfied per `gitscale-agent-quota-check` (every accepted and rejected query metered).

## ADR conformance

- ADR-017 (swap surface) — quoted in spec; resolvers receive `MetadataStore` + `CacheStore` via `Deps`, never import drivers.
- ADR-008 (outbox) — by composition; mutations forward to gRPC services that own Tx + outbox.
- ADR-019 (plane boundary) — no imports of `plane/git`, `plane/workflow`, `plane/edge`.
- ADR-010 (SVID re-verify) — applied at admin mutations.

Tracks #113. No new ADR.