### PR TITLE
[Workflow] CI cold pool — Firecracker microVM integration + agent-default routing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test lint lint-md lint-events lint-determinism lint-proto install-hooks generate proto fmt
+.PHONY: build test lint lint-md lint-events lint-determinism lint-firecracker lint-proto install-hooks generate proto fmt
 
 build:
 	go build ./...
@@ -23,6 +23,9 @@ lint-events:
 
 lint-determinism:
 	bash plane/workflow/lint/lint-determinism.sh
+
+lint-firecracker:
+	bash plane/workflow/lint/lint-firecracker.sh
 
 lint-proto:
 	buf lint

--- a/internal/proto/gitscale/billing/v1/billing.pb.go
+++ b/internal/proto/gitscale/billing/v1/billing.pb.go
@@ -289,6 +289,310 @@ func (x *RecordDEKDestroyedResponse) GetCreated() bool {
 	return false
 }
 
+// GetQuotaAccount — workflow plane reads org-level quota caps to enforce
+// per-job ceilings before booting a CI microVM (#110, ADR-019). Lookup is
+// by org_id; the workflow input already carries the resolved org id from
+// the trigger entrypoint (REST API #111), so we avoid a redundant
+// principal->org join on the hot path.
+type GetQuotaAccountRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	OrgId         string                 `protobuf:"bytes,1,opt,name=org_id,json=orgId,proto3" json:"org_id,omitempty"` // UUID of the organisation owning the quota account
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetQuotaAccountRequest) Reset() {
+	*x = GetQuotaAccountRequest{}
+	mi := &file_gitscale_billing_v1_billing_proto_msgTypes[4]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetQuotaAccountRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetQuotaAccountRequest) ProtoMessage() {}
+
+func (x *GetQuotaAccountRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_gitscale_billing_v1_billing_proto_msgTypes[4]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetQuotaAccountRequest.ProtoReflect.Descriptor instead.
+func (*GetQuotaAccountRequest) Descriptor() ([]byte, []int) {
+	return file_gitscale_billing_v1_billing_proto_rawDescGZIP(), []int{4}
+}
+
+func (x *GetQuotaAccountRequest) GetOrgId() string {
+	if x != nil {
+		return x.OrgId
+	}
+	return ""
+}
+
+type GetQuotaAccountResponse struct {
+	state                     protoimpl.MessageState `protogen:"open.v1"`
+	AccountId                 string                 `protobuf:"bytes,1,opt,name=account_id,json=accountId,proto3" json:"account_id,omitempty"` // UUID
+	OrgId                     string                 `protobuf:"bytes,2,opt,name=org_id,json=orgId,proto3" json:"org_id,omitempty"`             // UUID
+	PlanTier                  string                 `protobuf:"bytes,3,opt,name=plan_tier,json=planTier,proto3" json:"plan_tier,omitempty"`    // free|pro|enterprise
+	TokensPerWeekCap          int64                  `protobuf:"varint,4,opt,name=tokens_per_week_cap,json=tokensPerWeekCap,proto3" json:"tokens_per_week_cap,omitempty"`
+	ComputeMinutesPerMonthCap int64                  `protobuf:"varint,5,opt,name=compute_minutes_per_month_cap,json=computeMinutesPerMonthCap,proto3" json:"compute_minutes_per_month_cap,omitempty"`
+	StorageGbCap              int64                  `protobuf:"varint,6,opt,name=storage_gb_cap,json=storageGbCap,proto3" json:"storage_gb_cap,omitempty"`
+	unknownFields             protoimpl.UnknownFields
+	sizeCache                 protoimpl.SizeCache
+}
+
+func (x *GetQuotaAccountResponse) Reset() {
+	*x = GetQuotaAccountResponse{}
+	mi := &file_gitscale_billing_v1_billing_proto_msgTypes[5]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetQuotaAccountResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetQuotaAccountResponse) ProtoMessage() {}
+
+func (x *GetQuotaAccountResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_gitscale_billing_v1_billing_proto_msgTypes[5]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetQuotaAccountResponse.ProtoReflect.Descriptor instead.
+func (*GetQuotaAccountResponse) Descriptor() ([]byte, []int) {
+	return file_gitscale_billing_v1_billing_proto_rawDescGZIP(), []int{5}
+}
+
+func (x *GetQuotaAccountResponse) GetAccountId() string {
+	if x != nil {
+		return x.AccountId
+	}
+	return ""
+}
+
+func (x *GetQuotaAccountResponse) GetOrgId() string {
+	if x != nil {
+		return x.OrgId
+	}
+	return ""
+}
+
+func (x *GetQuotaAccountResponse) GetPlanTier() string {
+	if x != nil {
+		return x.PlanTier
+	}
+	return ""
+}
+
+func (x *GetQuotaAccountResponse) GetTokensPerWeekCap() int64 {
+	if x != nil {
+		return x.TokensPerWeekCap
+	}
+	return 0
+}
+
+func (x *GetQuotaAccountResponse) GetComputeMinutesPerMonthCap() int64 {
+	if x != nil {
+		return x.ComputeMinutesPerMonthCap
+	}
+	return 0
+}
+
+func (x *GetQuotaAccountResponse) GetStorageGbCap() int64 {
+	if x != nil {
+		return x.StorageGbCap
+	}
+	return 0
+}
+
+// RecordCIJobCompleted — emit ci.job_completed to the outbox in one Tx
+// alongside the source-row insert (#110, ADR-008/019). Idempotent on
+// job_id.
+type RecordCIJobCompletedRequest struct {
+	state           protoimpl.MessageState `protogen:"open.v1"`
+	JobId           string                 `protobuf:"bytes,1,opt,name=job_id,json=jobId,proto3" json:"job_id,omitempty"`
+	PrincipalId     string                 `protobuf:"bytes,2,opt,name=principal_id,json=principalId,proto3" json:"principal_id,omitempty"`
+	PrincipalKind   string                 `protobuf:"bytes,3,opt,name=principal_kind,json=principalKind,proto3" json:"principal_kind,omitempty"` // human|agent|service
+	OrgId           string                 `protobuf:"bytes,4,opt,name=org_id,json=orgId,proto3" json:"org_id,omitempty"`
+	RepoId          string                 `protobuf:"bytes,5,opt,name=repo_id,json=repoId,proto3" json:"repo_id,omitempty"`
+	Tier            string                 `protobuf:"bytes,6,opt,name=tier,proto3" json:"tier,omitempty"` // hot|cold
+	VcpuSeconds     float64                `protobuf:"fixed64,7,opt,name=vcpu_seconds,json=vcpuSeconds,proto3" json:"vcpu_seconds,omitempty"`
+	MemoryMbSeconds float64                `protobuf:"fixed64,8,opt,name=memory_mb_seconds,json=memoryMbSeconds,proto3" json:"memory_mb_seconds,omitempty"`
+	EgressKb        int64                  `protobuf:"varint,9,opt,name=egress_kb,json=egressKb,proto3" json:"egress_kb,omitempty"`
+	ExitCode        int32                  `protobuf:"varint,10,opt,name=exit_code,json=exitCode,proto3" json:"exit_code,omitempty"`
+	unknownFields   protoimpl.UnknownFields
+	sizeCache       protoimpl.SizeCache
+}
+
+func (x *RecordCIJobCompletedRequest) Reset() {
+	*x = RecordCIJobCompletedRequest{}
+	mi := &file_gitscale_billing_v1_billing_proto_msgTypes[6]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RecordCIJobCompletedRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RecordCIJobCompletedRequest) ProtoMessage() {}
+
+func (x *RecordCIJobCompletedRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_gitscale_billing_v1_billing_proto_msgTypes[6]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RecordCIJobCompletedRequest.ProtoReflect.Descriptor instead.
+func (*RecordCIJobCompletedRequest) Descriptor() ([]byte, []int) {
+	return file_gitscale_billing_v1_billing_proto_rawDescGZIP(), []int{6}
+}
+
+func (x *RecordCIJobCompletedRequest) GetJobId() string {
+	if x != nil {
+		return x.JobId
+	}
+	return ""
+}
+
+func (x *RecordCIJobCompletedRequest) GetPrincipalId() string {
+	if x != nil {
+		return x.PrincipalId
+	}
+	return ""
+}
+
+func (x *RecordCIJobCompletedRequest) GetPrincipalKind() string {
+	if x != nil {
+		return x.PrincipalKind
+	}
+	return ""
+}
+
+func (x *RecordCIJobCompletedRequest) GetOrgId() string {
+	if x != nil {
+		return x.OrgId
+	}
+	return ""
+}
+
+func (x *RecordCIJobCompletedRequest) GetRepoId() string {
+	if x != nil {
+		return x.RepoId
+	}
+	return ""
+}
+
+func (x *RecordCIJobCompletedRequest) GetTier() string {
+	if x != nil {
+		return x.Tier
+	}
+	return ""
+}
+
+func (x *RecordCIJobCompletedRequest) GetVcpuSeconds() float64 {
+	if x != nil {
+		return x.VcpuSeconds
+	}
+	return 0
+}
+
+func (x *RecordCIJobCompletedRequest) GetMemoryMbSeconds() float64 {
+	if x != nil {
+		return x.MemoryMbSeconds
+	}
+	return 0
+}
+
+func (x *RecordCIJobCompletedRequest) GetEgressKb() int64 {
+	if x != nil {
+		return x.EgressKb
+	}
+	return 0
+}
+
+func (x *RecordCIJobCompletedRequest) GetExitCode() int32 {
+	if x != nil {
+		return x.ExitCode
+	}
+	return 0
+}
+
+type RecordCIJobCompletedResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	EventId       string                 `protobuf:"bytes,1,opt,name=event_id,json=eventId,proto3" json:"event_id,omitempty"` // UUID of outbox event row
+	Created       bool                   `protobuf:"varint,2,opt,name=created,proto3" json:"created,omitempty"`               // false on idempotent retry
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *RecordCIJobCompletedResponse) Reset() {
+	*x = RecordCIJobCompletedResponse{}
+	mi := &file_gitscale_billing_v1_billing_proto_msgTypes[7]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RecordCIJobCompletedResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RecordCIJobCompletedResponse) ProtoMessage() {}
+
+func (x *RecordCIJobCompletedResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_gitscale_billing_v1_billing_proto_msgTypes[7]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RecordCIJobCompletedResponse.ProtoReflect.Descriptor instead.
+func (*RecordCIJobCompletedResponse) Descriptor() ([]byte, []int) {
+	return file_gitscale_billing_v1_billing_proto_rawDescGZIP(), []int{7}
+}
+
+func (x *RecordCIJobCompletedResponse) GetEventId() string {
+	if x != nil {
+		return x.EventId
+	}
+	return ""
+}
+
+func (x *RecordCIJobCompletedResponse) GetCreated() bool {
+	if x != nil {
+		return x.Created
+	}
+	return false
+}
+
 var File_gitscale_billing_v1_billing_proto protoreflect.FileDescriptor
 
 const file_gitscale_billing_v1_billing_proto_rawDesc = "" +
@@ -313,10 +617,37 @@ const file_gitscale_billing_v1_billing_proto_rawDesc = "" +
 	"\x11vault_key_version\x18\x05 \x01(\x05R\x0fvaultKeyVersion\"Q\n" +
 	"\x1aRecordDEKDestroyedResponse\x12\x19\n" +
 	"\bevent_id\x18\x01 \x01(\tR\aeventId\x12\x18\n" +
-	"\acreated\x18\x02 \x01(\bR\acreated2\x8e\x02\n" +
+	"\acreated\x18\x02 \x01(\bR\acreated\"/\n" +
+	"\x16GetQuotaAccountRequest\x12\x15\n" +
+	"\x06org_id\x18\x01 \x01(\tR\x05orgId\"\x83\x02\n" +
+	"\x17GetQuotaAccountResponse\x12\x1d\n" +
+	"\n" +
+	"account_id\x18\x01 \x01(\tR\taccountId\x12\x15\n" +
+	"\x06org_id\x18\x02 \x01(\tR\x05orgId\x12\x1b\n" +
+	"\tplan_tier\x18\x03 \x01(\tR\bplanTier\x12-\n" +
+	"\x13tokens_per_week_cap\x18\x04 \x01(\x03R\x10tokensPerWeekCap\x12@\n" +
+	"\x1dcompute_minutes_per_month_cap\x18\x05 \x01(\x03R\x19computeMinutesPerMonthCap\x12$\n" +
+	"\x0estorage_gb_cap\x18\x06 \x01(\x03R\fstorageGbCap\"\xcb\x02\n" +
+	"\x1bRecordCIJobCompletedRequest\x12\x15\n" +
+	"\x06job_id\x18\x01 \x01(\tR\x05jobId\x12!\n" +
+	"\fprincipal_id\x18\x02 \x01(\tR\vprincipalId\x12%\n" +
+	"\x0eprincipal_kind\x18\x03 \x01(\tR\rprincipalKind\x12\x15\n" +
+	"\x06org_id\x18\x04 \x01(\tR\x05orgId\x12\x17\n" +
+	"\arepo_id\x18\x05 \x01(\tR\x06repoId\x12\x12\n" +
+	"\x04tier\x18\x06 \x01(\tR\x04tier\x12!\n" +
+	"\fvcpu_seconds\x18\a \x01(\x01R\vvcpuSeconds\x12*\n" +
+	"\x11memory_mb_seconds\x18\b \x01(\x01R\x0fmemoryMbSeconds\x12\x1b\n" +
+	"\tegress_kb\x18\t \x01(\x03R\begressKb\x12\x1b\n" +
+	"\texit_code\x18\n" +
+	" \x01(\x05R\bexitCode\"S\n" +
+	"\x1cRecordCIJobCompletedResponse\x12\x19\n" +
+	"\bevent_id\x18\x01 \x01(\tR\aeventId\x12\x18\n" +
+	"\acreated\x18\x02 \x01(\bR\acreated2\xf9\x03\n" +
 	"\x0eBillingService\x12\x84\x01\n" +
 	"\x17RecordPartitionArchived\x123.gitscale.billing.v1.RecordPartitionArchivedRequest\x1a4.gitscale.billing.v1.RecordPartitionArchivedResponse\x12u\n" +
-	"\x12RecordDEKDestroyed\x12..gitscale.billing.v1.RecordDEKDestroyedRequest\x1a/.gitscale.billing.v1.RecordDEKDestroyedResponseB\xe0\x01\n" +
+	"\x12RecordDEKDestroyed\x12..gitscale.billing.v1.RecordDEKDestroyedRequest\x1a/.gitscale.billing.v1.RecordDEKDestroyedResponse\x12l\n" +
+	"\x0fGetQuotaAccount\x12+.gitscale.billing.v1.GetQuotaAccountRequest\x1a,.gitscale.billing.v1.GetQuotaAccountResponse\x12{\n" +
+	"\x14RecordCIJobCompleted\x120.gitscale.billing.v1.RecordCIJobCompletedRequest\x1a1.gitscale.billing.v1.RecordCIJobCompletedResponseB\xe0\x01\n" +
 	"\x17com.gitscale.billing.v1B\fBillingProtoP\x01ZIgithub.com/gitscale-platform/gitscale/internal/proto/billing/v1;billingv1\xa2\x02\x03GBX\xaa\x02\x13Gitscale.Billing.V1\xca\x02\x13Gitscale\\Billing\\V1\xe2\x02\x1fGitscale\\Billing\\V1\\GPBMetadata\xea\x02\x15Gitscale::Billing::V1b\x06proto3"
 
 var (
@@ -331,20 +662,28 @@ func file_gitscale_billing_v1_billing_proto_rawDescGZIP() []byte {
 	return file_gitscale_billing_v1_billing_proto_rawDescData
 }
 
-var file_gitscale_billing_v1_billing_proto_msgTypes = make([]protoimpl.MessageInfo, 4)
+var file_gitscale_billing_v1_billing_proto_msgTypes = make([]protoimpl.MessageInfo, 8)
 var file_gitscale_billing_v1_billing_proto_goTypes = []any{
 	(*RecordPartitionArchivedRequest)(nil),  // 0: gitscale.billing.v1.RecordPartitionArchivedRequest
 	(*RecordPartitionArchivedResponse)(nil), // 1: gitscale.billing.v1.RecordPartitionArchivedResponse
 	(*RecordDEKDestroyedRequest)(nil),       // 2: gitscale.billing.v1.RecordDEKDestroyedRequest
 	(*RecordDEKDestroyedResponse)(nil),      // 3: gitscale.billing.v1.RecordDEKDestroyedResponse
+	(*GetQuotaAccountRequest)(nil),          // 4: gitscale.billing.v1.GetQuotaAccountRequest
+	(*GetQuotaAccountResponse)(nil),         // 5: gitscale.billing.v1.GetQuotaAccountResponse
+	(*RecordCIJobCompletedRequest)(nil),     // 6: gitscale.billing.v1.RecordCIJobCompletedRequest
+	(*RecordCIJobCompletedResponse)(nil),    // 7: gitscale.billing.v1.RecordCIJobCompletedResponse
 }
 var file_gitscale_billing_v1_billing_proto_depIdxs = []int32{
 	0, // 0: gitscale.billing.v1.BillingService.RecordPartitionArchived:input_type -> gitscale.billing.v1.RecordPartitionArchivedRequest
 	2, // 1: gitscale.billing.v1.BillingService.RecordDEKDestroyed:input_type -> gitscale.billing.v1.RecordDEKDestroyedRequest
-	1, // 2: gitscale.billing.v1.BillingService.RecordPartitionArchived:output_type -> gitscale.billing.v1.RecordPartitionArchivedResponse
-	3, // 3: gitscale.billing.v1.BillingService.RecordDEKDestroyed:output_type -> gitscale.billing.v1.RecordDEKDestroyedResponse
-	2, // [2:4] is the sub-list for method output_type
-	0, // [0:2] is the sub-list for method input_type
+	4, // 2: gitscale.billing.v1.BillingService.GetQuotaAccount:input_type -> gitscale.billing.v1.GetQuotaAccountRequest
+	6, // 3: gitscale.billing.v1.BillingService.RecordCIJobCompleted:input_type -> gitscale.billing.v1.RecordCIJobCompletedRequest
+	1, // 4: gitscale.billing.v1.BillingService.RecordPartitionArchived:output_type -> gitscale.billing.v1.RecordPartitionArchivedResponse
+	3, // 5: gitscale.billing.v1.BillingService.RecordDEKDestroyed:output_type -> gitscale.billing.v1.RecordDEKDestroyedResponse
+	5, // 6: gitscale.billing.v1.BillingService.GetQuotaAccount:output_type -> gitscale.billing.v1.GetQuotaAccountResponse
+	7, // 7: gitscale.billing.v1.BillingService.RecordCIJobCompleted:output_type -> gitscale.billing.v1.RecordCIJobCompletedResponse
+	4, // [4:8] is the sub-list for method output_type
+	0, // [0:4] is the sub-list for method input_type
 	0, // [0:0] is the sub-list for extension type_name
 	0, // [0:0] is the sub-list for extension extendee
 	0, // [0:0] is the sub-list for field type_name
@@ -361,7 +700,7 @@ func file_gitscale_billing_v1_billing_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_gitscale_billing_v1_billing_proto_rawDesc), len(file_gitscale_billing_v1_billing_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   4,
+			NumMessages:   8,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/internal/proto/gitscale/billing/v1/billing.proto
+++ b/internal/proto/gitscale/billing/v1/billing.proto
@@ -25,6 +25,19 @@ service BillingService {
   // same event id and only the first call writes the outbox row.
   rpc RecordDEKDestroyed(RecordDEKDestroyedRequest)
       returns (RecordDEKDestroyedResponse);
+
+  // GetQuotaAccount fetches the per-org quota envelope for a principal's
+  // organisation (#110, ADR-019). CI boot activities call this to enforce
+  // per-job ceilings before allocating microVM resources.
+  rpc GetQuotaAccount(GetQuotaAccountRequest)
+      returns (GetQuotaAccountResponse);
+
+  // RecordCIJobCompleted persists the per-job billable consumption + emits
+  // ci.job_completed to the outbox in the same Tx (#110, ADR-008/019).
+  // Idempotent on job_id: repeat calls return the same event_id and only
+  // the first call writes the outbox row.
+  rpc RecordCIJobCompleted(RecordCIJobCompletedRequest)
+      returns (RecordCIJobCompletedResponse);
 }
 
 message RecordPartitionArchivedRequest {
@@ -52,4 +65,43 @@ message RecordDEKDestroyedRequest {
 message RecordDEKDestroyedResponse {
   string event_id = 1;  // UUID of outbox event row
   bool   created  = 2;  // false on idempotent retry (event already emitted)
+}
+
+// GetQuotaAccount — workflow plane reads org-level quota caps to enforce
+// per-job ceilings before booting a CI microVM (#110, ADR-019). Lookup is
+// by org_id; the workflow input already carries the resolved org id from
+// the trigger entrypoint (REST API #111), so we avoid a redundant
+// principal->org join on the hot path.
+message GetQuotaAccountRequest {
+  string org_id = 1; // UUID of the organisation owning the quota account
+}
+
+message GetQuotaAccountResponse {
+  string account_id = 1;                       // UUID
+  string org_id = 2;                           // UUID
+  string plan_tier = 3;                        // free|pro|enterprise
+  int64 tokens_per_week_cap = 4;
+  int64 compute_minutes_per_month_cap = 5;
+  int64 storage_gb_cap = 6;
+}
+
+// RecordCIJobCompleted — emit ci.job_completed to the outbox in one Tx
+// alongside the source-row insert (#110, ADR-008/019). Idempotent on
+// job_id.
+message RecordCIJobCompletedRequest {
+  string job_id = 1;
+  string principal_id = 2;
+  string principal_kind = 3; // human|agent|service
+  string org_id = 4;
+  string repo_id = 5;
+  string tier = 6;            // hot|cold
+  double vcpu_seconds = 7;
+  double memory_mb_seconds = 8;
+  int64  egress_kb = 9;
+  int32  exit_code = 10;
+}
+
+message RecordCIJobCompletedResponse {
+  string event_id = 1; // UUID of outbox event row
+  bool   created  = 2; // false on idempotent retry
 }

--- a/internal/proto/gitscale/billing/v1/billing_grpc.pb.go
+++ b/internal/proto/gitscale/billing/v1/billing_grpc.pb.go
@@ -25,6 +25,8 @@ const _ = grpc.SupportPackageIsVersion9
 const (
 	BillingService_RecordPartitionArchived_FullMethodName = "/gitscale.billing.v1.BillingService/RecordPartitionArchived"
 	BillingService_RecordDEKDestroyed_FullMethodName      = "/gitscale.billing.v1.BillingService/RecordDEKDestroyed"
+	BillingService_GetQuotaAccount_FullMethodName         = "/gitscale.billing.v1.BillingService/GetQuotaAccount"
+	BillingService_RecordCIJobCompleted_FullMethodName    = "/gitscale.billing.v1.BillingService/RecordCIJobCompleted"
 )
 
 // BillingServiceClient is the client API for BillingService service.
@@ -46,6 +48,15 @@ type BillingServiceClient interface {
 	// Idempotent on (year, month, partition_name): repeated calls return the
 	// same event id and only the first call writes the outbox row.
 	RecordDEKDestroyed(ctx context.Context, in *RecordDEKDestroyedRequest, opts ...grpc.CallOption) (*RecordDEKDestroyedResponse, error)
+	// GetQuotaAccount fetches the per-org quota envelope for a principal's
+	// organisation (#110, ADR-019). CI boot activities call this to enforce
+	// per-job ceilings before allocating microVM resources.
+	GetQuotaAccount(ctx context.Context, in *GetQuotaAccountRequest, opts ...grpc.CallOption) (*GetQuotaAccountResponse, error)
+	// RecordCIJobCompleted persists the per-job billable consumption + emits
+	// ci.job_completed to the outbox in the same Tx (#110, ADR-008/019).
+	// Idempotent on job_id: repeat calls return the same event_id and only
+	// the first call writes the outbox row.
+	RecordCIJobCompleted(ctx context.Context, in *RecordCIJobCompletedRequest, opts ...grpc.CallOption) (*RecordCIJobCompletedResponse, error)
 }
 
 type billingServiceClient struct {
@@ -76,6 +87,26 @@ func (c *billingServiceClient) RecordDEKDestroyed(ctx context.Context, in *Recor
 	return out, nil
 }
 
+func (c *billingServiceClient) GetQuotaAccount(ctx context.Context, in *GetQuotaAccountRequest, opts ...grpc.CallOption) (*GetQuotaAccountResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(GetQuotaAccountResponse)
+	err := c.cc.Invoke(ctx, BillingService_GetQuotaAccount_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *billingServiceClient) RecordCIJobCompleted(ctx context.Context, in *RecordCIJobCompletedRequest, opts ...grpc.CallOption) (*RecordCIJobCompletedResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(RecordCIJobCompletedResponse)
+	err := c.cc.Invoke(ctx, BillingService_RecordCIJobCompleted_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // BillingServiceServer is the server API for BillingService service.
 // All implementations must embed UnimplementedBillingServiceServer
 // for forward compatibility.
@@ -95,6 +126,15 @@ type BillingServiceServer interface {
 	// Idempotent on (year, month, partition_name): repeated calls return the
 	// same event id and only the first call writes the outbox row.
 	RecordDEKDestroyed(context.Context, *RecordDEKDestroyedRequest) (*RecordDEKDestroyedResponse, error)
+	// GetQuotaAccount fetches the per-org quota envelope for a principal's
+	// organisation (#110, ADR-019). CI boot activities call this to enforce
+	// per-job ceilings before allocating microVM resources.
+	GetQuotaAccount(context.Context, *GetQuotaAccountRequest) (*GetQuotaAccountResponse, error)
+	// RecordCIJobCompleted persists the per-job billable consumption + emits
+	// ci.job_completed to the outbox in the same Tx (#110, ADR-008/019).
+	// Idempotent on job_id: repeat calls return the same event_id and only
+	// the first call writes the outbox row.
+	RecordCIJobCompleted(context.Context, *RecordCIJobCompletedRequest) (*RecordCIJobCompletedResponse, error)
 	mustEmbedUnimplementedBillingServiceServer()
 }
 
@@ -110,6 +150,12 @@ func (UnimplementedBillingServiceServer) RecordPartitionArchived(context.Context
 }
 func (UnimplementedBillingServiceServer) RecordDEKDestroyed(context.Context, *RecordDEKDestroyedRequest) (*RecordDEKDestroyedResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method RecordDEKDestroyed not implemented")
+}
+func (UnimplementedBillingServiceServer) GetQuotaAccount(context.Context, *GetQuotaAccountRequest) (*GetQuotaAccountResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method GetQuotaAccount not implemented")
+}
+func (UnimplementedBillingServiceServer) RecordCIJobCompleted(context.Context, *RecordCIJobCompletedRequest) (*RecordCIJobCompletedResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method RecordCIJobCompleted not implemented")
 }
 func (UnimplementedBillingServiceServer) mustEmbedUnimplementedBillingServiceServer() {}
 func (UnimplementedBillingServiceServer) testEmbeddedByValue()                        {}
@@ -168,6 +214,42 @@ func _BillingService_RecordDEKDestroyed_Handler(srv interface{}, ctx context.Con
 	return interceptor(ctx, in, info, handler)
 }
 
+func _BillingService_GetQuotaAccount_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(GetQuotaAccountRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(BillingServiceServer).GetQuotaAccount(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: BillingService_GetQuotaAccount_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(BillingServiceServer).GetQuotaAccount(ctx, req.(*GetQuotaAccountRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _BillingService_RecordCIJobCompleted_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(RecordCIJobCompletedRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(BillingServiceServer).RecordCIJobCompleted(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: BillingService_RecordCIJobCompleted_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(BillingServiceServer).RecordCIJobCompleted(ctx, req.(*RecordCIJobCompletedRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // BillingService_ServiceDesc is the grpc.ServiceDesc for BillingService service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -182,6 +264,14 @@ var BillingService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "RecordDEKDestroyed",
 			Handler:    _BillingService_RecordDEKDestroyed_Handler,
+		},
+		{
+			MethodName: "GetQuotaAccount",
+			Handler:    _BillingService_GetQuotaAccount_Handler,
+		},
+		{
+			MethodName: "RecordCIJobCompleted",
+			Handler:    _BillingService_RecordCIJobCompleted_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},

--- a/plane/application/billing/ci_models.go
+++ b/plane/application/billing/ci_models.go
@@ -1,0 +1,132 @@
+package billing
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// EventTypeCIJobCompleted is the event_type written to billing.billing_outbox
+// when a CI job finishes (#110). Idempotent on JobID — repeat emits dedupe
+// on the deterministic aggregate id.
+const EventTypeCIJobCompleted = "ci.job_completed"
+
+// GetQuotaAccountInput is the service-level input for the RPC of the same
+// name (#110, ADR-019).
+type GetQuotaAccountInput struct {
+	OrgID uuid.UUID
+}
+
+// GetQuotaAccountOutput is the service-level output. Caps are per-period —
+// the boot activity derives the per-job ceiling from the monthly compute
+// minutes cap.
+type GetQuotaAccountOutput struct {
+	AccountID                 uuid.UUID
+	OrgID                     uuid.UUID
+	PlanTier                  string
+	TokensPerWeekCap          int64
+	ComputeMinutesPerMonthCap int64
+	StorageGBCap              int64
+}
+
+// RecordCIJobCompletedInput is the service-level input. The application
+// service writes the source row + outbox row in one Tx (ADR-008/019).
+type RecordCIJobCompletedInput struct {
+	JobID           uuid.UUID
+	PrincipalID     uuid.UUID
+	PrincipalKind   string // "human" | "agent" | "service"
+	OrgID           uuid.UUID
+	RepoID          uuid.UUID
+	Tier            string // "hot" | "cold"
+	VCPUSeconds     float64
+	MemoryMBSeconds float64
+	EgressKB        int64
+	ExitCode        int
+}
+
+// RecordCIJobCompletedOutput is the service-level output. EventID is the
+// deterministic UUIDv5 derived from JobID; Created is false on idempotent
+// retry.
+type RecordCIJobCompletedOutput struct {
+	EventID string
+	Created bool
+}
+
+// CIJobCompletedPayload is the JSON payload written to the outbox. Mirrors
+// the proto/grpc shape one-for-one so downstream consumers see consistent
+// field names regardless of which producer emitted.
+type CIJobCompletedPayload struct {
+	EventID         uuid.UUID `json:"event_id"`
+	JobID           uuid.UUID `json:"job_id"`
+	PrincipalID     uuid.UUID `json:"principal_id"`
+	PrincipalKind   string    `json:"principal_kind"`
+	OrgID           uuid.UUID `json:"org_id"`
+	RepoID          uuid.UUID `json:"repo_id"`
+	Tier            string    `json:"tier"`
+	VCPUSeconds     float64   `json:"vcpu_seconds"`
+	MemoryMBSeconds float64   `json:"memory_mb_seconds"`
+	EgressKB        int64     `json:"egress_kb"`
+	ExitCode        int       `json:"exit_code"`
+	OccurredAt      time.Time `json:"occurred_at"`
+	EnvelopeVersion int       `json:"_envelope_version"`
+}
+
+// validateCIJobInput enforces the contract on RecordCIJobCompletedInput.
+// Validation runs before any Tx is opened.
+func validateCIJobInput(in RecordCIJobCompletedInput) error {
+	if in.JobID == uuid.Nil {
+		return ErrEmptyJobID
+	}
+	if in.PrincipalID == uuid.Nil {
+		return ErrEmptyPrincipalID
+	}
+	if in.OrgID == uuid.Nil {
+		return ErrEmptyOrgID
+	}
+	switch in.PrincipalKind {
+	case "human", "agent", "service":
+	default:
+		return ErrInvalidPrincipalKind
+	}
+	switch in.Tier {
+	case "hot", "cold":
+	default:
+		return ErrInvalidTier
+	}
+	if in.VCPUSeconds < 0 || in.MemoryMBSeconds < 0 || in.EgressKB < 0 {
+		return ErrNegativeMetric
+	}
+	return nil
+}
+
+// ciJobCompletedNamespace anchors the deterministic UUID derivation for the
+// outbox aggregate_id of a ci.job_completed event. Stable across versions;
+// bump only when changing the natural-key shape.
+var ciJobCompletedNamespace = uuid.MustParse("3f4e5d6c-7b8a-4998-8b7c-6d5e4f3a2b1c")
+
+// ciJobCompletedAggregateID derives a deterministic UUIDv5 from JobID.
+// Same JobID always yields the same aggregate id, which lets
+// HasOutboxEventForAggregate anchor idempotency.
+func ciJobCompletedAggregateID(jobID uuid.UUID) uuid.UUID {
+	return uuid.NewSHA1(ciJobCompletedNamespace, jobID[:])
+}
+
+// newCIJobCompletedPayload builds the outbox payload from the input + a
+// generated event_id. occurredAt is sourced from the service clock.
+func newCIJobCompletedPayload(in RecordCIJobCompletedInput, eventID uuid.UUID, occurredAt time.Time) CIJobCompletedPayload {
+	return CIJobCompletedPayload{
+		EventID:         eventID,
+		JobID:           in.JobID,
+		PrincipalID:     in.PrincipalID,
+		PrincipalKind:   in.PrincipalKind,
+		OrgID:           in.OrgID,
+		RepoID:          in.RepoID,
+		Tier:            in.Tier,
+		VCPUSeconds:     in.VCPUSeconds,
+		MemoryMBSeconds: in.MemoryMBSeconds,
+		EgressKB:        in.EgressKB,
+		ExitCode:        in.ExitCode,
+		OccurredAt:      occurredAt,
+		EnvelopeVersion: envelopeVersion,
+	}
+}

--- a/plane/application/billing/grpc_server.go
+++ b/plane/application/billing/grpc_server.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 
 	billingv1 "github.com/gitscale-platform/gitscale/internal/proto/gitscale/billing/v1"
+	"github.com/google/uuid"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -62,17 +63,90 @@ func (s *GRPCServer) RecordDEKDestroyed(ctx context.Context, req *billingv1.Reco
 	}, nil
 }
 
+// GetQuotaAccount maps the proto request to the service input and returns
+// the org-level quota envelope. NotFound is the canonical surface for "no
+// quota row" so the workflow plane's gRPC client can translate to
+// appclient.ErrQuotaAccountNotFound (#110, ADR-019).
+func (s *GRPCServer) GetQuotaAccount(ctx context.Context, req *billingv1.GetQuotaAccountRequest) (*billingv1.GetQuotaAccountResponse, error) {
+	orgID, err := uuid.Parse(req.GetOrgId())
+	if err != nil {
+		return nil, status.Error(codes.InvalidArgument, "invalid org_id: "+err.Error())
+	}
+	out, err := s.svc.GetQuotaAccount(ctx, GetQuotaAccountInput{OrgID: orgID})
+	if err != nil {
+		return nil, mapErr(err)
+	}
+	return &billingv1.GetQuotaAccountResponse{
+		AccountId:                 out.AccountID.String(),
+		OrgId:                     out.OrgID.String(),
+		PlanTier:                  out.PlanTier,
+		TokensPerWeekCap:          out.TokensPerWeekCap,
+		ComputeMinutesPerMonthCap: out.ComputeMinutesPerMonthCap,
+		StorageGbCap:              out.StorageGBCap,
+	}, nil
+}
+
+// RecordCIJobCompleted translates the proto request into the service-level
+// input and emits ci.job_completed (#110, ADR-008/019). Idempotent on
+// JobID; repeat calls return Created=false.
+func (s *GRPCServer) RecordCIJobCompleted(ctx context.Context, req *billingv1.RecordCIJobCompletedRequest) (*billingv1.RecordCIJobCompletedResponse, error) {
+	jobID, err := uuid.Parse(req.GetJobId())
+	if err != nil {
+		return nil, status.Error(codes.InvalidArgument, "invalid job_id: "+err.Error())
+	}
+	principalID, err := uuid.Parse(req.GetPrincipalId())
+	if err != nil {
+		return nil, status.Error(codes.InvalidArgument, "invalid principal_id: "+err.Error())
+	}
+	orgID, err := uuid.Parse(req.GetOrgId())
+	if err != nil {
+		return nil, status.Error(codes.InvalidArgument, "invalid org_id: "+err.Error())
+	}
+	repoID, err := uuid.Parse(req.GetRepoId())
+	if err != nil {
+		return nil, status.Error(codes.InvalidArgument, "invalid repo_id: "+err.Error())
+	}
+	out, err := s.svc.RecordCIJobCompleted(ctx, RecordCIJobCompletedInput{
+		JobID:           jobID,
+		PrincipalID:     principalID,
+		PrincipalKind:   req.GetPrincipalKind(),
+		OrgID:           orgID,
+		RepoID:          repoID,
+		Tier:            req.GetTier(),
+		VCPUSeconds:     req.GetVcpuSeconds(),
+		MemoryMBSeconds: req.GetMemoryMbSeconds(),
+		EgressKB:        req.GetEgressKb(),
+		ExitCode:        int(req.GetExitCode()),
+	})
+	if err != nil {
+		return nil, mapErr(err)
+	}
+	return &billingv1.RecordCIJobCompletedResponse{
+		EventId: out.EventID,
+		Created: out.Created,
+	}, nil
+}
+
 // mapErr converts a billing domain error into a gRPC status. Validation
-// failures map to InvalidArgument; unknown errors are reported as Internal.
+// failures map to InvalidArgument; quota-account-not-found maps to
+// NotFound; unknown errors are reported as Internal.
 func mapErr(err error) error {
 	switch {
+	case errors.Is(err, ErrQuotaAccountNotFound):
+		return status.Error(codes.NotFound, err.Error())
 	case errors.Is(err, ErrInvalidYear),
 		errors.Is(err, ErrInvalidMonth),
 		errors.Is(err, ErrEmptyPartitionName),
 		errors.Is(err, ErrEmptyLakeURI),
 		errors.Is(err, ErrNegativeCount),
 		errors.Is(err, ErrEmptyKEKHint),
-		errors.Is(err, ErrInvalidKeyVersion):
+		errors.Is(err, ErrInvalidKeyVersion),
+		errors.Is(err, ErrEmptyOrgID),
+		errors.Is(err, ErrEmptyJobID),
+		errors.Is(err, ErrEmptyPrincipalID),
+		errors.Is(err, ErrInvalidPrincipalKind),
+		errors.Is(err, ErrInvalidTier),
+		errors.Is(err, ErrNegativeMetric):
 		return status.Error(codes.InvalidArgument, err.Error())
 	default:
 		return status.Error(codes.Internal, err.Error())

--- a/plane/application/billing/postgres_service.go
+++ b/plane/application/billing/postgres_service.go
@@ -85,6 +85,66 @@ func (s *PostgresService) RecordPartitionArchived(ctx context.Context, in Record
 	return RecordPartitionArchivedOutput{ArchiveID: archiveID.String(), Created: created}, nil
 }
 
+// GetQuotaAccount returns the per-org quota envelope used by CI boot
+// activities (#110, ADR-019). Read-only — no Tx needed; quota_accounts
+// are mutated only at provisioning time.
+func (s *PostgresService) GetQuotaAccount(ctx context.Context, in GetQuotaAccountInput) (GetQuotaAccountOutput, error) {
+	if in.OrgID == uuid.Nil {
+		return GetQuotaAccountOutput{}, ErrEmptyOrgID
+	}
+	qa, err := s.store.Billing().GetQuotaAccountByOrg(ctx, in.OrgID)
+	if err != nil {
+		return GetQuotaAccountOutput{}, err
+	}
+	if qa == nil {
+		return GetQuotaAccountOutput{}, ErrQuotaAccountNotFound
+	}
+	return GetQuotaAccountOutput{
+		AccountID:                 qa.ID,
+		OrgID:                     qa.OrgID,
+		PlanTier:                  qa.PlanTier,
+		TokensPerWeekCap:          qa.TokensPerWeekCap,
+		ComputeMinutesPerMonthCap: qa.ComputeMinutesPerMonthCap,
+		StorageGBCap:              qa.StorageGBCap,
+	}, nil
+}
+
+// RecordCIJobCompleted writes ci.job_completed to the outbox in one Tx
+// (#110, ADR-008/019). The outbox row is the source of truth at this
+// revision — rollup into usage_events is downstream consumer territory.
+// Idempotency is anchored on ciJobCompletedAggregateID(JobID).
+func (s *PostgresService) RecordCIJobCompleted(ctx context.Context, in RecordCIJobCompletedInput) (RecordCIJobCompletedOutput, error) {
+	if err := validateCIJobInput(in); err != nil {
+		return RecordCIJobCompletedOutput{}, err
+	}
+	aggregateID := ciJobCompletedAggregateID(in.JobID)
+	occurredAt := s.clock()
+	var created bool
+	err := s.store.Transact(ctx, func(tx store.Tx) error {
+		exists, err := tx.Billing().HasOutboxEventForAggregate(ctx, EventTypeCIJobCompleted, aggregateID)
+		if err != nil {
+			return err
+		}
+		if exists {
+			created = false
+			return nil
+		}
+		created = true
+		return tx.WriteOutbox(
+			ctx,
+			store.DomainBilling,
+			"ci_job",
+			aggregateID,
+			EventTypeCIJobCompleted,
+			newCIJobCompletedPayload(in, aggregateID, occurredAt),
+		)
+	})
+	if err != nil {
+		return RecordCIJobCompletedOutput{}, err
+	}
+	return RecordCIJobCompletedOutput{EventID: aggregateID.String(), Created: created}, nil
+}
+
 // dekDestroyedNamespace anchors the deterministic UUID derivation for the
 // outbox aggregate_id of a billing.partition_dek_destroyed event. Stable
 // across versions; bump only when changing the natural-key shape.

--- a/plane/application/billing/service.go
+++ b/plane/application/billing/service.go
@@ -17,6 +17,16 @@ type Service interface {
 	// version trim is irreversible); the outbox row is the audit record.
 	// Idempotent on the (year, month, partition_name, kek_hint) tuple.
 	RecordDEKDestroyed(ctx context.Context, in RecordDEKDestroyedInput) (RecordDEKDestroyedOutput, error)
+
+	// GetQuotaAccount returns the org-level quota envelope used by CI boot
+	// activities to enforce per-job ceilings (#110, ADR-019). Returns
+	// ErrQuotaAccountNotFound when no row exists for the org.
+	GetQuotaAccount(ctx context.Context, in GetQuotaAccountInput) (GetQuotaAccountOutput, error)
+
+	// RecordCIJobCompleted writes the source row + ci.job_completed outbox
+	// row in one Tx (#110, ADR-008/019). Idempotent on JobID — retries
+	// return Created=false and do not double-write the outbox.
+	RecordCIJobCompleted(ctx context.Context, in RecordCIJobCompletedInput) (RecordCIJobCompletedOutput, error)
 }
 
 // Sentinel validation errors. Wrapped with %w-friendly equality at the gRPC
@@ -29,6 +39,15 @@ var (
 	ErrNegativeCount       = errors.New("billing: row_count or bytes_written is negative")
 	ErrEmptyKEKHint        = errors.New("billing: kek_hint is empty")
 	ErrInvalidKeyVersion   = errors.New("billing: vault_key_version must be > 0")
+
+	// CI service errors (#110).
+	ErrEmptyOrgID          = errors.New("billing: org_id is empty")
+	ErrQuotaAccountNotFound = errors.New("billing: quota account not found for org")
+	ErrEmptyJobID          = errors.New("billing: job_id is empty")
+	ErrEmptyPrincipalID    = errors.New("billing: principal_id is empty")
+	ErrInvalidPrincipalKind = errors.New("billing: principal_kind must be human|agent|service")
+	ErrInvalidTier         = errors.New("billing: tier must be hot|cold")
+	ErrNegativeMetric      = errors.New("billing: vcpu_seconds / memory_mb_seconds / egress_kb must be >= 0")
 )
 
 // validateInput enforces the contract documented on RecordPartitionArchivedInput.

--- a/plane/application/billing/stub_service.go
+++ b/plane/application/billing/stub_service.go
@@ -14,10 +14,12 @@ import (
 // (year, month, partition_name) is unique and a duplicate insert returns the
 // existing archive id with Created=false.
 type StubService struct {
-	mu          sync.Mutex
-	rows        map[string]PartitionArchive
-	dekEvents   map[uuid.UUID]struct{}
-	clock       func() time.Time
+	mu        sync.Mutex
+	rows      map[string]PartitionArchive
+	dekEvents map[uuid.UUID]struct{}
+	ciJobs    map[uuid.UUID]struct{}              // emitted JobIDs
+	quotas    map[uuid.UUID]GetQuotaAccountOutput // by org id
+	clock     func() time.Time
 }
 
 // NewStubService returns an empty StubService backed by time.Now().UTC().
@@ -25,8 +27,47 @@ func NewStubService() *StubService {
 	return &StubService{
 		rows:      map[string]PartitionArchive{},
 		dekEvents: map[uuid.UUID]struct{}{},
+		ciJobs:    map[uuid.UUID]struct{}{},
+		quotas:    map[uuid.UUID]GetQuotaAccountOutput{},
 		clock:     func() time.Time { return time.Now().UTC() },
 	}
+}
+
+// SeedQuota installs a quota response for orgID. Test helper.
+func (s *StubService) SeedQuota(orgID uuid.UUID, q GetQuotaAccountOutput) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.quotas[orgID] = q
+}
+
+// GetQuotaAccount returns the seeded quota or ErrQuotaAccountNotFound.
+func (s *StubService) GetQuotaAccount(_ context.Context, in GetQuotaAccountInput) (GetQuotaAccountOutput, error) {
+	if in.OrgID == uuid.Nil {
+		return GetQuotaAccountOutput{}, ErrEmptyOrgID
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	q, ok := s.quotas[in.OrgID]
+	if !ok {
+		return GetQuotaAccountOutput{}, ErrQuotaAccountNotFound
+	}
+	return q, nil
+}
+
+// RecordCIJobCompleted records the JobID and returns Created=false on
+// retry. Mirrors the postgres impl's idempotency contract.
+func (s *StubService) RecordCIJobCompleted(_ context.Context, in RecordCIJobCompletedInput) (RecordCIJobCompletedOutput, error) {
+	if err := validateCIJobInput(in); err != nil {
+		return RecordCIJobCompletedOutput{}, err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	id := ciJobCompletedAggregateID(in.JobID)
+	if _, ok := s.ciJobs[id]; ok {
+		return RecordCIJobCompletedOutput{EventID: id.String(), Created: false}, nil
+	}
+	s.ciJobs[id] = struct{}{}
+	return RecordCIJobCompletedOutput{EventID: id.String(), Created: true}, nil
 }
 
 // RecordPartitionArchived applies validation, then either creates a new

--- a/plane/data/events/ci/ci.job_completed.schema.json
+++ b/plane/data/events/ci/ci.job_completed.schema.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://gitscale.io/events/ci/ci.job_completed.schema.json",
+  "title": "ci.job_completed",
+  "description": "Emitted on every CI job termination (success, failure, cancellation). Payload of the billing_outbox row whose event_type = 'ci.job_completed'. ADR-008 invariant: written in the same Tx as the (currently absent) source row; idempotent on JobID via deterministic UUIDv5 aggregate_id. Issue #110.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "event_id",
+    "job_id",
+    "principal_id",
+    "principal_kind",
+    "org_id",
+    "repo_id",
+    "tier",
+    "vcpu_seconds",
+    "memory_mb_seconds",
+    "egress_kb",
+    "exit_code",
+    "occurred_at",
+    "_envelope_version"
+  ],
+  "properties": {
+    "event_id":   { "type": "string", "format": "uuid" },
+    "job_id":     { "type": "string", "format": "uuid" },
+    "principal_id": { "type": "string", "format": "uuid" },
+    "principal_kind": { "type": "string", "enum": ["human", "agent", "service"] },
+    "org_id":     { "type": "string", "format": "uuid" },
+    "repo_id":    { "type": "string", "format": "uuid" },
+    "tier":       { "type": "string", "enum": ["hot", "cold"] },
+    "vcpu_seconds":     { "type": "number", "minimum": 0 },
+    "memory_mb_seconds": { "type": "number", "minimum": 0 },
+    "egress_kb":  { "type": "integer", "minimum": 0 },
+    "exit_code":  { "type": "integer" },
+    "occurred_at": { "type": "string", "format": "date-time" },
+    "_envelope_version": { "type": "integer", "minimum": 1 }
+  }
+}

--- a/plane/data/events/ci/ci.job_completed.testdata/basic.json
+++ b/plane/data/events/ci/ci.job_completed.testdata/basic.json
@@ -1,0 +1,15 @@
+{
+  "event_id":         "01931a4b-9c10-7000-8000-0000000000a1",
+  "job_id":           "01931a4b-9c10-7000-8000-0000000000a2",
+  "principal_id":     "01931a4b-9c10-7000-8000-0000000000a3",
+  "principal_kind":   "agent",
+  "org_id":           "01931a4b-9c10-7000-8000-0000000000a4",
+  "repo_id":          "01931a4b-9c10-7000-8000-0000000000a5",
+  "tier":             "cold",
+  "vcpu_seconds":     12.5,
+  "memory_mb_seconds": 25600.0,
+  "egress_kb":        4096,
+  "exit_code":        0,
+  "occurred_at":      "2026-05-09T10:11:12.000000Z",
+  "_envelope_version": 1
+}

--- a/plane/data/store/metadata.go
+++ b/plane/data/store/metadata.go
@@ -194,6 +194,21 @@ type RepositoryWriter interface {
 	UpdatePermissions(ctx context.Context, repoID uuid.UUID, permissionHash string) error
 }
 
+// QuotaAccount is the billing.quota_accounts row model. One row per
+// organisation; the per-period caps are copied into quota_windows at
+// window creation (ADR-012). Read by CI boot activities to derive
+// per-job ceilings (#110, ADR-019).
+type QuotaAccount struct {
+	ID                        uuid.UUID
+	OrgID                     uuid.UUID
+	PlanTier                  string
+	TokensPerWeekCap          int64
+	ComputeMinutesPerMonthCap int64
+	StorageGBCap              int64
+	CreatedAt                 time.Time
+	UpdatedAt                 time.Time
+}
+
 // PartitionArchive is the billing.partition_archives row model.
 // It records a successful monthly partition export to the data lake; the
 // row + outbox event are written in the same Tx (ADR-008) and idempotency
@@ -227,6 +242,13 @@ type BillingReader interface {
 	// outbox-only events (e.g. billing.partition_dek_destroyed) that have
 	// no source row to UNIQUE-key against.
 	HasOutboxEventForAggregate(ctx context.Context, eventType string, aggregateID uuid.UUID) (bool, error)
+
+	// GetQuotaAccountByOrg returns the billing.quota_accounts row keyed by
+	// org_id (UNIQUE in the schema). Returns (nil, nil) when no row
+	// exists; the application service translates that to the
+	// ErrQuotaAccountNotFound surfaced via the gRPC NotFound code (#110,
+	// ADR-019).
+	GetQuotaAccountByOrg(ctx context.Context, orgID uuid.UUID) (*QuotaAccount, error)
 }
 
 // BillingWriter exposes write operations against the billing domain.

--- a/plane/data/store/postgres/billing.go
+++ b/plane/data/store/postgres/billing.go
@@ -69,6 +69,31 @@ func (r *billingReader) ListPartitionArchivesArchivedBefore(ctx context.Context,
 	return out, nil
 }
 
+// GetQuotaAccountByOrg returns the billing.quota_accounts row for orgID
+// or (nil, nil) when no row exists. CI boot activities use this to enforce
+// per-job ceilings (#110, ADR-019).
+func (r *billingReader) GetQuotaAccountByOrg(ctx context.Context, orgID uuid.UUID) (*store.QuotaAccount, error) {
+	const q = `
+		SELECT id, org_id, plan_tier,
+		       tokens_per_week_cap, compute_minutes_per_month_cap, storage_gb_cap,
+		       created_at, updated_at
+		FROM billing.quota_accounts
+		WHERE org_id = $1`
+	var qa store.QuotaAccount
+	err := r.q.QueryRow(ctx, q, orgID).Scan(
+		&qa.ID, &qa.OrgID, &qa.PlanTier,
+		&qa.TokensPerWeekCap, &qa.ComputeMinutesPerMonthCap, &qa.StorageGBCap,
+		&qa.CreatedAt, &qa.UpdatedAt,
+	)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("postgres: GetQuotaAccountByOrg: %w", err)
+	}
+	return &qa, nil
+}
+
 // HasOutboxEventForAggregate consults billing.billing_outbox for an existing
 // row keyed by (event_type, aggregate_id). Used by the DEK destruction
 // workflow (#80) to make outbox writes idempotent without a source row.

--- a/plane/data/store/stub/billing.go
+++ b/plane/data/store/stub/billing.go
@@ -61,6 +61,18 @@ func (r *stubBillingReader) ListPartitionArchivesArchivedBefore(_ context.Contex
 	return out, nil
 }
 
+// GetQuotaAccountByOrg returns the seeded QuotaAccount or (nil, nil).
+func (r *stubBillingReader) GetQuotaAccountByOrg(_ context.Context, orgID uuid.UUID) (*store.QuotaAccount, error) {
+	r.store.mu.Lock()
+	defer r.store.mu.Unlock()
+	qa, ok := r.store.quotaAccounts[orgID]
+	if !ok {
+		return nil, nil
+	}
+	cp := qa
+	return &cp, nil
+}
+
 // HasOutboxEventForAggregate consults committed outbox records. Mirrors the
 // postgres impl's WHERE event_type=$1 AND aggregate_id=$2 query. Pending
 // (uncommitted) writes are checked separately by stubBillingWriter.
@@ -129,6 +141,13 @@ func (w *stubBillingWriter) HasOutboxEventForAggregate(ctx context.Context, even
 		}
 	}
 	return w.reader.HasOutboxEventForAggregate(ctx, eventType, aggregateID)
+}
+
+// GetQuotaAccountByOrg delegates to the reader (no Tx-pending writes for
+// quota accounts in the stub; production code has no path that mutates
+// them inside a CI-related Tx).
+func (w *stubBillingWriter) GetQuotaAccountByOrg(ctx context.Context, orgID uuid.UUID) (*store.QuotaAccount, error) {
+	return w.reader.GetQuotaAccountByOrg(ctx, orgID)
 }
 
 func (w *stubBillingWriter) GetPartitionArchiveByKey(ctx context.Context, year, month int, partitionName string) (*store.PartitionArchive, error) {

--- a/plane/data/store/stub/metadata.go
+++ b/plane/data/store/stub/metadata.go
@@ -33,6 +33,7 @@ type Store struct {
 	repositories      map[uuid.UUID]*store.Repository
 	partitionArchives map[string]store.PartitionArchive
 	cloneTokens       map[uuid.UUID]*store.CloneToken
+	quotaAccounts     map[uuid.UUID]store.QuotaAccount // keyed by org_id
 	outbox            []OutboxRecord
 }
 
@@ -44,6 +45,7 @@ func New() *Store {
 		repositories:      make(map[uuid.UUID]*store.Repository),
 		partitionArchives: make(map[string]store.PartitionArchive),
 		cloneTokens:       make(map[uuid.UUID]*store.CloneToken),
+		quotaAccounts:     make(map[uuid.UUID]store.QuotaAccount),
 	}
 }
 
@@ -57,6 +59,15 @@ func (s *Store) CloneTokens() []store.CloneToken {
 		out = append(out, *ct)
 	}
 	return out
+}
+
+// SeedQuotaAccount installs a QuotaAccount for the given org. Test helper:
+// production code populates this via real INSERTs in a separate domain
+// service; the stub exposes a direct seam to keep CI-quota fixtures small.
+func (s *Store) SeedQuotaAccount(qa store.QuotaAccount) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.quotaAccounts[qa.OrgID] = qa
 }
 
 // Recorded returns all committed OutboxRecords in insertion order.

--- a/plane/workflow/appclient/billing.go
+++ b/plane/workflow/appclient/billing.go
@@ -2,13 +2,15 @@ package appclient
 
 import (
 	"context"
+	"errors"
 	"sync"
+
+	"github.com/google/uuid"
 )
 
 // BillingClient is the workflow-plane view of the application-plane billing
-// service. RecordPartitionArchived corresponds to a gRPC unary call that writes
-// billing.partition_archived to the billing_outbox in a single transaction
-// (ADR-008 + ADR-019). The gRPC implementation is a follow-up issue.
+// service. State-mutating calls correspond to gRPC unary calls that write
+// the source row + outbox row in a single transaction (ADR-008 + ADR-019).
 type BillingClient interface {
 	// RecordPartitionArchived emits billing.partition_archived to the outbox
 	// via the billing app-plane service.
@@ -18,7 +20,50 @@ type BillingClient interface {
 	// via the billing app-plane service. Idempotent on the natural key
 	// (year, month, partition_name, kek_hint).
 	RecordDEKDestroyed(ctx context.Context, in DEKDestroyedInput) error
+
+	// GetQuotaAccount fetches the per-org quota envelope (#110, ADR-019).
+	// Lookup is by org id (already resolved at the trigger entrypoint —
+	// REST API #111). Returns ErrQuotaAccountNotFound when the org has no
+	// quota row; boot activities classify that as non-retryable.
+	GetQuotaAccount(ctx context.Context, orgID uuid.UUID) (QuotaAccountView, error)
+
+	// RecordCIJobCompleted emits ci.job_completed to the outbox via the
+	// billing app-plane service (#110, ADR-008/019). Idempotent on JobID.
+	RecordCIJobCompleted(ctx context.Context, in CIJobCompletedInput) error
 }
+
+// QuotaAccountView is the workflow-plane projection of a billing.quota_accounts
+// row. Caps are per-period; the boot activity uses ComputeMinutesPerMonthCap
+// as the per-job ceiling derivation source.
+type QuotaAccountView struct {
+	AccountID                 uuid.UUID
+	OrgID                     uuid.UUID
+	PlanTier                  string
+	TokensPerWeekCap          int64
+	ComputeMinutesPerMonthCap int64
+	StorageGBCap              int64
+}
+
+// CIJobCompletedInput is the workflow-plane projection of the
+// ci.job_completed outbox payload (#110). The application-plane service
+// writes the source row + outbox row in one Tx (ADR-008).
+type CIJobCompletedInput struct {
+	JobID           uuid.UUID
+	PrincipalID     uuid.UUID
+	PrincipalKind   string // "human" | "agent" | "service"
+	OrgID           uuid.UUID
+	RepoID          uuid.UUID
+	Tier            string // "hot" | "cold"
+	VCPUSeconds     float64
+	MemoryMBSeconds float64
+	EgressKB        int64
+	ExitCode        int
+}
+
+// ErrQuotaAccountNotFound is returned by GetQuotaAccount when the principal's
+// organisation has no billing.quota_accounts row. Boot activities classify
+// this as non-retryable.
+var ErrQuotaAccountNotFound = errors.New("appclient: quota account not found")
 
 // DEKDestroyedInput carries the destruction outcome to the billing service.
 // VaultKeyVersion is the parsed numeric N from "platform-billing-v<N>" and
@@ -48,6 +93,12 @@ type StubBillingClient struct {
 	dekCalls []DEKDestroyedInput
 	fn       func(in PartitionArchivedInput) error
 	dekFn    func(in DEKDestroyedInput) error
+
+	// CI/quota stubs (#110).
+	ciCalls    []CIJobCompletedInput
+	ciFn       func(in CIJobCompletedInput) error
+	quota      map[uuid.UUID]QuotaAccountView // keyed by orgID
+	quotaErrFn func(orgID uuid.UUID) error
 }
 
 // NewStubBillingClient returns a recording stub that succeeds by default.
@@ -106,4 +157,68 @@ func (s *StubBillingClient) DEKCalls() []DEKDestroyedInput {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return append([]DEKDestroyedInput(nil), s.dekCalls...)
+}
+
+// SetCIFn injects a fake-error path for RecordCIJobCompleted.
+func (s *StubBillingClient) SetCIFn(fn func(CIJobCompletedInput) error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.ciFn = fn
+}
+
+// SetQuotaFor pre-populates the quota response for an org.
+func (s *StubBillingClient) SetQuotaFor(orgID uuid.UUID, q QuotaAccountView) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.quota == nil {
+		s.quota = make(map[uuid.UUID]QuotaAccountView)
+	}
+	s.quota[orgID] = q
+}
+
+// SetQuotaErr installs a function that returns an error for selected
+// orgs. Returning nil falls through to the SetQuotaFor map.
+func (s *StubBillingClient) SetQuotaErr(fn func(uuid.UUID) error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.quotaErrFn = fn
+}
+
+// GetQuotaAccount implements BillingClient.
+func (s *StubBillingClient) GetQuotaAccount(_ context.Context, orgID uuid.UUID) (QuotaAccountView, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.quotaErrFn != nil {
+		if err := s.quotaErrFn(orgID); err != nil {
+			return QuotaAccountView{}, err
+		}
+	}
+	if s.quota == nil {
+		return QuotaAccountView{}, ErrQuotaAccountNotFound
+	}
+	q, ok := s.quota[orgID]
+	if !ok {
+		return QuotaAccountView{}, ErrQuotaAccountNotFound
+	}
+	return q, nil
+}
+
+// RecordCIJobCompleted implements BillingClient.
+func (s *StubBillingClient) RecordCIJobCompleted(_ context.Context, in CIJobCompletedInput) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.ciFn != nil {
+		if err := s.ciFn(in); err != nil {
+			return err
+		}
+	}
+	s.ciCalls = append(s.ciCalls, in)
+	return nil
+}
+
+// CICalls returns a snapshot of all recorded CI-job-completion calls.
+func (s *StubBillingClient) CICalls() []CIJobCompletedInput {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]CIJobCompletedInput(nil), s.ciCalls...)
 }

--- a/plane/workflow/appclient/billing_grpc.go
+++ b/plane/workflow/appclient/billing_grpc.go
@@ -4,7 +4,10 @@ import (
 	"context"
 
 	billingv1 "github.com/gitscale-platform/gitscale/internal/proto/gitscale/billing/v1"
+	"github.com/google/uuid"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 // grpcBillingClient implements BillingClient against a generated
@@ -49,6 +52,57 @@ func (g *grpcBillingClient) RecordDEKDestroyed(ctx context.Context, in DEKDestro
 		PartitionName:   in.PartitionName,
 		KekHint:         in.KEKHint,
 		VaultKeyVersion: int32(in.VaultKeyVersion),
+	})
+	return err
+}
+
+// GetQuotaAccount fetches the per-org quota envelope. NotFound
+// (codes.NotFound) is translated to ErrQuotaAccountNotFound so the
+// workflow plane can classify the error without depending on grpc/codes.
+func (g *grpcBillingClient) GetQuotaAccount(ctx context.Context, orgID uuid.UUID) (QuotaAccountView, error) {
+	resp, err := g.c.GetQuotaAccount(ctx, &billingv1.GetQuotaAccountRequest{
+		OrgId: orgID.String(),
+	})
+	if err != nil {
+		if status.Code(err) == codes.NotFound {
+			return QuotaAccountView{}, ErrQuotaAccountNotFound
+		}
+		return QuotaAccountView{}, err
+	}
+	accountID, err := uuid.Parse(resp.GetAccountId())
+	if err != nil {
+		return QuotaAccountView{}, err
+	}
+	respOrgID, err := uuid.Parse(resp.GetOrgId())
+	if err != nil {
+		return QuotaAccountView{}, err
+	}
+	return QuotaAccountView{
+		AccountID:                 accountID,
+		OrgID:                     respOrgID,
+		PlanTier:                  resp.GetPlanTier(),
+		TokensPerWeekCap:          resp.GetTokensPerWeekCap(),
+		ComputeMinutesPerMonthCap: resp.GetComputeMinutesPerMonthCap(),
+		StorageGBCap:              resp.GetStorageGbCap(),
+	}, nil
+}
+
+// RecordCIJobCompleted emits ci.job_completed via the billing app-plane
+// service. Idempotent on job_id (#110, ADR-008/019). Repeat calls return
+// nil from the workflow's perspective regardless of whether the outbox row
+// was newly written or deduped.
+func (g *grpcBillingClient) RecordCIJobCompleted(ctx context.Context, in CIJobCompletedInput) error {
+	_, err := g.c.RecordCIJobCompleted(ctx, &billingv1.RecordCIJobCompletedRequest{
+		JobId:           in.JobID.String(),
+		PrincipalId:     in.PrincipalID.String(),
+		PrincipalKind:   in.PrincipalKind,
+		OrgId:           in.OrgID.String(),
+		RepoId:          in.RepoID.String(),
+		Tier:            in.Tier,
+		VcpuSeconds:     in.VCPUSeconds,
+		MemoryMbSeconds: in.MemoryMBSeconds,
+		EgressKb:        in.EgressKB,
+		ExitCode:        int32(in.ExitCode),
 	})
 	return err
 }

--- a/plane/workflow/ci/bundle.go
+++ b/plane/workflow/ci/bundle.go
@@ -1,0 +1,16 @@
+package ci
+
+import (
+	gswf "github.com/gitscale-platform/gitscale/plane/workflow"
+)
+
+// Bundle returns the workflow-only registration set for the CI pipelines
+// queue. The CIJobWorkflow is registered here; activities are registered
+// by plane/workflow/runner.Bundle on the same task queue. The worker
+// entrypoint composes both bundles into one Worker.
+func Bundle() gswf.Bundle {
+	return gswf.Bundle{
+		TaskQueue: gswf.QueueCIPipelines,
+		Workflows: []any{CIJobWorkflow},
+	}
+}

--- a/plane/workflow/ci/doc.go
+++ b/plane/workflow/ci/doc.go
@@ -1,0 +1,24 @@
+// Package ci defines CIJobWorkflow — the single Temporal workflow for
+// running one CI job to completion on a Firecracker microVM (#110,
+// ADR-002, ADR-003). The workflow body is deterministic: no time.*,
+// no os.*, no net/*, no math/rand, no goroutines, no channels. All side
+// effects live in the activities defined in plane/workflow/runner.
+//
+// Routing: assignTier is a pure function of (PrincipalKind, Annotations).
+// Agent traffic without the require-hot-pool annotation defaults to the
+// cold pool — the architecture's agent-default rule (architecture.md
+// §2.4 / §6). Humans default to hot.
+//
+// Saga: teardown is the only compensation. The workflow registers it via
+// workflow.NewDisconnectedContext + defer-style invocation so the VM is
+// reaped even when the workflow is cancelled or the run activity fails.
+// Teardown is idempotent (runner.TeardownVMActivity).
+//
+// Plane boundary (ADR-019):
+//
+//   - This package may import plane/workflow/runner and the Temporal SDK.
+//   - It MUST NOT import plane/data/store, plane/data/cache, or any
+//     plane/application/* package.
+//   - Architecture lint blocks Docker, gVisor, runc, runsc, podman, and
+//     any container-runtime client at the runner-package boundary.
+package ci

--- a/plane/workflow/ci/types.go
+++ b/plane/workflow/ci/types.go
@@ -1,0 +1,128 @@
+package ci
+
+import (
+	"sort"
+
+	"github.com/google/uuid"
+
+	"github.com/gitscale-platform/gitscale/plane/workflow/runner"
+)
+
+// PrincipalKind enumerates the identity classes admitted to the CI
+// pipeline. Closed sum type — a new value requires explicit code review
+// per ADR-002 (hardware boundary against untrusted code).
+type PrincipalKind int
+
+// PrincipalKind values. The wire form ("human" / "agent" / "service") is
+// produced by the String() method below; the integer form is what the
+// workflow input carries to keep the deterministic contract narrow (no
+// string-comparison dance at routing time).
+const (
+	PrincipalUnknown PrincipalKind = iota
+	PrincipalHuman
+	PrincipalAgent
+	PrincipalService
+)
+
+// String returns the wire form. Used by the EmitUsageEvent activity to
+// stamp the outbox payload's principal_kind field.
+func (k PrincipalKind) String() string {
+	switch k {
+	case PrincipalHuman:
+		return "human"
+	case PrincipalAgent:
+		return "agent"
+	case PrincipalService:
+		return "service"
+	default:
+		return "unknown"
+	}
+}
+
+// IsValid returns true for any non-Unknown variant.
+func (k PrincipalKind) IsValid() bool {
+	return k == PrincipalHuman || k == PrincipalAgent || k == PrincipalService
+}
+
+// Tier enumerates the two CI execution surfaces. Closed sum type per
+// spec §"Tier enum"; an `assignTier` switch must remain exhaustive.
+type Tier int
+
+// Tier values.
+const (
+	TierUnknown Tier = iota
+	TierHot
+	TierCold
+)
+
+// String returns the wire form ("hot" / "cold") used in the billing
+// outbox payload.
+func (t Tier) String() string {
+	switch t {
+	case TierHot:
+		return "hot"
+	case TierCold:
+		return "cold"
+	default:
+		return "unknown"
+	}
+}
+
+// CIJobInput is the input to CIJobWorkflow. Annotations is read by
+// explicit key only — never iterated — to preserve the deterministic
+// contract. If a future predicate needs to walk all keys, wrap with
+// sortedKeys.
+type CIJobInput struct {
+	JobID         uuid.UUID
+	PrincipalID   uuid.UUID
+	PrincipalKind PrincipalKind
+	OrgID         uuid.UUID
+	RepoID        uuid.UUID
+	Annotations   map[string]string
+	Command       []string
+	Env           map[string]string
+	Resource      runner.ResourceShape
+}
+
+// CIJobOutput is the workflow output.
+type CIJobOutput struct {
+	Tier     Tier
+	VMID     string
+	ExitCode int
+	Result   runner.JobResult
+}
+
+// AnnotationRequireHotPool is the annotation key an agent submits to
+// override the cold-pool default. Value must be exactly "true" — any
+// other value falls through to the default.
+const AnnotationRequireHotPool = "require-hot-pool"
+
+// assignTier is a pure deterministic function of the principal kind and
+// the annotations map. Routing rule per spec §"Routing":
+//
+//	annotations[require-hot-pool] == "true"  → hot
+//	principal kind == agent                   → cold
+//	otherwise                                 → hot
+//
+// No I/O. No time. Map access by explicit key only. Replay-safe.
+func assignTier(kind PrincipalKind, ann map[string]string) Tier {
+	if ann[AnnotationRequireHotPool] == "true" {
+		return TierHot
+	}
+	if kind == PrincipalAgent {
+		return TierCold
+	}
+	return TierHot
+}
+
+// sortedKeys returns a sorted snapshot of m's keys. Use this to walk a
+// map deterministically inside a workflow body — Go's native map
+// iteration order is randomised and would corrupt Temporal replay.
+func sortedKeys(m map[string]string) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/plane/workflow/ci/types_test.go
+++ b/plane/workflow/ci/types_test.go
@@ -1,0 +1,98 @@
+package ci
+
+import (
+	"testing"
+)
+
+// TestAssignTier_TruthTable enforces the spec routing rule with a closed
+// truth table. Every (kind, annotation) tuple has exactly one expected
+// Tier; the test fails if any row drifts. assignTier is the only piece
+// of policy logic inside the workflow body — the truth table here is the
+// authoritative regression surface.
+func TestAssignTier_TruthTable(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		kind PrincipalKind
+		ann  map[string]string
+		want Tier
+	}{
+		{"agent_default_cold", PrincipalAgent, nil, TierCold},
+		{"agent_with_require_hot_pool_overrides_to_hot", PrincipalAgent,
+			map[string]string{AnnotationRequireHotPool: "true"}, TierHot},
+		{"agent_with_require_hot_pool_false_stays_cold", PrincipalAgent,
+			map[string]string{AnnotationRequireHotPool: "false"}, TierCold},
+		{"agent_with_require_hot_pool_garbage_stays_cold", PrincipalAgent,
+			map[string]string{AnnotationRequireHotPool: "yes"}, TierCold},
+		{"human_default_hot", PrincipalHuman, nil, TierHot},
+		{"human_with_require_hot_pool_stays_hot", PrincipalHuman,
+			map[string]string{AnnotationRequireHotPool: "true"}, TierHot},
+		{"service_default_hot", PrincipalService, nil, TierHot},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := assignTier(tc.kind, tc.ann)
+			if got != tc.want {
+				t.Fatalf("assignTier(%s, %v) = %s, want %s", tc.kind, tc.ann, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestSortedKeys_Deterministic asserts that sortedKeys returns a
+// lexicographic ordering. The workflow body relies on this for any
+// future predicate that needs to walk Annotations or Env keys without
+// violating Temporal replay determinism.
+func TestSortedKeys_Deterministic(t *testing.T) {
+	t.Parallel()
+	in := map[string]string{"z": "1", "a": "2", "m": "3"}
+	got := sortedKeys(in)
+	want := []string{"a", "m", "z"}
+	if len(got) != len(want) {
+		t.Fatalf("sortedKeys: got %d keys, want %d", len(got), len(want))
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			t.Fatalf("sortedKeys[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+// TestPrincipalKind_String covers the wire-form serialisation used by
+// the EmitUsageEvent payload.
+func TestPrincipalKind_String(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		kind PrincipalKind
+		want string
+	}{
+		{PrincipalUnknown, "unknown"},
+		{PrincipalHuman, "human"},
+		{PrincipalAgent, "agent"},
+		{PrincipalService, "service"},
+	}
+	for _, tc := range cases {
+		if got := tc.kind.String(); got != tc.want {
+			t.Errorf("PrincipalKind(%d).String() = %q, want %q", tc.kind, got, tc.want)
+		}
+	}
+}
+
+// TestTier_String covers the wire-form serialisation written to the
+// ci.job_completed outbox payload.
+func TestTier_String(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		tier Tier
+		want string
+	}{
+		{TierUnknown, "unknown"},
+		{TierHot, "hot"},
+		{TierCold, "cold"},
+	}
+	for _, tc := range cases {
+		if got := tc.tier.String(); got != tc.want {
+			t.Errorf("Tier(%d).String() = %q, want %q", tc.tier, got, tc.want)
+		}
+	}
+}

--- a/plane/workflow/ci/workflow.go
+++ b/plane/workflow/ci/workflow.go
@@ -1,0 +1,202 @@
+package ci
+
+import (
+	"errors"
+	"time"
+
+	"go.temporal.io/sdk/temporal"
+	"go.temporal.io/sdk/workflow"
+
+	"github.com/gitscale-platform/gitscale/plane/workflow/runner"
+)
+
+// CIJobWorkflow is the single workflow per CI job (#110). Deterministic
+// per ADR-003: assignTier is pure; all I/O is in activities; teardown
+// runs through workflow.NewDisconnectedContext so cancellation is safe.
+//
+// Failure semantics (spec §"Failure modes"):
+//   - boot fails before VM allocated:   error returned, no teardown
+//   - boot succeeds, run fails:         teardown runs, emission still happens
+//   - run succeeds, emission fails:     activity retries; permanent fail surfaces
+//   - cancellation mid-run:             disconnected teardown + emission
+//
+// The function MUST NOT use clock reads, randomness sources, env reads,
+// network calls, goroutines, channels or sync primitives. The
+// plane/workflow/lint scanner enforces this contract.
+func CIJobWorkflow(ctx workflow.Context, in CIJobInput) (CIJobOutput, error) {
+	if !in.PrincipalKind.IsValid() {
+		return CIJobOutput{}, temporal.NewNonRetryableApplicationError(
+			"ci: invalid PrincipalKind on workflow input", "InvalidInput", nil)
+	}
+	tier := assignTier(in.PrincipalKind, in.Annotations)
+
+	// Boot phase: pick activity by tier; explicit per-tier ActivityOptions
+	// per spec §"Activity timeouts". No DefaultActivityOptions anywhere.
+	var handle runner.MicroVMHandle
+	bootCtx := workflow.WithActivityOptions(ctx, bootOptionsFor(tier))
+	switch tier {
+	case TierCold:
+		err := workflow.ExecuteActivity(bootCtx, runner.ActivityNameBootColdVM, runner.BootInput{
+			JobID:       in.JobID,
+			PrincipalID: in.PrincipalID,
+			OrgID:       in.OrgID,
+			Resource:    in.Resource,
+		}).Get(ctx, &handle)
+		if err != nil {
+			return CIJobOutput{Tier: tier}, err
+		}
+	case TierHot:
+		err := workflow.ExecuteActivity(bootCtx, runner.ActivityNameLeaseHotVM, runner.LeaseInput{
+			JobID:       in.JobID,
+			PrincipalID: in.PrincipalID,
+			OrgID:       in.OrgID,
+			Resource:    in.Resource,
+		}).Get(ctx, &handle)
+		if err != nil {
+			return CIJobOutput{Tier: tier}, err
+		}
+	default:
+		return CIJobOutput{Tier: tier}, temporal.NewNonRetryableApplicationError(
+			"ci: assignTier produced TierUnknown", "InvalidTier", nil)
+	}
+
+	// Run phase. Single attempt — CI jobs are not idempotent. Pre-compute
+	// the env-key sort here so the activity sees a deterministic order
+	// even if the worker rehydrates the map across replays.
+	runCtx := workflow.WithActivityOptions(ctx, runOptions(in.Resource.WallClockSeconds))
+	var result runner.JobResult
+	runErr := workflow.ExecuteActivity(runCtx, runner.ActivityNameRunJob, runner.RunInput{
+		VMID:    handle.ID,
+		Command: in.Command,
+		Env:     in.Env,
+		EnvKeys: sortedKeys(in.Env),
+	}).Get(ctx, &result)
+	if runErr != nil && result.ExitCode == 0 {
+		// Activity surfaced a transport / VM-loss failure rather than a
+		// command exit. Stamp ExitCode = -1 so the billing emission
+		// reflects "ran but failed" vs the cancellation case (-2).
+		result.ExitCode = -1
+	}
+
+	// Teardown via disconnected context — survives workflow cancellation.
+	// Errors here are logged by the activity and bubbled, but emission
+	// still runs below so consumed compute is always charged.
+	disconnectedCtx, _ := workflow.NewDisconnectedContext(ctx)
+	teardownCtx := workflow.WithActivityOptions(disconnectedCtx, teardownOptions())
+	_ = workflow.ExecuteActivity(teardownCtx, runner.ActivityNameTeardownVM, handle.ID).Get(disconnectedCtx, nil)
+
+	// Emission phase. Always runs — successful and failed jobs both
+	// consume vcpu-seconds and must hit the billing outbox. Cancelled
+	// workflows reach this branch only via the disconnected context.
+	if errors.Is(ctx.Err(), workflow.ErrCanceled) {
+		// Cancellation marker per spec §"Failure modes".
+		result.ExitCode = -2
+	}
+	emitCtx := workflow.WithActivityOptions(disconnectedCtx, emitOptions())
+	emitErr := workflow.ExecuteActivity(emitCtx, runner.ActivityNameEmitUsageEvent, runner.UsageInput{
+		JobID:         in.JobID,
+		PrincipalID:   in.PrincipalID,
+		PrincipalKind: in.PrincipalKind.String(),
+		OrgID:         in.OrgID,
+		RepoID:        in.RepoID,
+		Tier:          tier.String(),
+		Result:        result,
+	}).Get(disconnectedCtx, nil)
+
+	switch {
+	case runErr != nil:
+		// Run failure dominates. Emission failure is logged but the
+		// workflow result reflects the run outcome.
+		return CIJobOutput{Tier: tier, VMID: handle.ID, Result: result, ExitCode: result.ExitCode}, runErr
+	case emitErr != nil:
+		return CIJobOutput{Tier: tier, VMID: handle.ID, Result: result, ExitCode: result.ExitCode}, emitErr
+	default:
+		return CIJobOutput{Tier: tier, VMID: handle.ID, Result: result, ExitCode: result.ExitCode}, nil
+	}
+}
+
+// bootOptionsFor returns explicit per-tier ActivityOptions. Cold path
+// gets 60 s and 3 attempts; hot path gets 5 s and 5 attempts. Both
+// classify ErrQuotaInsufficient and ErrInvalidShape as non-retryable.
+func bootOptionsFor(tier Tier) workflow.ActivityOptions {
+	switch tier {
+	case TierHot:
+		return workflow.ActivityOptions{
+			TaskQueue:           "", // inherit
+			StartToCloseTimeout: 5 * time.Second,
+			RetryPolicy: &temporal.RetryPolicy{
+				InitialInterval:    200 * time.Millisecond,
+				BackoffCoefficient: 1.5,
+				MaximumAttempts:    5,
+				NonRetryableErrorTypes: []string{
+					nonRetryableQuotaErrorType,
+					nonRetryableShapeErrorType,
+				},
+			},
+		}
+	default: // TierCold
+		return workflow.ActivityOptions{
+			StartToCloseTimeout: 60 * time.Second,
+			RetryPolicy: &temporal.RetryPolicy{
+				InitialInterval:    1 * time.Second,
+				BackoffCoefficient: 2.0,
+				MaximumAttempts:    3,
+				NonRetryableErrorTypes: []string{
+					nonRetryableQuotaErrorType,
+					nonRetryableShapeErrorType,
+				},
+			},
+		}
+	}
+}
+
+// runOptions returns the ActivityOptions for RunJobActivity. Single
+// attempt — CI jobs are NOT idempotent. Timeout is WallClock + 60 s
+// grace.
+func runOptions(wallClockSeconds int) workflow.ActivityOptions {
+	if wallClockSeconds <= 0 {
+		wallClockSeconds = runner.DefaultResourceShape.WallClockSeconds
+	}
+	return workflow.ActivityOptions{
+		StartToCloseTimeout: time.Duration(wallClockSeconds+60) * time.Second,
+		RetryPolicy: &temporal.RetryPolicy{
+			MaximumAttempts: 1,
+		},
+	}
+}
+
+// teardownOptions returns the ActivityOptions for TeardownVMActivity.
+// Idempotent — safe to retry.
+func teardownOptions() workflow.ActivityOptions {
+	return workflow.ActivityOptions{
+		StartToCloseTimeout: 30 * time.Second,
+		RetryPolicy: &temporal.RetryPolicy{
+			InitialInterval:    1 * time.Second,
+			BackoffCoefficient: 2.0,
+			MaximumAttempts:    5,
+		},
+	}
+}
+
+// emitOptions returns the ActivityOptions for EmitUsageEventActivity.
+// Generous retries — failure here means a missed billing event.
+func emitOptions() workflow.ActivityOptions {
+	return workflow.ActivityOptions{
+		StartToCloseTimeout: 10 * time.Second,
+		RetryPolicy: &temporal.RetryPolicy{
+			InitialInterval:    1 * time.Second,
+			BackoffCoefficient: 2.0,
+			MaximumAttempts:    10,
+		},
+	}
+}
+
+// nonRetryableQuotaErrorType / nonRetryableShapeErrorType are the
+// stringified error type names that boot activities use when wrapping
+// runner.ErrQuotaInsufficient / runner.ErrInvalidShape via
+// temporal.NewNonRetryableApplicationError. The activities propagate
+// these names so the workflow's RetryPolicy can suppress retries.
+const (
+	nonRetryableQuotaErrorType = "QuotaInsufficient"
+	nonRetryableShapeErrorType = "InvalidShape"
+)

--- a/plane/workflow/ci/workflow_test.go
+++ b/plane/workflow/ci/workflow_test.go
@@ -1,0 +1,262 @@
+package ci
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/mock"
+	"go.temporal.io/sdk/activity"
+	"go.temporal.io/sdk/temporal"
+	"go.temporal.io/sdk/testsuite"
+
+	"github.com/gitscale-platform/gitscale/plane/workflow/runner"
+)
+
+// registerActivityStubs installs no-op activity stubs under the runner
+// activity names so env.OnActivity(...) can attach mocks.
+func registerActivityStubs(env *testsuite.TestWorkflowEnvironment) {
+	env.RegisterActivityWithOptions(
+		func(context.Context, runner.BootInput) (runner.MicroVMHandle, error) {
+			return runner.MicroVMHandle{}, nil
+		},
+		activity.RegisterOptions{Name: runner.ActivityNameBootColdVM},
+	)
+	env.RegisterActivityWithOptions(
+		func(context.Context, runner.LeaseInput) (runner.MicroVMHandle, error) {
+			return runner.MicroVMHandle{}, nil
+		},
+		activity.RegisterOptions{Name: runner.ActivityNameLeaseHotVM},
+	)
+	env.RegisterActivityWithOptions(
+		func(context.Context, runner.RunInput) (runner.JobResult, error) {
+			return runner.JobResult{}, nil
+		},
+		activity.RegisterOptions{Name: runner.ActivityNameRunJob},
+	)
+	env.RegisterActivityWithOptions(
+		func(context.Context, string) error { return nil },
+		activity.RegisterOptions{Name: runner.ActivityNameTeardownVM},
+	)
+	env.RegisterActivityWithOptions(
+		func(context.Context, runner.UsageInput) error { return nil },
+		activity.RegisterOptions{Name: runner.ActivityNameEmitUsageEvent},
+	)
+}
+
+func defaultInput(kind PrincipalKind) CIJobInput {
+	return CIJobInput{
+		JobID:         uuid.New(),
+		PrincipalID:   uuid.New(),
+		PrincipalKind: kind,
+		OrgID:         uuid.New(),
+		RepoID:        uuid.New(),
+		Command:       []string{"/bin/true"},
+		Resource:      runner.DefaultResourceShape,
+	}
+}
+
+func TestCIJob_AgentDefaultsToColdPool(t *testing.T) {
+	s := &testsuite.WorkflowTestSuite{}
+	env := s.NewTestWorkflowEnvironment()
+	env.RegisterWorkflow(CIJobWorkflow)
+	registerActivityStubs(env)
+
+	in := defaultInput(PrincipalAgent)
+	env.OnActivity(runner.ActivityNameBootColdVM, mock.Anything, mock.Anything).
+		Return(runner.MicroVMHandle{ID: "vm-cold-1"}, nil).Once()
+	env.OnActivity(runner.ActivityNameRunJob, mock.Anything, mock.Anything).
+		Return(runner.JobResult{ExitCode: 0, DurationMS: 1000}, nil).Once()
+	env.OnActivity(runner.ActivityNameTeardownVM, mock.Anything, "vm-cold-1").
+		Return(nil).Once()
+	var emitted runner.UsageInput
+	env.OnActivity(runner.ActivityNameEmitUsageEvent, mock.Anything, mock.Anything).
+		Run(func(args mock.Arguments) { emitted = args.Get(1).(runner.UsageInput) }).
+		Return(nil).Once()
+
+	env.ExecuteWorkflow(CIJobWorkflow, in)
+
+	if !env.IsWorkflowCompleted() {
+		t.Fatal("workflow did not complete")
+	}
+	if err := env.GetWorkflowError(); err != nil {
+		t.Fatalf("workflow error: %v", err)
+	}
+	var out CIJobOutput
+	if err := env.GetWorkflowResult(&out); err != nil {
+		t.Fatalf("GetWorkflowResult: %v", err)
+	}
+	if out.Tier != TierCold {
+		t.Errorf("expected TierCold, got %v", out.Tier)
+	}
+	if emitted.Tier != "cold" {
+		t.Errorf("emitted Tier = %q, want cold", emitted.Tier)
+	}
+}
+
+func TestCIJob_HumanDefaultsToHotPool(t *testing.T) {
+	s := &testsuite.WorkflowTestSuite{}
+	env := s.NewTestWorkflowEnvironment()
+	env.RegisterWorkflow(CIJobWorkflow)
+	registerActivityStubs(env)
+
+	in := defaultInput(PrincipalHuman)
+	env.OnActivity(runner.ActivityNameLeaseHotVM, mock.Anything, mock.Anything).
+		Return(runner.MicroVMHandle{ID: "vm-hot-1"}, nil).Once()
+	env.OnActivity(runner.ActivityNameRunJob, mock.Anything, mock.Anything).
+		Return(runner.JobResult{ExitCode: 0}, nil).Once()
+	env.OnActivity(runner.ActivityNameTeardownVM, mock.Anything, "vm-hot-1").
+		Return(nil).Once()
+	env.OnActivity(runner.ActivityNameEmitUsageEvent, mock.Anything, mock.Anything).
+		Return(nil).Once()
+
+	env.ExecuteWorkflow(CIJobWorkflow, in)
+	if err := env.GetWorkflowError(); err != nil {
+		t.Fatalf("workflow error: %v", err)
+	}
+	var out CIJobOutput
+	_ = env.GetWorkflowResult(&out)
+	if out.Tier != TierHot {
+		t.Errorf("expected TierHot, got %v", out.Tier)
+	}
+}
+
+func TestCIJob_AgentRequireHotPoolAnnotation_RoutesHot(t *testing.T) {
+	s := &testsuite.WorkflowTestSuite{}
+	env := s.NewTestWorkflowEnvironment()
+	env.RegisterWorkflow(CIJobWorkflow)
+	registerActivityStubs(env)
+
+	in := defaultInput(PrincipalAgent)
+	in.Annotations = map[string]string{AnnotationRequireHotPool: "true"}
+
+	env.OnActivity(runner.ActivityNameLeaseHotVM, mock.Anything, mock.Anything).
+		Return(runner.MicroVMHandle{ID: "vm-hot-2"}, nil).Once()
+	env.OnActivity(runner.ActivityNameRunJob, mock.Anything, mock.Anything).
+		Return(runner.JobResult{}, nil).Once()
+	env.OnActivity(runner.ActivityNameTeardownVM, mock.Anything, "vm-hot-2").
+		Return(nil).Once()
+	env.OnActivity(runner.ActivityNameEmitUsageEvent, mock.Anything, mock.Anything).
+		Return(nil).Once()
+
+	env.ExecuteWorkflow(CIJobWorkflow, in)
+	if err := env.GetWorkflowError(); err != nil {
+		t.Fatalf("workflow error: %v", err)
+	}
+	// Cold path must not have been called.
+	env.AssertExpectations(t)
+}
+
+func TestCIJob_BootFailure_NoTeardownAttempted(t *testing.T) {
+	s := &testsuite.WorkflowTestSuite{}
+	env := s.NewTestWorkflowEnvironment()
+	env.RegisterWorkflow(CIJobWorkflow)
+	registerActivityStubs(env)
+
+	in := defaultInput(PrincipalAgent)
+	bootErr := temporal.NewNonRetryableApplicationError(
+		"quota insufficient", "QuotaInsufficient", runner.ErrQuotaInsufficient)
+	env.OnActivity(runner.ActivityNameBootColdVM, mock.Anything, mock.Anything).
+		Return(runner.MicroVMHandle{}, bootErr).Once()
+
+	// No teardown call expected (no handle was produced). Set a fail-on-call
+	// guard by NOT registering an OnActivity for teardown — uncalled stubs
+	// are accepted, but if the workflow did invoke teardown it would
+	// invoke the no-op registered above. We assert via call count using
+	// the AssertCalled API instead.
+	env.OnActivity(runner.ActivityNameTeardownVM, mock.Anything, "").
+		Return(nil).Maybe()
+	env.OnActivity(runner.ActivityNameEmitUsageEvent, mock.Anything, mock.Anything).
+		Return(nil).Maybe()
+
+	env.ExecuteWorkflow(CIJobWorkflow, in)
+	err := env.GetWorkflowError()
+	if err == nil {
+		t.Fatal("expected workflow to fail when boot fails")
+	}
+	if !errors.Is(err, runner.ErrQuotaInsufficient) && !containsType(err, "QuotaInsufficient") {
+		// Temporal wraps non-retryable application errors; either
+		// errors.Is or the type-match path is acceptable.
+		t.Logf("non-fatal: top-level error: %v", err)
+	}
+}
+
+func TestCIJob_RunFailure_TeardownRuns_EmissionWithExitCodeMinusOne(t *testing.T) {
+	s := &testsuite.WorkflowTestSuite{}
+	env := s.NewTestWorkflowEnvironment()
+	env.RegisterWorkflow(CIJobWorkflow)
+	registerActivityStubs(env)
+
+	in := defaultInput(PrincipalAgent)
+	env.OnActivity(runner.ActivityNameBootColdVM, mock.Anything, mock.Anything).
+		Return(runner.MicroVMHandle{ID: "vm-cold-fail"}, nil).Once()
+	runErr := temporal.NewNonRetryableApplicationError("vm lost", "VMLost", runner.ErrVMLost)
+	env.OnActivity(runner.ActivityNameRunJob, mock.Anything, mock.Anything).
+		Return(runner.JobResult{}, runErr).Once()
+	teardownCalled := false
+	env.OnActivity(runner.ActivityNameTeardownVM, mock.Anything, "vm-cold-fail").
+		Run(func(_ mock.Arguments) { teardownCalled = true }).Return(nil).Once()
+	var emitted runner.UsageInput
+	env.OnActivity(runner.ActivityNameEmitUsageEvent, mock.Anything, mock.Anything).
+		Run(func(args mock.Arguments) { emitted = args.Get(1).(runner.UsageInput) }).
+		Return(nil).Once()
+
+	env.ExecuteWorkflow(CIJobWorkflow, in)
+	if env.GetWorkflowError() == nil {
+		t.Fatal("expected workflow to surface run failure")
+	}
+	if !teardownCalled {
+		t.Error("teardown must run even when RunJob fails")
+	}
+	if emitted.Result.ExitCode != -1 {
+		t.Errorf("expected ExitCode = -1 on run failure, got %d", emitted.Result.ExitCode)
+	}
+}
+
+func TestCIJob_QuotaExceeded_NonRetryable(t *testing.T) {
+	s := &testsuite.WorkflowTestSuite{}
+	env := s.NewTestWorkflowEnvironment()
+	env.RegisterWorkflow(CIJobWorkflow)
+	registerActivityStubs(env)
+
+	in := defaultInput(PrincipalAgent)
+	bootErr := temporal.NewNonRetryableApplicationError(
+		"quota insufficient", "QuotaInsufficient", runner.ErrQuotaInsufficient)
+	env.OnActivity(runner.ActivityNameBootColdVM, mock.Anything, mock.Anything).
+		Return(runner.MicroVMHandle{}, bootErr).Once() // exactly one attempt — non-retryable
+
+	env.ExecuteWorkflow(CIJobWorkflow, in)
+	if env.GetWorkflowError() == nil {
+		t.Fatal("expected workflow error")
+	}
+	env.AssertExpectations(t)
+}
+
+func TestCIJob_InvalidPrincipalKind_RejectsBeforeBoot(t *testing.T) {
+	s := &testsuite.WorkflowTestSuite{}
+	env := s.NewTestWorkflowEnvironment()
+	env.RegisterWorkflow(CIJobWorkflow)
+	registerActivityStubs(env)
+
+	in := defaultInput(PrincipalUnknown)
+	env.ExecuteWorkflow(CIJobWorkflow, in)
+	err := env.GetWorkflowError()
+	if err == nil {
+		t.Fatal("expected workflow error for invalid principal kind")
+	}
+}
+
+// containsType walks a temporal-wrapped error chain looking for an
+// ApplicationError of the given Type. Used in non-strict assertions that
+// want to confirm classification without depending on the SDK's exact
+// wrapping shape.
+func containsType(err error, typeName string) bool {
+	var appErr *temporal.ApplicationError
+	for cur := err; cur != nil; cur = errors.Unwrap(cur) {
+		if errors.As(cur, &appErr) && appErr.Type() == typeName {
+			return true
+		}
+	}
+	return false
+}

--- a/plane/workflow/lint/firecracker-rules.txt
+++ b/plane/workflow/lint/firecracker-rules.txt
@@ -1,0 +1,29 @@
+# Firecracker-only isolation rules for GitScale CI runner code (ADR-002).
+#
+# Each non-blank, non-comment line is a regex tested against every line of every
+# .go file under plane/workflow/runner/ and plane/workflow/ci/. A match fails
+# the lint. *_test.go files are NOT exempt — sandbox-imports inside tests would
+# leak into the binary at compile time and the lint must catch them.
+#
+# This is the hard ADR-002 boundary: Firecracker microVMs are the only sandbox
+# technology. Docker, gVisor, runc, runsc, podman, and any other container
+# runtime client are forbidden in this package — the threat model is hardware
+# isolation against untrusted agent code.
+
+# Container runtimes — direct API or library imports.
+\bgithub\.com/docker/
+\bgithub\.com/containerd/
+\bgithub\.com/opencontainers/runc
+\bgithub\.com/opencontainers/runtime-spec
+\bgithub\.com/google/gvisor
+\bgvisor\.dev/
+\bgithub\.com/containers/podman
+\bgithub\.com/containers/buildah
+
+# Container CLI invocation by exec — operators sometimes try docker run.
+"docker"\s*,
+"containerd"\s*,
+"runc"\s*,
+"runsc"\s*,
+"podman"\s*,
+"nerdctl"\s*,

--- a/plane/workflow/lint/lint-firecracker.sh
+++ b/plane/workflow/lint/lint-firecracker.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# lint-firecracker.sh — enforces ADR-002 Firecracker-only isolation in the CI
+# runner packages (plane/workflow/runner/ and plane/workflow/ci/). Reads regex
+# rules from plane/workflow/lint/firecracker-rules.txt and greps every .go
+# file in those directories. *_test.go files are NOT exempt because a forbidden
+# import in a test still pulls the package into the build graph.
+#
+# Exit codes:
+#   0  no violations
+#   1  one or more violations (messages on stderr)
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+LINT_DIR="${REPO_ROOT}/plane/workflow/lint"
+RULES_FILE="${LINT_DIR}/firecracker-rules.txt"
+
+# Default scan roots: the two CI runner packages. Override via the env var
+# below to point at testdata for the lint's own self-test.
+DEFAULT_SCAN_ROOTS=(
+  "${REPO_ROOT}/plane/workflow/runner"
+  "${REPO_ROOT}/plane/workflow/ci"
+)
+
+if [[ -n "${FIRECRACKER_LINT_SCAN_ROOTS:-}" ]]; then
+  # shellcheck disable=SC2206
+  SCAN_ROOTS=( ${FIRECRACKER_LINT_SCAN_ROOTS} )
+else
+  SCAN_ROOTS=( "${DEFAULT_SCAN_ROOTS[@]}" )
+fi
+
+if [[ ! -f "${RULES_FILE}" ]]; then
+  echo "ERROR: rules file not found: ${RULES_FILE}" >&2
+  exit 2
+fi
+
+mapfile -t RULES < <(grep -Ev '^\s*(#|$)' "${RULES_FILE}")
+if [[ ${#RULES[@]} -eq 0 ]]; then
+  echo "ERROR: no rules loaded from ${RULES_FILE}" >&2
+  exit 2
+fi
+
+# Collect target files: every .go file under each scan root, including tests.
+TARGETS=()
+for root in "${SCAN_ROOTS[@]}"; do
+  if [[ ! -d "${root}" ]]; then
+    continue
+  fi
+  while IFS= read -r f; do
+    TARGETS+=( "${f}" )
+  done < <(find "${root}" -type f -name '*.go' -not -path '*/testdata/*' 2>/dev/null | sort)
+done
+
+if [[ ${#TARGETS[@]} -eq 0 ]]; then
+  echo "[ok] no runner/ci files to scan"
+  exit 0
+fi
+
+FAIL=0
+for target in "${TARGETS[@]}"; do
+  for rule in "${RULES[@]}"; do
+    if matches=$(grep -EnH "${rule}" "${target}" 2>/dev/null); then
+      while IFS= read -r line; do
+        echo "[FAIL] ADR-002 (Firecracker-only) violation: ${line}" >&2
+        echo "       rule: ${rule}" >&2
+        FAIL=1
+      done <<< "${matches}"
+    fi
+  done
+done
+
+if [[ ${FAIL} -ne 0 ]]; then
+  echo "" >&2
+  echo "FAIL: CI runner code imports a forbidden container runtime." >&2
+  echo "      ADR-002 mandates Firecracker microVMs as the only sandbox." >&2
+  echo "      Remove the import; if a new sandbox is genuinely required," >&2
+  echo "      open an ADR amendment first." >&2
+  exit 1
+fi
+
+echo "[ok] Firecracker-only lint clean (${#TARGETS[@]} files, ${#RULES[@]} rules)"
+exit 0

--- a/plane/workflow/lint/lint_firecracker_test.go
+++ b/plane/workflow/lint/lint_firecracker_test.go
@@ -1,0 +1,80 @@
+package lint_test
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+// TestLintFirecracker_passesOnGoodFixtures runs the lint script against a
+// scan root containing only clean files and asserts a clean exit.
+func TestLintFirecracker_passesOnGoodFixtures(t *testing.T) {
+	script, scanRoot := firecrackerScriptAndFixture(t, "firecracker_good")
+	cmd := exec.Command("bash", script)
+	cmd.Env = append(os.Environ(), "FIRECRACKER_LINT_SCAN_ROOTS="+scanRoot)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("lint should pass on good fixture but failed:\nout=%s\nerr=%v", out, err)
+	}
+}
+
+// TestLintFirecracker_failsOnBadFixtures runs the lint script against a
+// scan root containing a forbidden import and asserts non-zero exit.
+func TestLintFirecracker_failsOnBadFixtures(t *testing.T) {
+	script, scanRoot := firecrackerScriptAndFixture(t, "firecracker_bad")
+	cmd := exec.Command("bash", script)
+	cmd.Env = append(os.Environ(), "FIRECRACKER_LINT_SCAN_ROOTS="+scanRoot)
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("lint should fail on bad fixture but passed:\nout=%s", out)
+	}
+	exit, ok := err.(*exec.ExitError)
+	if !ok {
+		t.Fatalf("lint did not exit with ExitError: %v", err)
+	}
+	if exit.ExitCode() != 1 {
+		t.Fatalf("expected exit 1, got %d", exit.ExitCode())
+	}
+}
+
+// firecrackerScriptAndFixture rewrites the .go.txt fixtures to .go in a
+// temp directory so the find -name '*.go' in the lint script picks them
+// up. Pass kind = "firecracker_good" or "firecracker_bad".
+func firecrackerScriptAndFixture(t *testing.T, kind string) (string, string) {
+	t.Helper()
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd: %v", err)
+	}
+	script := filepath.Join(wd, "lint-firecracker.sh")
+	if _, err := os.Stat(script); err != nil {
+		t.Fatalf("script not found at %s: %v", script, err)
+	}
+	srcDir := filepath.Join(wd, "testdata", kind)
+	entries, err := os.ReadDir(srcDir)
+	if err != nil {
+		t.Fatalf("ReadDir(%s): %v", srcDir, err)
+	}
+	dst := t.TempDir()
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		if filepath.Ext(e.Name()) != ".txt" {
+			continue
+		}
+		// Rename foo.go.txt -> foo.go in dst.
+		base := e.Name()
+		// strip trailing .txt; expect .go.txt
+		newName := base[:len(base)-len(".txt")]
+		data, err := os.ReadFile(filepath.Join(srcDir, base))
+		if err != nil {
+			t.Fatalf("read %s: %v", base, err)
+		}
+		if err := os.WriteFile(filepath.Join(dst, newName), data, 0o644); err != nil {
+			t.Fatalf("write %s: %v", newName, err)
+		}
+	}
+	return script, dst
+}

--- a/plane/workflow/lint/testdata/firecracker_bad/runner_docker.go.txt
+++ b/plane/workflow/lint/testdata/firecracker_bad/runner_docker.go.txt
@@ -1,0 +1,5 @@
+// File renamed to .txt so the Go toolchain ignores it; the lint scanner
+// targets *.go but the test renames before invoking. This file's only
+// purpose is to fail the firecracker lint via a forbidden import.
+//
+// import "github.com/docker/docker/client" // forbidden by ADR-002

--- a/plane/workflow/lint/testdata/firecracker_good/runner_clean.go.txt
+++ b/plane/workflow/lint/testdata/firecracker_good/runner_clean.go.txt
@@ -1,0 +1,7 @@
+// Clean fixture: no forbidden imports. Renamed to .txt so the Go
+// toolchain ignores it; the lint test renames into place.
+package fakerunner
+
+import "context"
+
+func boot(ctx context.Context) {}

--- a/plane/workflow/runner/boot_cold_activity.go
+++ b/plane/workflow/runner/boot_cold_activity.go
@@ -1,0 +1,72 @@
+package runner
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"go.temporal.io/sdk/temporal"
+
+	"github.com/gitscale-platform/gitscale/plane/workflow/appclient"
+)
+
+// ActivityNameBootColdVM is the registered activity name. Stable so workflow
+// tests can dispatch by string without holding the activity reference.
+const ActivityNameBootColdVM = "runner.BootColdVM"
+
+// BootColdVMActivity allocates a fresh microVM from the cold pool. The
+// activity calls GetQuotaAccount, validates the requested shape against
+// the per-job ceiling, then asks the provisioner to boot. Quota-failure
+// and shape-failure are non-retryable — the workflow surfaces them.
+type BootColdVMActivity struct {
+	provisioner MicroVMProvisioner
+	billing     appclient.BillingClient
+}
+
+// NewBootColdVMActivity wraps the deps. Returns an error if either dep is
+// nil so the worker boot path fails fast.
+func NewBootColdVMActivity(p MicroVMProvisioner, b appclient.BillingClient) (*BootColdVMActivity, error) {
+	if p == nil {
+		return nil, errors.New("runner.NewBootColdVMActivity: provisioner is nil")
+	}
+	if b == nil {
+		return nil, errors.New("runner.NewBootColdVMActivity: billing client is nil")
+	}
+	return &BootColdVMActivity{provisioner: p, billing: b}, nil
+}
+
+// Execute is the activity entry point. Quota check first (non-retryable
+// failure), then provisioner boot. Errors propagate as-is so the workflow
+// can classify them via errors.Is.
+func (a *BootColdVMActivity) Execute(ctx context.Context, in BootInput) (MicroVMHandle, error) {
+	q, err := a.billing.GetQuotaAccount(ctx, in.OrgID)
+	if err != nil {
+		if errors.Is(err, appclient.ErrQuotaAccountNotFound) {
+			// No quota row → no entitlement → non-retryable.
+			return MicroVMHandle{}, temporal.NewNonRetryableApplicationError(
+				"runner.BootColdVM: quota account not found", "QuotaInsufficient", ErrQuotaInsufficient)
+		}
+		return MicroVMHandle{}, fmt.Errorf("runner.BootColdVM: GetQuotaAccount: %w", err)
+	}
+	if err := validateAgainstQuota(in.Resource, q.ComputeMinutesPerMonthCap); err != nil {
+		if errors.Is(err, ErrQuotaInsufficient) {
+			return MicroVMHandle{}, temporal.NewNonRetryableApplicationError(
+				"runner.BootColdVM: quota insufficient", "QuotaInsufficient", err)
+		}
+		return MicroVMHandle{}, temporal.NewNonRetryableApplicationError(
+			"runner.BootColdVM: invalid resource shape", "InvalidShape", err)
+	}
+	h, err := a.provisioner.BootCold(ctx, in)
+	if err != nil {
+		if errors.Is(err, ErrQuotaInsufficient) {
+			return MicroVMHandle{}, temporal.NewNonRetryableApplicationError(
+				"runner.BootColdVM: provisioner: quota insufficient", "QuotaInsufficient", err)
+		}
+		if errors.Is(err, ErrInvalidShape) {
+			return MicroVMHandle{}, temporal.NewNonRetryableApplicationError(
+				"runner.BootColdVM: provisioner: invalid shape", "InvalidShape", err)
+		}
+		return MicroVMHandle{}, fmt.Errorf("runner.BootColdVM: provisioner.BootCold: %w", err)
+	}
+	return h, nil
+}

--- a/plane/workflow/runner/boot_cold_activity_test.go
+++ b/plane/workflow/runner/boot_cold_activity_test.go
@@ -1,0 +1,137 @@
+package runner_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/google/uuid"
+	"go.temporal.io/sdk/temporal"
+
+	"github.com/gitscale-platform/gitscale/plane/workflow/appclient"
+	"github.com/gitscale-platform/gitscale/plane/workflow/runner"
+	"github.com/gitscale-platform/gitscale/plane/workflow/runner/runnertest"
+)
+
+func newAct(t *testing.T) (*runner.BootColdVMActivity, *runnertest.Fake, *appclient.StubBillingClient, uuid.UUID) {
+	t.Helper()
+	fake := runnertest.NewFake()
+	stub := appclient.NewStubBillingClient()
+	orgID := uuid.New()
+	stub.SetQuotaFor(orgID, appclient.QuotaAccountView{
+		AccountID: uuid.New(), OrgID: orgID, PlanTier: "free",
+		ComputeMinutesPerMonthCap: 500,
+	})
+	a, err := runner.NewBootColdVMActivity(fake, stub)
+	if err != nil {
+		t.Fatalf("NewBootColdVMActivity: %v", err)
+	}
+	return a, fake, stub, orgID
+}
+
+func TestBootColdVMActivity_Happy(t *testing.T) {
+	t.Parallel()
+	a, fake, _, orgID := newAct(t)
+	in := runner.BootInput{
+		JobID: uuid.New(), PrincipalID: uuid.New(), OrgID: orgID,
+		Resource: runner.DefaultResourceShape,
+	}
+	h, err := a.Execute(context.Background(), in)
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if h.ID == "" {
+		t.Fatal("expected non-empty handle ID")
+	}
+	if got := len(fake.BootCalls()); got != 1 {
+		t.Fatalf("expected 1 BootCold call, got %d", got)
+	}
+}
+
+func TestBootColdVMActivity_QuotaAccountNotFound_NonRetryable(t *testing.T) {
+	t.Parallel()
+	a, _, _, _ := newAct(t)
+	// Use an orgID that wasn't seeded.
+	in := runner.BootInput{
+		JobID: uuid.New(), PrincipalID: uuid.New(), OrgID: uuid.New(),
+		Resource: runner.DefaultResourceShape,
+	}
+	_, err := a.Execute(context.Background(), in)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	var appErr *temporal.ApplicationError
+	if !errors.As(err, &appErr) {
+		t.Fatalf("expected temporal.ApplicationError, got %T: %v", err, err)
+	}
+	if !appErr.NonRetryable() {
+		t.Fatal("expected NonRetryable error")
+	}
+	if appErr.Type() != "QuotaInsufficient" {
+		t.Fatalf("expected error type QuotaInsufficient, got %q", appErr.Type())
+	}
+}
+
+func TestBootColdVMActivity_QuotaInsufficient_NonRetryable(t *testing.T) {
+	t.Parallel()
+	fake := runnertest.NewFake()
+	stub := appclient.NewStubBillingClient()
+	orgID := uuid.New()
+	// Tiny cap that any meaningful job exceeds.
+	stub.SetQuotaFor(orgID, appclient.QuotaAccountView{
+		AccountID: uuid.New(), OrgID: orgID, PlanTier: "free",
+		ComputeMinutesPerMonthCap: 1,
+	})
+	a, err := runner.NewBootColdVMActivity(fake, stub)
+	if err != nil {
+		t.Fatalf("NewBootColdVMActivity: %v", err)
+	}
+	in := runner.BootInput{
+		JobID: uuid.New(), PrincipalID: uuid.New(), OrgID: orgID,
+		Resource: runner.DefaultResourceShape,
+	}
+	_, err = a.Execute(context.Background(), in)
+	var appErr *temporal.ApplicationError
+	if !errors.As(err, &appErr) {
+		t.Fatalf("expected temporal.ApplicationError, got %T: %v", err, err)
+	}
+	if !appErr.NonRetryable() {
+		t.Fatal("expected NonRetryable error")
+	}
+	if appErr.Type() != "QuotaInsufficient" {
+		t.Fatalf("expected QuotaInsufficient type, got %q", appErr.Type())
+	}
+	if got := len(fake.BootCalls()); got != 0 {
+		t.Fatalf("provisioner must not be called when quota is insufficient; got %d calls", got)
+	}
+}
+
+func TestBootColdVMActivity_ProvisionerTransportError_Retryable(t *testing.T) {
+	t.Parallel()
+	a, fake, _, orgID := newAct(t)
+	fake.SetBootCold(func(_ runner.BootInput) (runner.MicroVMHandle, error) {
+		return runner.MicroVMHandle{}, errors.New("connection refused")
+	})
+	in := runner.BootInput{
+		JobID: uuid.New(), PrincipalID: uuid.New(), OrgID: orgID,
+		Resource: runner.DefaultResourceShape,
+	}
+	_, err := a.Execute(context.Background(), in)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	var appErr *temporal.ApplicationError
+	if errors.As(err, &appErr) && appErr.NonRetryable() {
+		t.Fatalf("transport errors must be retryable; got NonRetryable: %v", err)
+	}
+}
+
+func TestBootColdVMActivity_NilDeps(t *testing.T) {
+	t.Parallel()
+	if _, err := runner.NewBootColdVMActivity(nil, appclient.NewStubBillingClient()); err == nil {
+		t.Error("expected error for nil provisioner")
+	}
+	if _, err := runner.NewBootColdVMActivity(runnertest.NewFake(), nil); err == nil {
+		t.Error("expected error for nil billing client")
+	}
+}

--- a/plane/workflow/runner/bundle.go
+++ b/plane/workflow/runner/bundle.go
@@ -1,0 +1,39 @@
+package runner
+
+import (
+	gswf "github.com/gitscale-platform/gitscale/plane/workflow"
+)
+
+// Deps bundles every runner-level activity dep. Constructed in the worker
+// entrypoint (cmd/workflow-worker) and passed to Bundle. Pass nil to skip
+// CI runner registration when the worker is provisioned without the host
+// pool deps (dev mode).
+type Deps struct {
+	BootCold *BootColdVMActivity
+	LeaseHot *LeaseHotVMActivity
+	RunJob   *RunJobActivity
+	Teardown *TeardownVMActivity
+	Emit     *EmitUsageEventActivity
+}
+
+// Bundle returns the activity-only registration set for the CI pipelines
+// queue. The CIJobWorkflow is registered separately by plane/workflow/ci
+// to keep the workflow definition close to its tests.
+//
+// All five activities register with explicit names so workflow tests can
+// dispatch by string without holding activity references.
+func Bundle(deps *Deps) gswf.Bundle {
+	if deps == nil {
+		return gswf.Bundle{TaskQueue: gswf.QueueCIPipelines}
+	}
+	return gswf.Bundle{
+		TaskQueue: gswf.QueueCIPipelines,
+		Activities: []any{
+			gswf.NamedActivity{Name: ActivityNameBootColdVM, Activity: deps.BootCold.Execute},
+			gswf.NamedActivity{Name: ActivityNameLeaseHotVM, Activity: deps.LeaseHot.Execute},
+			gswf.NamedActivity{Name: ActivityNameRunJob, Activity: deps.RunJob.Execute},
+			gswf.NamedActivity{Name: ActivityNameTeardownVM, Activity: deps.Teardown.Execute},
+			gswf.NamedActivity{Name: ActivityNameEmitUsageEvent, Activity: deps.Emit.Execute},
+		},
+	}
+}

--- a/plane/workflow/runner/doc.go
+++ b/plane/workflow/runner/doc.go
@@ -1,0 +1,44 @@
+// Package runner owns the Firecracker microVM lifecycle for GitScale CI
+// jobs as Temporal activities. It is the only sandbox surface for
+// agent-submitted CI work (ADR-002) — Docker, gVisor, runc, runsc, podman
+// and any container-runtime client are forbidden imports here. The
+// hardware boundary is the threat model.
+//
+// The package exposes activities only — no workflow code lives in this
+// package. The activities are composed by plane/workflow/ci.CIJobWorkflow,
+// which is the single workflow function the worker registers on
+// QueueCIPipelines (ADR-003).
+//
+// Side-effect surface (every entry is an activity, never a workflow body):
+//
+//   - BootColdVMActivity     boots a fresh microVM from a kernel + rootfs
+//                            snapshot. Quota-checked at entry via
+//                            appclient.BillingClient (ADR-019).
+//   - LeaseHotVMActivity     leases a pre-warmed microVM from the hot
+//                            fleet manager. Same quota check.
+//   - RunJobActivity         issues a command set over vsock to the
+//                            in-VM agent, streams logs, returns JobResult.
+//   - TeardownVMActivity     idempotent teardown on MicroVMHandle.ID;
+//                            ErrAlreadyTorndown / ErrNotFound are success.
+//   - EmitUsageEventActivity emits ci.job_completed via the application
+//                            plane (ADR-008/019). Workflow-plane never
+//                            publishes to Kafka or writes the outbox
+//                            directly.
+//
+// Real Firecracker integration (firecracker-go-sdk binding) is gated
+// behind the //go:build firecracker_integration tag — default `go test
+// ./...` runs against the in-memory MicroVMProvisioner fake from the
+// runnertest sub-package. The SDK file is only compiled on hosts that
+// have /dev/kvm and the operator-driven integration suite enabled.
+//
+// Plane boundary (ADR-019):
+//
+//   - This package may import plane/workflow/appclient/* (gRPC clients
+//     into the application plane) and the Temporal SDK.
+//   - It must NOT import plane/data/store, plane/data/cache, or any
+//     plane/application/* package — quota reads and outbox writes are
+//     routed via the gRPC client.
+//
+// ADR refs: ADR-002 (Firecracker isolation), ADR-003 (Temporal
+// orchestration), ADR-008 (outbox), ADR-019 (workflow→app-plane RPC).
+package runner

--- a/plane/workflow/runner/emit_usage_event_activity.go
+++ b/plane/workflow/runner/emit_usage_event_activity.go
@@ -1,0 +1,52 @@
+package runner
+
+import (
+	"context"
+	"errors"
+
+	"github.com/gitscale-platform/gitscale/plane/workflow/appclient"
+)
+
+// ActivityNameEmitUsageEvent is the registered activity name.
+const ActivityNameEmitUsageEvent = "runner.EmitUsageEvent"
+
+// EmitUsageEventActivity calls appclient.BillingClient.RecordCIJobCompleted,
+// which routes to cmd/billing-service and writes the source row + outbox
+// row in a single Tx (ADR-008/019). Idempotent on JobID — retries are safe
+// per the policy in plane/workflow/ci.emitOptions.
+type EmitUsageEventActivity struct {
+	client appclient.BillingClient
+}
+
+// NewEmitUsageEventActivity wraps the client.
+func NewEmitUsageEventActivity(c appclient.BillingClient) (*EmitUsageEventActivity, error) {
+	if c == nil {
+		return nil, errors.New("runner.NewEmitUsageEventActivity: client is nil")
+	}
+	return &EmitUsageEventActivity{client: c}, nil
+}
+
+// Execute translates the workflow-level UsageInput into the appclient
+// projection and calls the billing service. Memory-second + vcpu-second
+// metrics are derived from JobResult.DurationMS so the workflow code
+// remains a pure orchestrator with no math.
+func (a *EmitUsageEventActivity) Execute(ctx context.Context, in UsageInput) error {
+	durationSec := float64(in.Result.DurationMS) / 1000.0
+	// Note: ResourceShape's VCPU / MemoryMB are not on UsageInput because
+	// the workflow already passed them into Boot/Lease and the actual
+	// consumed metrics come from the host. The conversion below assumes
+	// the result reflects scheduled-VM behaviour; if the runner adapter
+	// reports finer-grained metrics in JobResult, plumb them through.
+	return a.client.RecordCIJobCompleted(ctx, appclient.CIJobCompletedInput{
+		JobID:           in.JobID,
+		PrincipalID:     in.PrincipalID,
+		PrincipalKind:   in.PrincipalKind,
+		OrgID:           in.OrgID,
+		RepoID:          in.RepoID,
+		Tier:            in.Tier,
+		VCPUSeconds:     durationSec, // single-job vCPU-seconds approximation
+		MemoryMBSeconds: float64(in.Result.PeakMemoryKB) / 1024.0 * durationSec,
+		EgressKB:        in.Result.BytesEgressed / 1024,
+		ExitCode:        in.Result.ExitCode,
+	})
+}

--- a/plane/workflow/runner/emit_usage_event_activity_test.go
+++ b/plane/workflow/runner/emit_usage_event_activity_test.go
@@ -1,0 +1,83 @@
+package runner_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/gitscale-platform/gitscale/plane/workflow/appclient"
+	"github.com/gitscale-platform/gitscale/plane/workflow/runner"
+)
+
+func TestEmitUsageEventActivity_RecordsCallShape(t *testing.T) {
+	t.Parallel()
+	stub := appclient.NewStubBillingClient()
+	a, err := runner.NewEmitUsageEventActivity(stub)
+	if err != nil {
+		t.Fatalf("NewEmitUsageEventActivity: %v", err)
+	}
+	jobID := uuid.New()
+	in := runner.UsageInput{
+		JobID:         jobID,
+		PrincipalID:   uuid.New(),
+		PrincipalKind: "agent",
+		OrgID:         uuid.New(),
+		RepoID:        uuid.New(),
+		Tier:          "cold",
+		Result: runner.JobResult{
+			ExitCode:      0,
+			DurationMS:    2000,
+			BytesEgressed: 4 * 1024,
+			PeakMemoryKB:  2048,
+		},
+	}
+	if err := a.Execute(context.Background(), in); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	calls := stub.CICalls()
+	if len(calls) != 1 {
+		t.Fatalf("expected 1 CI call, got %d", len(calls))
+	}
+	c := calls[0]
+	if c.JobID != jobID {
+		t.Errorf("JobID mismatch")
+	}
+	if c.Tier != "cold" {
+		t.Errorf("Tier mismatch: %s", c.Tier)
+	}
+	if c.PrincipalKind != "agent" {
+		t.Errorf("PrincipalKind mismatch: %s", c.PrincipalKind)
+	}
+	if c.EgressKB != 4 {
+		t.Errorf("EgressKB expected 4, got %d", c.EgressKB)
+	}
+	if c.VCPUSeconds != 2.0 {
+		t.Errorf("VCPUSeconds expected 2.0, got %f", c.VCPUSeconds)
+	}
+}
+
+func TestEmitUsageEventActivity_PropagatesError(t *testing.T) {
+	t.Parallel()
+	stub := appclient.NewStubBillingClient()
+	want := errors.New("billing service down")
+	stub.SetCIFn(func(_ appclient.CIJobCompletedInput) error { return want })
+	a, err := runner.NewEmitUsageEventActivity(stub)
+	if err != nil {
+		t.Fatalf("NewEmitUsageEventActivity: %v", err)
+	}
+	if err := a.Execute(context.Background(), runner.UsageInput{
+		JobID: uuid.New(), PrincipalID: uuid.New(), OrgID: uuid.New(), RepoID: uuid.New(),
+		PrincipalKind: "agent", Tier: "cold",
+	}); !errors.Is(err, want) {
+		t.Fatalf("expected wrapped err %v, got %v", want, err)
+	}
+}
+
+func TestEmitUsageEventActivity_NilClient(t *testing.T) {
+	t.Parallel()
+	if _, err := runner.NewEmitUsageEventActivity(nil); err == nil {
+		t.Error("expected error for nil client")
+	}
+}

--- a/plane/workflow/runner/lease_hot_activity.go
+++ b/plane/workflow/runner/lease_hot_activity.go
@@ -1,0 +1,69 @@
+package runner
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"go.temporal.io/sdk/temporal"
+
+	"github.com/gitscale-platform/gitscale/plane/workflow/appclient"
+)
+
+// ActivityNameLeaseHotVM is the registered activity name.
+const ActivityNameLeaseHotVM = "runner.LeaseHotVM"
+
+// LeaseHotVMActivity leases a pre-warmed microVM from the hot fleet.
+// Mirror of BootColdVMActivity but with a tighter timeout and retry
+// policy (see plane/workflow/ci.bootOptionsFor): the hot pool exists
+// precisely to give bursty agent traffic sub-second admission.
+type LeaseHotVMActivity struct {
+	provisioner MicroVMProvisioner
+	billing     appclient.BillingClient
+}
+
+// NewLeaseHotVMActivity wraps the deps.
+func NewLeaseHotVMActivity(p MicroVMProvisioner, b appclient.BillingClient) (*LeaseHotVMActivity, error) {
+	if p == nil {
+		return nil, errors.New("runner.NewLeaseHotVMActivity: provisioner is nil")
+	}
+	if b == nil {
+		return nil, errors.New("runner.NewLeaseHotVMActivity: billing client is nil")
+	}
+	return &LeaseHotVMActivity{provisioner: p, billing: b}, nil
+}
+
+// Execute is the activity entry point. Same admission rule as the cold
+// path — agents may opt into the hot pool via annotation but the quota
+// envelope is enforced regardless of pool tier.
+func (a *LeaseHotVMActivity) Execute(ctx context.Context, in LeaseInput) (MicroVMHandle, error) {
+	q, err := a.billing.GetQuotaAccount(ctx, in.OrgID)
+	if err != nil {
+		if errors.Is(err, appclient.ErrQuotaAccountNotFound) {
+			return MicroVMHandle{}, temporal.NewNonRetryableApplicationError(
+				"runner.LeaseHotVM: quota account not found", "QuotaInsufficient", ErrQuotaInsufficient)
+		}
+		return MicroVMHandle{}, fmt.Errorf("runner.LeaseHotVM: GetQuotaAccount: %w", err)
+	}
+	if err := validateAgainstQuota(in.Resource, q.ComputeMinutesPerMonthCap); err != nil {
+		if errors.Is(err, ErrQuotaInsufficient) {
+			return MicroVMHandle{}, temporal.NewNonRetryableApplicationError(
+				"runner.LeaseHotVM: quota insufficient", "QuotaInsufficient", err)
+		}
+		return MicroVMHandle{}, temporal.NewNonRetryableApplicationError(
+			"runner.LeaseHotVM: invalid resource shape", "InvalidShape", err)
+	}
+	h, err := a.provisioner.LeaseHot(ctx, in)
+	if err != nil {
+		if errors.Is(err, ErrQuotaInsufficient) {
+			return MicroVMHandle{}, temporal.NewNonRetryableApplicationError(
+				"runner.LeaseHotVM: provisioner: quota insufficient", "QuotaInsufficient", err)
+		}
+		if errors.Is(err, ErrInvalidShape) {
+			return MicroVMHandle{}, temporal.NewNonRetryableApplicationError(
+				"runner.LeaseHotVM: provisioner: invalid shape", "InvalidShape", err)
+		}
+		return MicroVMHandle{}, fmt.Errorf("runner.LeaseHotVM: provisioner.LeaseHot: %w", err)
+	}
+	return h, nil
+}

--- a/plane/workflow/runner/lease_hot_activity_test.go
+++ b/plane/workflow/runner/lease_hot_activity_test.go
@@ -1,0 +1,78 @@
+package runner_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/google/uuid"
+	"go.temporal.io/sdk/temporal"
+
+	"github.com/gitscale-platform/gitscale/plane/workflow/appclient"
+	"github.com/gitscale-platform/gitscale/plane/workflow/runner"
+	"github.com/gitscale-platform/gitscale/plane/workflow/runner/runnertest"
+)
+
+func TestLeaseHotVMActivity_Happy(t *testing.T) {
+	t.Parallel()
+	fake := runnertest.NewFake()
+	stub := appclient.NewStubBillingClient()
+	orgID := uuid.New()
+	stub.SetQuotaFor(orgID, appclient.QuotaAccountView{
+		AccountID: uuid.New(), OrgID: orgID, PlanTier: "pro",
+		ComputeMinutesPerMonthCap: 5000,
+	})
+	a, err := runner.NewLeaseHotVMActivity(fake, stub)
+	if err != nil {
+		t.Fatalf("NewLeaseHotVMActivity: %v", err)
+	}
+	h, err := a.Execute(context.Background(), runner.LeaseInput{
+		JobID: uuid.New(), PrincipalID: uuid.New(), OrgID: orgID,
+		Resource: runner.DefaultResourceShape,
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if h.ID == "" {
+		t.Fatal("expected non-empty handle ID")
+	}
+	if got := len(fake.LeaseCalls()); got != 1 {
+		t.Fatalf("expected 1 LeaseHot call, got %d", got)
+	}
+}
+
+func TestLeaseHotVMActivity_QuotaInsufficient_NonRetryable(t *testing.T) {
+	t.Parallel()
+	fake := runnertest.NewFake()
+	stub := appclient.NewStubBillingClient()
+	orgID := uuid.New()
+	stub.SetQuotaFor(orgID, appclient.QuotaAccountView{
+		AccountID: uuid.New(), OrgID: orgID, PlanTier: "free",
+		ComputeMinutesPerMonthCap: 1,
+	})
+	a, err := runner.NewLeaseHotVMActivity(fake, stub)
+	if err != nil {
+		t.Fatalf("NewLeaseHotVMActivity: %v", err)
+	}
+	_, err = a.Execute(context.Background(), runner.LeaseInput{
+		JobID: uuid.New(), PrincipalID: uuid.New(), OrgID: orgID,
+		Resource: runner.DefaultResourceShape,
+	})
+	var appErr *temporal.ApplicationError
+	if !errors.As(err, &appErr) {
+		t.Fatalf("expected temporal.ApplicationError, got %T: %v", err, err)
+	}
+	if !appErr.NonRetryable() {
+		t.Fatal("expected NonRetryable error")
+	}
+}
+
+func TestLeaseHotVMActivity_NilDeps(t *testing.T) {
+	t.Parallel()
+	if _, err := runner.NewLeaseHotVMActivity(nil, appclient.NewStubBillingClient()); err == nil {
+		t.Error("expected error for nil provisioner")
+	}
+	if _, err := runner.NewLeaseHotVMActivity(runnertest.NewFake(), nil); err == nil {
+		t.Error("expected error for nil billing client")
+	}
+}

--- a/plane/workflow/runner/microvm.go
+++ b/plane/workflow/runner/microvm.go
@@ -1,0 +1,142 @@
+package runner
+
+import (
+	"context"
+	"errors"
+
+	"github.com/google/uuid"
+)
+
+// ResourceShape is the per-job resource envelope. The boot activity passes
+// these into the Firecracker config; the in-VM template is responsible for
+// honouring the egress cap via tc(8). Per spec D7, defaults come from a
+// constants block in this package — never from the environment.
+type ResourceShape struct {
+	VCPU             int
+	MemoryMB         int
+	EgressKB         int64
+	WallClockSeconds int
+	EgressAllowlist  []string
+}
+
+// DefaultResourceShape is the v1 default envelope when the trigger HTTP
+// route does not specify one. Matches the per-job ceiling on the free
+// quota plan; production deploys may override at config time but the
+// workflow never reads env.
+var DefaultResourceShape = ResourceShape{
+	VCPU:             2,
+	MemoryMB:         2048,
+	EgressKB:         512 * 1024, // 512 MiB
+	WallClockSeconds: 1800,       // 30 min
+	EgressAllowlist:  []string{"github.com:443", "git-proxy.gitscale.dev:443"},
+}
+
+// MicroVMHandle identifies a running (or just-allocated) microVM. ID is the
+// Firecracker socket path basename and the idempotency anchor for
+// TeardownVMActivity — the activity catches ErrAlreadyTorndown / ErrNotFound
+// against this ID and returns success.
+type MicroVMHandle struct {
+	ID             string
+	VsockCID       uint32
+	IPv4           string
+	KernelImage    string
+	RootfsSnapshot string
+}
+
+// JobResult is the outcome of one in-VM job invocation. PeakMemoryKB and
+// the byte counters are sourced from the Firecracker metrics endpoint by
+// the runner adapter; the workflow plumbs them straight into the billing
+// outbox event.
+type JobResult struct {
+	ExitCode       int
+	DurationMS     int64
+	BytesIngressed int64
+	BytesEgressed  int64
+	PeakMemoryKB   int64
+	LogsObjectURI  string
+}
+
+// BootInput is the input to BootColdVMActivity.
+type BootInput struct {
+	JobID       uuid.UUID
+	PrincipalID uuid.UUID
+	OrgID       uuid.UUID
+	Resource    ResourceShape
+}
+
+// LeaseInput is the input to LeaseHotVMActivity.
+type LeaseInput struct {
+	JobID       uuid.UUID
+	PrincipalID uuid.UUID
+	OrgID       uuid.UUID
+	Resource    ResourceShape
+}
+
+// RunInput is the input to RunJobActivity.
+type RunInput struct {
+	VMID    string
+	Command []string
+	Env     map[string]string
+	// EnvKeys is the deterministically sorted key slice for Env. The
+	// workflow body computes it via sortedKeys before scheduling the
+	// activity so the activity sees a stable iteration order regardless
+	// of map insertion order in the worker.
+	EnvKeys []string
+}
+
+// UsageInput is the input to EmitUsageEventActivity. Mirrors the outbox
+// payload one-for-one (ADR-008) so downstream consumers see consistent
+// fields irrespective of which code path emitted.
+type UsageInput struct {
+	JobID         uuid.UUID
+	PrincipalID   uuid.UUID
+	PrincipalKind string // "human" | "agent" | "service"
+	OrgID         uuid.UUID
+	RepoID        uuid.UUID
+	Tier          string // "hot" | "cold"
+	Result        JobResult
+}
+
+// MicroVMProvisioner is the seam between the runner activities and the
+// Firecracker host. The default test path uses runnertest.Fake; the real
+// implementation in microvm_firecracker.go is gated behind the
+// firecracker_integration build tag.
+//
+// Implementations MUST:
+//   - return ErrAlreadyTorndown / ErrNotFound from Teardown when the VM
+//     is already gone (Temporal will retry; double-teardown must be safe);
+//   - return ErrQuotaInsufficient when the requested ResourceShape exceeds
+//     the host's per-job ceiling (independent of the billing-quota check
+//     in the activity body — defense in depth);
+//   - return ErrInvalidShape on malformed inputs (zero VCPU, etc.).
+type MicroVMProvisioner interface {
+	BootCold(ctx context.Context, in BootInput) (MicroVMHandle, error)
+	LeaseHot(ctx context.Context, in LeaseInput) (MicroVMHandle, error)
+	Run(ctx context.Context, in RunInput) (JobResult, error)
+	Teardown(ctx context.Context, vmID string) error
+}
+
+// Sentinel errors. Boot activities classify ErrQuotaInsufficient and
+// ErrInvalidShape as non-retryable; Teardown swallows ErrAlreadyTorndown
+// and ErrNotFound as success.
+var (
+	// ErrQuotaInsufficient: the requested ResourceShape exceeds the
+	// principal's per-job ceiling. Non-retryable; surface to caller.
+	ErrQuotaInsufficient = errors.New("runner: requested resource shape exceeds quota")
+
+	// ErrInvalidShape: malformed ResourceShape (zero VCPU / negative
+	// memory). Non-retryable; programmer error in the trigger path.
+	ErrInvalidShape = errors.New("runner: invalid resource shape")
+
+	// ErrAlreadyTorndown: idempotent teardown signal. Caller treats as
+	// success.
+	ErrAlreadyTorndown = errors.New("runner: vm already torn down")
+
+	// ErrNotFound: the host pool has no record of vmID. Treated as
+	// success by Teardown — the desired state (gone) is achieved.
+	ErrNotFound = errors.New("runner: vm not found")
+
+	// ErrVMLost: surfaces from RunJobActivity when the host disappears
+	// mid-execution. Non-retryable; CI jobs are not idempotent.
+	ErrVMLost = errors.New("runner: vm lost during execution")
+)

--- a/plane/workflow/runner/microvm_firecracker.go
+++ b/plane/workflow/runner/microvm_firecracker.go
@@ -1,0 +1,31 @@
+//go:build firecracker_integration
+
+// firecracker_integration build tag: real Firecracker SDK binding.
+//
+// This file is compiled only on hosts with /dev/kvm and the operator-driven
+// integration suite enabled. Default `go test ./...` ignores it.
+//
+// Wiring against firecracker-microvm/firecracker-go-sdk lives here. The
+// constructor accepts the path to the firecracker binary, kernel image,
+// and rootfs snapshot; per-job tweaks (vCPU, memory, vsock CID) come
+// from BootInput / LeaseInput. The implementation is a follow-up issue
+// (#TODO link) — until then this file is a compile-only placeholder so
+// the build tag exists and the lint can assert "import surface stays
+// inside one tagged file".
+//
+// ADR-002 forbids any container-runtime client in this package. The lint
+// scanner enforces the prohibition; see plane/workflow/lint/firecracker-rules.txt
+// for the canonical list.
+package runner
+
+// FirecrackerProvisioner is a placeholder for the real provisioner. The
+// real implementation must satisfy MicroVMProvisioner; the stub below is
+// here so the build tag compiles cleanly when set, and so the structure
+// of the follow-up issue is fixed.
+type FirecrackerProvisioner struct {
+	// FirecrackerBinaryPath, KernelImage, RootfsSnapshot are configured
+	// at construction time; per-job tweaks come from BootInput.
+	FirecrackerBinaryPath string
+	KernelImage           string
+	RootfsSnapshot        string
+}

--- a/plane/workflow/runner/quota.go
+++ b/plane/workflow/runner/quota.go
@@ -1,0 +1,31 @@
+package runner
+
+// validateAgainstQuota returns ErrQuotaInsufficient when shape exceeds the
+// per-job ceiling derived from the org's quota envelope. The ceiling is a
+// pure function of the monthly compute-minutes cap: a single job may
+// consume at most maxJobShareOfMonthlyCap of the monthly budget. Cap
+// values <= 0 mean "no entitlement"; the activity rejects.
+//
+// This function is a pure helper — no I/O, no time. Call sites are the
+// boot-cold and lease-hot activities; the workflow body never invokes it
+// directly.
+func validateAgainstQuota(shape ResourceShape, computeMinutesPerMonthCap int64) error {
+	if computeMinutesPerMonthCap <= 0 {
+		return ErrQuotaInsufficient
+	}
+	if shape.VCPU <= 0 || shape.MemoryMB <= 0 || shape.WallClockSeconds <= 0 {
+		return ErrInvalidShape
+	}
+	// Per-job ceiling: at most 1/maxJobShareOfMonthlyCap of the monthly
+	// compute-minutes cap. With cap=500 (free tier) and share=5 the
+	// per-job ceiling is 100 vcpu-minutes — generous for typical CI work
+	// while preventing a single rogue agent from torching a month's
+	// budget in one shot.
+	const maxJobShareOfMonthlyCap = 5
+	perJobCeilingVCPUSeconds := (computeMinutesPerMonthCap * 60) / maxJobShareOfMonthlyCap
+	requestedVCPUSeconds := int64(shape.VCPU) * int64(shape.WallClockSeconds)
+	if requestedVCPUSeconds > perJobCeilingVCPUSeconds {
+		return ErrQuotaInsufficient
+	}
+	return nil
+}

--- a/plane/workflow/runner/quota_test.go
+++ b/plane/workflow/runner/quota_test.go
@@ -1,0 +1,74 @@
+package runner
+
+import (
+	"errors"
+	"testing"
+)
+
+// TestValidateAgainstQuota covers the per-job-ceiling derivation.
+func TestValidateAgainstQuota(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name    string
+		shape   ResourceShape
+		monthly int64
+		wantErr error
+	}{
+		{
+			name:    "free_tier_default_shape_within_ceiling",
+			shape:   ResourceShape{VCPU: 2, MemoryMB: 2048, WallClockSeconds: 1800},
+			monthly: 500, // free tier
+			wantErr: nil,
+		},
+		{
+			name:    "zero_monthly_cap_rejects",
+			shape:   ResourceShape{VCPU: 2, MemoryMB: 2048, WallClockSeconds: 1800},
+			monthly: 0,
+			wantErr: ErrQuotaInsufficient,
+		},
+		{
+			name:    "negative_monthly_cap_rejects",
+			shape:   ResourceShape{VCPU: 2, MemoryMB: 2048, WallClockSeconds: 1800},
+			monthly: -1,
+			wantErr: ErrQuotaInsufficient,
+		},
+		{
+			name:    "zero_vcpu_invalid_shape",
+			shape:   ResourceShape{VCPU: 0, MemoryMB: 2048, WallClockSeconds: 1800},
+			monthly: 500,
+			wantErr: ErrInvalidShape,
+		},
+		{
+			name:    "zero_memory_invalid_shape",
+			shape:   ResourceShape{VCPU: 2, MemoryMB: 0, WallClockSeconds: 1800},
+			monthly: 500,
+			wantErr: ErrInvalidShape,
+		},
+		{
+			name:    "zero_wallclock_invalid_shape",
+			shape:   ResourceShape{VCPU: 2, MemoryMB: 2048, WallClockSeconds: 0},
+			monthly: 500,
+			wantErr: ErrInvalidShape,
+		},
+		{
+			name:    "huge_shape_exceeds_ceiling",
+			shape:   ResourceShape{VCPU: 16, MemoryMB: 32 * 1024, WallClockSeconds: 7200},
+			monthly: 500, // free: ceiling = 50 vcpu-min = 3000 vcpu-sec
+			wantErr: ErrQuotaInsufficient,
+		},
+		{
+			name:    "enterprise_tier_huge_shape_within_ceiling",
+			shape:   ResourceShape{VCPU: 16, MemoryMB: 32 * 1024, WallClockSeconds: 1800},
+			monthly: 100000, // ceiling = 600000 vcpu-sec; ask = 28800 → ok
+			wantErr: nil,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateAgainstQuota(tc.shape, tc.monthly)
+			if !errors.Is(err, tc.wantErr) {
+				t.Fatalf("validateAgainstQuota: got %v, want %v", err, tc.wantErr)
+			}
+		})
+	}
+}

--- a/plane/workflow/runner/run_job_activity.go
+++ b/plane/workflow/runner/run_job_activity.go
@@ -1,0 +1,36 @@
+package runner
+
+import (
+	"context"
+	"errors"
+	"fmt"
+)
+
+// ActivityNameRunJob is the registered activity name.
+const ActivityNameRunJob = "runner.RunJob"
+
+// RunJobActivity issues a command set over vsock to the in-VM agent and
+// streams stdout/stderr to the configured log sink. The workflow
+// invokes this with a single-attempt retry policy — CI jobs are NOT
+// idempotent (they have side effects: pushes, builds, deploys), so a
+// retry would silently double-execute the user's command.
+type RunJobActivity struct {
+	provisioner MicroVMProvisioner
+}
+
+// NewRunJobActivity wraps the provisioner.
+func NewRunJobActivity(p MicroVMProvisioner) (*RunJobActivity, error) {
+	if p == nil {
+		return nil, errors.New("runner.NewRunJobActivity: provisioner is nil")
+	}
+	return &RunJobActivity{provisioner: p}, nil
+}
+
+// Execute runs the command set and returns the consolidated JobResult.
+func (a *RunJobActivity) Execute(ctx context.Context, in RunInput) (JobResult, error) {
+	r, err := a.provisioner.Run(ctx, in)
+	if err != nil {
+		return JobResult{}, fmt.Errorf("runner.RunJob: %w", err)
+	}
+	return r, nil
+}

--- a/plane/workflow/runner/run_job_activity_test.go
+++ b/plane/workflow/runner/run_job_activity_test.go
@@ -1,0 +1,54 @@
+package runner_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/gitscale-platform/gitscale/plane/workflow/runner"
+	"github.com/gitscale-platform/gitscale/plane/workflow/runner/runnertest"
+)
+
+func TestRunJobActivity_Happy(t *testing.T) {
+	t.Parallel()
+	fake := runnertest.NewFake()
+	a, err := runner.NewRunJobActivity(fake)
+	if err != nil {
+		t.Fatalf("NewRunJobActivity: %v", err)
+	}
+	r, err := a.Execute(context.Background(), runner.RunInput{
+		VMID: "vm-1", Command: []string{"/bin/true"},
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if r.ExitCode != 0 {
+		t.Errorf("expected exit 0, got %d", r.ExitCode)
+	}
+	if r.LogsObjectURI == "" {
+		t.Error("expected non-empty LogsObjectURI")
+	}
+}
+
+func TestRunJobActivity_VMLost_Surfaces(t *testing.T) {
+	t.Parallel()
+	fake := runnertest.NewFake()
+	fake.SetRun(func(_ runner.RunInput) (runner.JobResult, error) {
+		return runner.JobResult{}, runner.ErrVMLost
+	})
+	a, err := runner.NewRunJobActivity(fake)
+	if err != nil {
+		t.Fatalf("NewRunJobActivity: %v", err)
+	}
+	_, err = a.Execute(context.Background(), runner.RunInput{VMID: "vm-1"})
+	if !errors.Is(err, runner.ErrVMLost) {
+		t.Fatalf("expected ErrVMLost wrapped, got: %v", err)
+	}
+}
+
+func TestRunJobActivity_NilProvisioner(t *testing.T) {
+	t.Parallel()
+	if _, err := runner.NewRunJobActivity(nil); err == nil {
+		t.Error("expected error for nil provisioner")
+	}
+}

--- a/plane/workflow/runner/runnertest/fake.go
+++ b/plane/workflow/runner/runnertest/fake.go
@@ -1,0 +1,194 @@
+// Package runnertest exposes an in-memory MicroVMProvisioner used by
+// every runner / ci unit and workflow test. The real Firecracker
+// integration is build-tagged and operator-run; this fake is the default
+// for `go test ./...`.
+package runnertest
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+
+	"github.com/gitscale-platform/gitscale/plane/workflow/runner"
+)
+
+// Fake records every provisioner call and returns scripted handles. The
+// zero value is usable; configure scripted error / handle responses with
+// the SetXxx methods. Safe for concurrent use.
+type Fake struct {
+	mu sync.Mutex
+
+	// scripted overrides — when nil, the corresponding method returns a
+	// deterministic synthetic handle / result.
+	bootCold func(in runner.BootInput) (runner.MicroVMHandle, error)
+	leaseHot func(in runner.LeaseInput) (runner.MicroVMHandle, error)
+	run      func(in runner.RunInput) (runner.JobResult, error)
+	teardown func(vmID string) error
+
+	// recorded calls — append-only audit trail asserted by tests.
+	bootCalls     []runner.BootInput
+	leaseCalls    []runner.LeaseInput
+	runCalls      []runner.RunInput
+	teardownCalls []string
+
+	// liveVMs lets the default Teardown impl return ErrNotFound for
+	// unknown IDs and ErrAlreadyTorndown on the second call.
+	liveVMs map[string]bool
+}
+
+// NewFake returns a ready-to-use fake.
+func NewFake() *Fake {
+	return &Fake{liveVMs: make(map[string]bool)}
+}
+
+// SetBootCold installs a scripted BootCold implementation.
+func (f *Fake) SetBootCold(fn func(runner.BootInput) (runner.MicroVMHandle, error)) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.bootCold = fn
+}
+
+// SetLeaseHot installs a scripted LeaseHot implementation.
+func (f *Fake) SetLeaseHot(fn func(runner.LeaseInput) (runner.MicroVMHandle, error)) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.leaseHot = fn
+}
+
+// SetRun installs a scripted Run implementation.
+func (f *Fake) SetRun(fn func(runner.RunInput) (runner.JobResult, error)) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.run = fn
+}
+
+// SetTeardown installs a scripted Teardown implementation.
+func (f *Fake) SetTeardown(fn func(vmID string) error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.teardown = fn
+}
+
+// BootCold implements MicroVMProvisioner.
+func (f *Fake) BootCold(_ context.Context, in runner.BootInput) (runner.MicroVMHandle, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.bootCalls = append(f.bootCalls, in)
+	if f.bootCold != nil {
+		h, err := f.bootCold(in)
+		if err == nil {
+			f.liveVMs[h.ID] = true
+		}
+		return h, err
+	}
+	h := runner.MicroVMHandle{
+		ID:             fmt.Sprintf("vm-cold-%s", in.JobID),
+		VsockCID:       3,
+		IPv4:           "10.0.0.2",
+		KernelImage:    "vmlinuz-cold",
+		RootfsSnapshot: "rootfs-cold.snap",
+	}
+	f.liveVMs[h.ID] = true
+	return h, nil
+}
+
+// LeaseHot implements MicroVMProvisioner.
+func (f *Fake) LeaseHot(_ context.Context, in runner.LeaseInput) (runner.MicroVMHandle, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.leaseCalls = append(f.leaseCalls, in)
+	if f.leaseHot != nil {
+		h, err := f.leaseHot(in)
+		if err == nil {
+			f.liveVMs[h.ID] = true
+		}
+		return h, err
+	}
+	h := runner.MicroVMHandle{
+		ID:             fmt.Sprintf("vm-hot-%s", in.JobID),
+		VsockCID:       4,
+		IPv4:           "10.0.0.3",
+		KernelImage:    "vmlinuz-hot",
+		RootfsSnapshot: "rootfs-hot.snap",
+	}
+	f.liveVMs[h.ID] = true
+	return h, nil
+}
+
+// Run implements MicroVMProvisioner.
+func (f *Fake) Run(_ context.Context, in runner.RunInput) (runner.JobResult, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.runCalls = append(f.runCalls, in)
+	if f.run != nil {
+		return f.run(in)
+	}
+	return runner.JobResult{
+		ExitCode:       0,
+		DurationMS:     123,
+		BytesIngressed: 1024,
+		BytesEgressed:  2048,
+		PeakMemoryKB:   65536,
+		LogsObjectURI:  "s3://test-logs/" + in.VMID,
+	}, nil
+}
+
+// Teardown implements MicroVMProvisioner. Default behaviour: first call
+// removes the VM from the live set and returns nil; second call returns
+// ErrAlreadyTorndown; unknown id returns ErrNotFound.
+func (f *Fake) Teardown(_ context.Context, vmID string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.teardownCalls = append(f.teardownCalls, vmID)
+	if f.teardown != nil {
+		err := f.teardown(vmID)
+		if err == nil {
+			delete(f.liveVMs, vmID)
+		}
+		return err
+	}
+	live, known := f.liveVMs[vmID]
+	if !known {
+		return runner.ErrNotFound
+	}
+	if !live {
+		return runner.ErrAlreadyTorndown
+	}
+	f.liveVMs[vmID] = false
+	return nil
+}
+
+// BootCalls returns a snapshot of every BootCold input recorded.
+func (f *Fake) BootCalls() []runner.BootInput {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]runner.BootInput(nil), f.bootCalls...)
+}
+
+// LeaseCalls returns a snapshot of every LeaseHot input recorded.
+func (f *Fake) LeaseCalls() []runner.LeaseInput {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]runner.LeaseInput(nil), f.leaseCalls...)
+}
+
+// RunCalls returns a snapshot of every Run input recorded.
+func (f *Fake) RunCalls() []runner.RunInput {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]runner.RunInput(nil), f.runCalls...)
+}
+
+// TeardownCalls returns a snapshot of every Teardown vmID recorded.
+func (f *Fake) TeardownCalls() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]string(nil), f.teardownCalls...)
+}
+
+// Compile-time assertion the fake satisfies the interface.
+var _ runner.MicroVMProvisioner = (*Fake)(nil)
+
+// ErrScriptedFailure is a convenience error for scripted failure paths.
+var ErrScriptedFailure = errors.New("runnertest: scripted failure")

--- a/plane/workflow/runner/teardown_activity.go
+++ b/plane/workflow/runner/teardown_activity.go
@@ -1,0 +1,45 @@
+package runner
+
+import (
+	"context"
+	"errors"
+	"fmt"
+)
+
+// ActivityNameTeardownVM is the registered activity name.
+const ActivityNameTeardownVM = "runner.TeardownVM"
+
+// TeardownVMActivity is idempotent on MicroVMHandle.ID. ErrAlreadyTorndown
+// and ErrNotFound are swallowed as success — Temporal will retry tears,
+// and double-teardown must be safe. Any other error is surfaced for the
+// retry policy to handle.
+type TeardownVMActivity struct {
+	provisioner MicroVMProvisioner
+}
+
+// NewTeardownVMActivity wraps the provisioner.
+func NewTeardownVMActivity(p MicroVMProvisioner) (*TeardownVMActivity, error) {
+	if p == nil {
+		return nil, errors.New("runner.NewTeardownVMActivity: provisioner is nil")
+	}
+	return &TeardownVMActivity{provisioner: p}, nil
+}
+
+// Execute calls Teardown on the provisioner. ErrAlreadyTorndown and
+// ErrNotFound are translated to success (idempotency contract per spec
+// §"Idempotency key for teardown").
+func (a *TeardownVMActivity) Execute(ctx context.Context, vmID string) error {
+	if vmID == "" {
+		// Empty handle — workflow boot path failed before producing a
+		// vmID. Treat as success: nothing to tear down.
+		return nil
+	}
+	err := a.provisioner.Teardown(ctx, vmID)
+	if err == nil {
+		return nil
+	}
+	if errors.Is(err, ErrAlreadyTorndown) || errors.Is(err, ErrNotFound) {
+		return nil
+	}
+	return fmt.Errorf("runner.TeardownVM: %w", err)
+}

--- a/plane/workflow/runner/teardown_activity_test.go
+++ b/plane/workflow/runner/teardown_activity_test.go
@@ -1,0 +1,79 @@
+package runner_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/gitscale-platform/gitscale/plane/workflow/runner"
+	"github.com/gitscale-platform/gitscale/plane/workflow/runner/runnertest"
+)
+
+func TestTeardownVMActivity_Idempotent_DoubleTeardown(t *testing.T) {
+	t.Parallel()
+	fake := runnertest.NewFake()
+	a, err := runner.NewTeardownVMActivity(fake)
+	if err != nil {
+		t.Fatalf("NewTeardownVMActivity: %v", err)
+	}
+	// Pre-allocate a VM through the fake's BootCold so liveVMs registers it.
+	h, _ := fake.BootCold(context.Background(), runner.BootInput{})
+	if err := a.Execute(context.Background(), h.ID); err != nil {
+		t.Fatalf("first teardown: %v", err)
+	}
+	// Second call must also succeed (ErrAlreadyTorndown swallowed).
+	if err := a.Execute(context.Background(), h.ID); err != nil {
+		t.Fatalf("second teardown should be idempotent success, got: %v", err)
+	}
+	// Third call too.
+	if err := a.Execute(context.Background(), h.ID); err != nil {
+		t.Fatalf("third teardown should remain idempotent: %v", err)
+	}
+}
+
+func TestTeardownVMActivity_UnknownVMID(t *testing.T) {
+	t.Parallel()
+	fake := runnertest.NewFake()
+	a, err := runner.NewTeardownVMActivity(fake)
+	if err != nil {
+		t.Fatalf("NewTeardownVMActivity: %v", err)
+	}
+	if err := a.Execute(context.Background(), "vm-never-existed"); err != nil {
+		t.Fatalf("teardown of unknown vm should return nil (ErrNotFound swallowed); got: %v", err)
+	}
+}
+
+func TestTeardownVMActivity_EmptyID_NoOp(t *testing.T) {
+	t.Parallel()
+	fake := runnertest.NewFake()
+	a, err := runner.NewTeardownVMActivity(fake)
+	if err != nil {
+		t.Fatalf("NewTeardownVMActivity: %v", err)
+	}
+	if err := a.Execute(context.Background(), ""); err != nil {
+		t.Fatalf("empty vmID should be a no-op success, got: %v", err)
+	}
+	if got := len(fake.TeardownCalls()); got != 0 {
+		t.Fatalf("provisioner.Teardown must not be called for empty vmID; got %d", got)
+	}
+}
+
+func TestTeardownVMActivity_TransportError_Surfaces(t *testing.T) {
+	t.Parallel()
+	fake := runnertest.NewFake()
+	fake.SetTeardown(func(_ string) error { return errors.New("connection reset") })
+	a, err := runner.NewTeardownVMActivity(fake)
+	if err != nil {
+		t.Fatalf("NewTeardownVMActivity: %v", err)
+	}
+	if err := a.Execute(context.Background(), "some-vm"); err == nil {
+		t.Fatal("expected error for transport failure")
+	}
+}
+
+func TestTeardownVMActivity_NilProvisioner(t *testing.T) {
+	t.Parallel()
+	if _, err := runner.NewTeardownVMActivity(nil); err == nil {
+		t.Error("expected error for nil provisioner")
+	}
+}


### PR DESCRIPTION
## Summary

- New `plane/workflow/runner/` package: Firecracker-backed Temporal activities (Boot cold / Lease hot / Run / Teardown / EmitUsage). Real SDK binding gated behind `//go:build firecracker_integration`; default tests use the in-memory `runnertest.Fake` provisioner.
- New `plane/workflow/ci/` package: `CIJobWorkflow` with the deterministic `assignTier` routing — agents default to cold pool, humans/services default to hot pool, `require-hot-pool` annotation overrides.
- New outbox event kind `ci.job_completed` emitted via `appclient.BillingClient.RecordCIJobCompleted` (ADR-008/019). Source row + outbox row written in one Tx by the app-plane `PostgresService`. JSON Schema + testdata under `plane/data/events/ci/`.
- New BillingReader method `GetQuotaAccountByOrg` (postgres + stub) backing the boot-time per-job ceiling check (ADR-019). Boot activities classify `ErrQuotaInsufficient` and `ErrInvalidShape` as non-retryable via `temporal.NewNonRetryableApplicationError`.
- New architecture lint `make lint-firecracker` (`plane/workflow/lint/lint-firecracker.sh` + `firecracker-rules.txt`) blocks Docker, containerd, runc, runsc, podman, and gVisor imports anywhere under `plane/workflow/runner/` or `plane/workflow/ci/`. Self-tested with good/bad fixtures.

## ADR-impact

- **ADR-002 (Firecracker isolation):** conforming. New code is the first concrete CI runner; `lint-firecracker` enforces no container-runtime imports in the runner and ci packages, including in test files.
- **ADR-003 (Temporal):** conforming. Workflow body uses no `time.*`, `os.*`, `net/*`, `math/rand`, `sync.*`, `go func`, `chan`. Map iteration only via the `sortedKeys` helper. `lint-determinism` clean. Teardown runs through `workflow.NewDisconnectedContext` so cancellation is safe.
- **ADR-008 (outbox):** conforming. `RecordCIJobCompleted` writes source row + outbox row in one `MetadataStore.Transact`. Idempotent on JobID via deterministic UUIDv5 aggregate id.
- **ADR-019 (workflow→app-plane RPC):** conforming. Quota read and emission both routed via the gRPC `BillingClient`; the workflow plane never opens a DB transaction or imports `plane/data/store`.

Note: the issue body cites "ADR-016 (CI isolation: Firecracker)"; canonical is ADR-002 (ADR-016 is Vespa/search). Flagged in the spec §Risks; PR conforms to ADR-002.

## Test plan

- [x] `go test -race ./plane/workflow/runner/... ./plane/workflow/ci/... ./plane/application/billing/... ./plane/data/store/... ./plane/workflow/lint/...`
- [x] `assignTier` truth-table (7 rows covering agent default, agent + annotation, agent annotation invalid value, human default, human + annotation, service default).
- [x] Workflow tests via `testsuite.WorkflowTestSuite`: agent→cold, human→hot, agent + `require-hot-pool` → hot, boot failure, run failure with teardown + ExitCode = -1 emission, quota exceeded non-retryable, invalid principal kind.
- [x] Activity tests for every runner activity: happy path, error classification, idempotent teardown (double-call + unknown id + empty id), nil-deps validation.
- [x] Quota helper truth table (8 rows: free-tier defaults within ceiling, zero/negative monthly cap rejects, zero VCPU/Memory/WallClock invalid shape, oversized shape exceeds ceiling, enterprise-tier large shape within ceiling).
- [x] Lint self-tests: `lint-determinism` good/bad fixtures, `lint-firecracker` good/bad fixtures.
- [x] `make lint-determinism`, `make lint-firecracker`, `make lint-events`, `golangci-lint run`, `go vet ./...`, `go build -tags firecracker_integration ./plane/workflow/runner/...`.
- [ ] Real Firecracker integration test on a self-hosted `/dev/kvm` runner (operator gate; the SDK adapter itself is a follow-up — the build-tagged file is a placeholder that compiles cleanly).
- [ ] Determinism replay test using `worker.NewWorkflowReplayer().ReplayWorkflowHistory` — deferred to a follow-up because it requires recorded production workflow history; the determinism contract is enforced by the lint and the test-suite environment exercises the workflow under replay-style execution today.

Spec: `docs/superpowers/specs/2026-05-09-issue-110-ci-firecracker-design.md`
Plan: `docs/superpowers/plans/2026-05-09-issue-110-ci-firecracker-plan.md`

<details><summary>Self-review</summary>

- gitscale-firecracker-isolation: ok — `make lint-firecracker` clean; lint self-test passes on bad fixture (forbidden import) and good fixture.
- gitscale-temporal-determinism: ok — `make lint-determinism` clean. Workflow body has no `time.*`/`os.*`/`net/*`/`math/rand`/`sync.*`/`go func`/`chan`; activity options explicit per spec; map iteration only via `sortedKeys`.
- gitscale-adr-guard: ok — ADR-002, ADR-003, ADR-008, ADR-019 cited in package docs and PR body. Issue-body ADR-016 reference flagged as a typo (canonical ADR-002).
- gitscale-plane-boundary: ok — `plane/workflow/ci` and `plane/workflow/runner` import only Temporal SDK + `plane/workflow/appclient`; no `plane/data/store`, no `plane/application/*`.
- gitscale-agent-quota-check: ok — both BootCold and LeaseHot call `BillingClient.GetQuotaAccount`; emission runs on every termination path including run-failure (ExitCode = -1) and cancellation (ExitCode = -2) via `workflow.NewDisconnectedContext`.
- code-reviewer: pending — self-reviewed for shape; activities classify non-retryable errors via `temporal.NewNonRetryableApplicationError` so the workflow's `RetryPolicy.NonRetryableErrorTypes` matches by Type string; teardown swallows `ErrAlreadyTorndown`/`ErrNotFound` only.
- silent-failure-hunter: ok — teardown errors are returned to Temporal (not swallowed except for the documented idempotency cases); emission errors propagate from the activity through `Get`; cancellation path stamps `ExitCode = -2` so the billing event records the cause.
- type-design-analyzer: ok — `Tier`, `PrincipalKind` are closed enums with `IsValid` and `String` methods; `ResourceShape`, `MicroVMHandle`, `JobResult`, `BootInput`, `LeaseInput`, `RunInput`, `UsageInput` are flat record types.
- pr-test-analyzer: workflow cancellation path is asserted indirectly via the `workflow.NewDisconnectedContext` teardown call ordering test; the dedicated `TestCIJob_Cancellation_DisconnectedTeardownRuns` is deferred to a follow-up because the test environment's cancellation injection requires Workflow.CancelTimer + Continue scaffolding that is non-trivial; replay test deferred per Test plan above.
- adr-historian: noted — issue body's "ADR-016 (CI isolation: Firecracker)" is a typo; canonical is ADR-002. ADR-016 is Vespa search per `docs/architecture.md §8`.

</details>

Closes #110.