### PR TITLE
[Application] PR noise pipeline enforcement — semantic dedup + quality signals + composite routing

### DIFF
--- a/plane/application/prnoise/config.go
+++ b/plane/application/prnoise/config.go
@@ -1,0 +1,79 @@
+package prnoise
+
+// QualityWeights are the per-sub-signal weights consumed by the
+// rule-based quality scorer. Defaults sum to exactly 1.00 (verified in
+// config_test). Order matches the spec table; weights live in [0, 1].
+type QualityWeights struct {
+	Size         float64
+	TestCoverage float64
+	CIBuild      float64
+	Lint         float64
+	AgentsMD     float64
+	Diversity    float64
+	Churn        float64
+}
+
+// Sum returns the total of all sub-signal weights. Used by validation.
+func (w QualityWeights) Sum() float64 {
+	return w.Size + w.TestCoverage + w.CIBuild + w.Lint + w.AgentsMD + w.Diversity + w.Churn
+}
+
+// CompositeWeights govern how the composite router blends quality and
+// reputation, and how heavily a duplicate hit zeros the composite.
+type CompositeWeights struct {
+	Quality      float64
+	Reputation   float64
+	DedupPenalty float64 // multiplies (1 - DedupScore)
+}
+
+// RouterBands are the inclusive thresholds for the composite router.
+// AutoMerge must be strictly greater than Reject.
+type RouterBands struct {
+	AutoMerge float64
+	Reject    float64
+}
+
+// FeatureFlags gate non-default pipeline behaviours.
+type FeatureFlags struct {
+	// CrossOrgDedup, when true, removes the per-repo filter from the
+	// Qdrant query. Default false (CLAUDE.md open question, August 2026
+	// decision). Read once at pipeline construction (per spec) to avoid
+	// scoring drift mid-evaluation.
+	CrossOrgDedup bool
+}
+
+// Config bundles every tuning surface. The pipeline reads it once at
+// construction; it never re-reads inside Score.
+type Config struct {
+	QualityWeights QualityWeights
+	Composite      CompositeWeights
+	Bands          RouterBands
+	FeatureFlags   FeatureFlags
+}
+
+// DefaultConfig returns the production defaults documented in the spec
+// (issue #116 §Architecture). Weights sum to 1.00, AutoMergeBand=0.85,
+// RejectBand=0.30, cross-org dedup OFF.
+func DefaultConfig() Config {
+	return Config{
+		QualityWeights: QualityWeights{
+			Size:         0.20,
+			TestCoverage: 0.20,
+			CIBuild:      0.15,
+			Lint:         0.10,
+			AgentsMD:     0.20,
+			Diversity:    0.10,
+			Churn:        0.05,
+		},
+		Composite: CompositeWeights{
+			Quality:      0.5,
+			Reputation:   0.4,
+			DedupPenalty: 1.0,
+		},
+		Bands: RouterBands{
+			AutoMerge: 0.85,
+			Reject:    0.30,
+		},
+		FeatureFlags: FeatureFlags{CrossOrgDedup: false},
+	}
+}

--- a/plane/application/prnoise/config_test.go
+++ b/plane/application/prnoise/config_test.go
@@ -1,0 +1,93 @@
+package prnoise
+
+import (
+	"math"
+	"testing"
+)
+
+func TestDefaultConfig_QualityWeightsSumToOne(t *testing.T) {
+	t.Parallel()
+	w := DefaultConfig().QualityWeights
+	if math.Abs(w.Sum()-1.0) > 1e-9 {
+		t.Errorf("QualityWeights sum = %v, want 1.0", w.Sum())
+	}
+}
+
+func TestDefaultConfig_BandsAreOrdered(t *testing.T) {
+	t.Parallel()
+	b := DefaultConfig().Bands
+	if !(b.AutoMerge > b.Reject) {
+		t.Errorf("bands: AutoMerge (%v) must be > Reject (%v)", b.AutoMerge, b.Reject)
+	}
+}
+
+func TestDefaultConfig_CrossOrgDedupOff(t *testing.T) {
+	t.Parallel()
+	if DefaultConfig().FeatureFlags.CrossOrgDedup {
+		t.Errorf("CrossOrgDedup default = true, want false (CLAUDE.md open question, August 2026)")
+	}
+}
+
+func TestDefaultConfig_BandValues(t *testing.T) {
+	t.Parallel()
+	c := DefaultConfig()
+	if c.Bands.AutoMerge != 0.85 {
+		t.Errorf("AutoMerge = %v, want 0.85", c.Bands.AutoMerge)
+	}
+	if c.Bands.Reject != 0.30 {
+		t.Errorf("Reject = %v, want 0.30", c.Bands.Reject)
+	}
+}
+
+func TestDefaultConfig_CompositeWeights(t *testing.T) {
+	t.Parallel()
+	w := DefaultConfig().Composite
+	if w.Quality != 0.5 {
+		t.Errorf("Quality = %v, want 0.5", w.Quality)
+	}
+	if w.Reputation != 0.4 {
+		t.Errorf("Reputation = %v, want 0.4", w.Reputation)
+	}
+	if w.DedupPenalty != 1.0 {
+		t.Errorf("DedupPenalty = %v, want 1.0", w.DedupPenalty)
+	}
+}
+
+func TestDefaultConfig_QualityWeightTable(t *testing.T) {
+	t.Parallel()
+	w := DefaultConfig().QualityWeights
+	tests := []struct {
+		name string
+		got  float64
+		want float64
+	}{
+		{"size", w.Size, 0.20},
+		{"test_coverage", w.TestCoverage, 0.20},
+		{"ci_build", w.CIBuild, 0.15},
+		{"lint", w.Lint, 0.10},
+		{"agents_md", w.AgentsMD, 0.20},
+		{"diversity", w.Diversity, 0.10},
+		{"churn", w.Churn, 0.05},
+	}
+	for _, tc := range tests {
+		if math.Abs(tc.got-tc.want) > 1e-9 {
+			t.Errorf("%s = %v, want %v", tc.name, tc.got, tc.want)
+		}
+	}
+}
+
+func TestDecisionCode_Valid(t *testing.T) {
+	t.Parallel()
+	for _, c := range []DecisionCode{
+		DecisionAutoMergeEligible,
+		DecisionMaintainerReview,
+		DecisionReject,
+	} {
+		if !c.Valid() {
+			t.Errorf("DecisionCode %q: Valid() = false", c)
+		}
+	}
+	if DecisionCode("garbage").Valid() {
+		t.Errorf("invalid code passed Valid()")
+	}
+}

--- a/plane/application/prnoise/dedup/dedup_test.go
+++ b/plane/application/prnoise/dedup/dedup_test.go
@@ -1,0 +1,143 @@
+package dedup
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/gitscale-platform/gitscale/plane/application/prnoise"
+	"github.com/google/uuid"
+)
+
+// recordingClient is a QdrantSearcher fake that records the last call
+// and returns a programmable result. Tests assert both the threshold
+// gate and the cross-org filter behaviour through it.
+type recordingClient struct {
+	hits   []QdrantHit
+	err    error
+	gotK   int
+	gotVec []float32
+	gotRF  *uuid.UUID
+	calls  int
+}
+
+func (c *recordingClient) Search(_ context.Context, vec []float32, k int, repoFilter *uuid.UUID) ([]QdrantHit, error) {
+	c.calls++
+	c.gotK = k
+	c.gotVec = vec
+	c.gotRF = repoFilter
+	return c.hits, c.err
+}
+
+func TestNearestDuplicate_ThresholdGate(t *testing.T) {
+	t.Parallel()
+	hit := uuid.New()
+	tests := []struct {
+		name      string
+		topScore  float64
+		expectHit bool
+	}{
+		{"above_threshold", 0.95, true},
+		{"at_threshold", prnoise.DedupCosineThreshold, true},
+		{"just_below_threshold", prnoise.DedupCosineThreshold - 0.001, false},
+		{"far_below_threshold", 0.10, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			c := &recordingClient{hits: []QdrantHit{{PRID: hit, Score: tc.topScore}}}
+			d := NewQdrantDeduper(c, false)
+			got, err := d.NearestDuplicate(context.Background(), uuid.New(), []float32{1, 0, 0})
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if tc.expectHit {
+				if got == nil {
+					t.Fatalf("expected hit, got nil")
+				}
+				if got.PRID != hit {
+					t.Errorf("PRID = %v, want %v", got.PRID, hit)
+				}
+				if got.Similarity != tc.topScore {
+					t.Errorf("Similarity = %v, want %v", got.Similarity, tc.topScore)
+				}
+			} else if got != nil {
+				t.Errorf("expected nil, got %+v", got)
+			}
+		})
+	}
+}
+
+func TestNearestDuplicate_NoHits(t *testing.T) {
+	t.Parallel()
+	c := &recordingClient{hits: nil}
+	d := NewQdrantDeduper(c, false)
+	got, err := d.NearestDuplicate(context.Background(), uuid.New(), []float32{1})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != nil {
+		t.Errorf("expected nil, got %+v", got)
+	}
+}
+
+func TestNearestDuplicate_CrossOrgFlagControlsFilter(t *testing.T) {
+	t.Parallel()
+	repoID := uuid.New()
+
+	// Flag OFF → repoFilter must be set.
+	cOff := &recordingClient{hits: []QdrantHit{{PRID: uuid.New(), Score: 0.99}}}
+	dOff := NewQdrantDeduper(cOff, false)
+	if _, err := dOff.NearestDuplicate(context.Background(), repoID, []float32{1}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cOff.gotRF == nil {
+		t.Fatalf("cross-org OFF: expected non-nil repoFilter")
+	}
+	if *cOff.gotRF != repoID {
+		t.Errorf("repoFilter = %v, want %v", *cOff.gotRF, repoID)
+	}
+
+	// Flag ON → repoFilter must be nil.
+	cOn := &recordingClient{hits: []QdrantHit{{PRID: uuid.New(), Score: 0.99}}}
+	dOn := NewQdrantDeduper(cOn, true)
+	if _, err := dOn.NearestDuplicate(context.Background(), repoID, []float32{1}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cOn.gotRF != nil {
+		t.Errorf("cross-org ON: expected nil repoFilter, got %v", *cOn.gotRF)
+	}
+}
+
+func TestNearestDuplicate_TopKIsOne(t *testing.T) {
+	t.Parallel()
+	c := &recordingClient{hits: []QdrantHit{{PRID: uuid.New(), Score: 0.99}}}
+	d := NewQdrantDeduper(c, false)
+	if _, err := d.NearestDuplicate(context.Background(), uuid.New(), []float32{1}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if c.gotK != 1 {
+		t.Errorf("top-K = %d, want 1", c.gotK)
+	}
+}
+
+func TestNearestDuplicate_SearchErrorIsWrapped(t *testing.T) {
+	t.Parallel()
+	want := errors.New("qdrant exploded")
+	c := &recordingClient{err: want}
+	d := NewQdrantDeduper(c, false)
+	_, err := d.NearestDuplicate(context.Background(), uuid.New(), []float32{1})
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if !errors.Is(err, want) {
+		t.Errorf("expected wrapped %v, got %v", want, err)
+	}
+}
+
+func TestDedupCosineThresholdIsADR016Value(t *testing.T) {
+	// Anchor: an ADR-016 amendment must update both the constant and
+	// this test together. Drift is caught here.
+	if prnoise.DedupCosineThreshold != 0.92 {
+		t.Errorf("DedupCosineThreshold = %v, want 0.92 (ADR-016)", prnoise.DedupCosineThreshold)
+	}
+}

--- a/plane/application/prnoise/dedup/qdrant_client.go
+++ b/plane/application/prnoise/dedup/qdrant_client.go
@@ -1,0 +1,68 @@
+// Package dedup provides the Qdrant-backed implementation of
+// prnoise.Deduper used in Stage 1 of the PR noise pipeline. The cosine
+// similarity threshold is fixed at prnoise.DedupCosineThreshold (0.92,
+// quoted from ADR-016 — see prnoise/dedup_threshold.go).
+package dedup
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/gitscale-platform/gitscale/plane/application/prnoise"
+	"github.com/google/uuid"
+)
+
+// QdrantSearcher is the minimum surface QdrantDeduper needs from a
+// Qdrant client. Keeping the dependency this small lets tests inject a
+// recording fake without pulling the real driver into the test binary.
+type QdrantSearcher interface {
+	Search(ctx context.Context, vec []float32, k int, repoFilter *uuid.UUID) ([]QdrantHit, error)
+}
+
+// QdrantHit is the per-result projection returned by QdrantSearcher.
+type QdrantHit struct {
+	PRID  uuid.UUID
+	Score float64 // cosine similarity in [-1, 1]
+}
+
+// QdrantDeduper implements prnoise.Deduper against a QdrantSearcher.
+//
+// CrossOrg is read once at construction (the spec calls this out to
+// avoid scoring drift mid-evaluation). When false, NearestDuplicate
+// passes a non-nil repoFilter to the searcher; when true, the filter
+// is dropped.
+type QdrantDeduper struct {
+	Client   QdrantSearcher
+	CrossOrg bool
+}
+
+// NewQdrantDeduper returns a Deduper backed by client. crossOrg
+// captures the prnoise.cross_org_dedup feature flag at construction.
+func NewQdrantDeduper(client QdrantSearcher, crossOrg bool) *QdrantDeduper {
+	return &QdrantDeduper{Client: client, CrossOrg: crossOrg}
+}
+
+// NearestDuplicate runs a top-1 ANN search and gates on
+// prnoise.DedupCosineThreshold. Sub-threshold hits return (nil, nil).
+//
+// Errors from the searcher are wrapped with %w; partial results are
+// never returned.
+func (d *QdrantDeduper) NearestDuplicate(ctx context.Context, repoID uuid.UUID, vec []float32) (*prnoise.DuplicateHit, error) {
+	var filter *uuid.UUID
+	if !d.CrossOrg {
+		r := repoID
+		filter = &r
+	}
+	hits, err := d.Client.Search(ctx, vec, 1, filter)
+	if err != nil {
+		return nil, fmt.Errorf("dedup: qdrant search: %w", err)
+	}
+	if len(hits) == 0 {
+		return nil, nil
+	}
+	top := hits[0]
+	if top.Score < prnoise.DedupCosineThreshold {
+		return nil, nil
+	}
+	return &prnoise.DuplicateHit{PRID: top.PRID, Similarity: top.Score}, nil
+}

--- a/plane/application/prnoise/dedup_threshold.go
+++ b/plane/application/prnoise/dedup_threshold.go
@@ -1,0 +1,13 @@
+package prnoise
+
+// DedupCosineThreshold is the cosine-similarity gate for declaring a PR
+// a semantic duplicate. The value is quoted directly from ADR-016:
+//
+//	"Qdrant is reserved for PR deduplication only, with a cosine
+//	 similarity threshold of 0.92."
+//
+// It is intentionally a `const` and not a configuration field; tuning
+// it would silently change the ADR-016 contract surface and must be
+// done via an ADR amendment. Both the QdrantDeduper implementation and
+// the dedup_test threshold-gate cases anchor on this value.
+const DedupCosineThreshold = 0.92

--- a/plane/application/prnoise/doc.go
+++ b/plane/application/prnoise/doc.go
@@ -1,0 +1,38 @@
+// Package prnoise owns the PR noise pipeline that scores incoming pull
+// requests across four stages — semantic dedup, quality signals, agent
+// reputation, and a composite router — and persists the resulting Decision
+// alongside an outbox event for downstream consumers (webhook delivery,
+// audit, future reputation feedback loop).
+//
+// The pipeline is deterministic: same PRInput → same Decision (modulo the
+// embedder, which is an injected dependency). All sub-scores live in
+// [0, 1] and are uniformly weighted.
+//
+// ADR alignment:
+//
+//   - ADR-008 (outbox): RecordDecision writes the prnoise decision row and
+//     a pr.noise_decision_recorded outbox row in the same Tx. Callers ack on
+//     DB commit, never on Kafka publish.
+//   - ADR-016 (Vespa primary, Qdrant for PR dedup): Stage 1 issues a
+//     cosine ANN query against Qdrant at the non-configurable threshold
+//     of 0.92 quoted verbatim from the ADR. Vespa is untouched by this
+//     package.
+//   - ADR-017 (swap surfaces): ReputationScorer and QualitySignalScorer
+//     are interfaces. The current shipping impl is rule-based; the open
+//     question (CLAUDE.md, July 2026) over an ML reputation model is
+//     resolved by swapping in a new ReputationScorer with no call-site
+//     changes.
+//   - ADR-019 (plane boundary): the package depends only on the identity
+//     service (in-process, application-plane), an injected MetadataStore
+//     for outbox writes, an injected Embedder, and a Qdrant client. No
+//     imports from plane/git, plane/workflow, or plane/edge.
+//   - ADR-021 (Qdrant role): Qdrant is consumed exclusively by this
+//     package and exclusively for PR dedup.
+//
+// Cross-org dedup is gated behind the prnoise.cross_org_dedup feature
+// flag, default OFF (CLAUDE.md open question, August 2026 decision).
+//
+// PR-state mutation (close, label, comment) is the responsibility of the
+// webhook delivery worker subscribed to pr.noise_decision_recorded, not
+// of any code in this package — see ADR-008 acknowledgement boundary.
+package prnoise

--- a/plane/application/prnoise/events.go
+++ b/plane/application/prnoise/events.go
@@ -1,0 +1,62 @@
+package prnoise
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// EventTypeNoiseDecisionRecorded is the event_type written to
+// collaboration.collaboration_outbox when RecordDecision commits a
+// decision row. The schema lives at
+// plane/data/events/collaboration/pr.noise_decision_recorded.schema.json;
+// lint-events validates fixtures against it on every CI run.
+const EventTypeNoiseDecisionRecorded = "pr.noise_decision_recorded"
+
+// noiseDecisionEnvelopeVersion is the payload-level version. Bump on
+// any non-backwards-compatible change to the field set.
+const noiseDecisionEnvelopeVersion = 1
+
+// NoiseDecisionRecordedPayload is the JSON-encoded payload of a
+// pr.noise_decision_recorded outbox row. Field names match the schema.
+type NoiseDecisionRecordedPayload struct {
+	PRID            uuid.UUID    `json:"pr_id"`
+	RepoID          uuid.UUID    `json:"repo_id"`
+	OrgID           uuid.UUID    `json:"org_id"`
+	AgentID         *uuid.UUID   `json:"agent_id,omitempty"`
+	DecisionCode    DecisionCode `json:"decision_code"`
+	DedupScore      float64      `json:"dedup_score"`
+	DuplicateOf     *uuid.UUID   `json:"duplicate_of,omitempty"`
+	QualityScore    float64      `json:"quality_score"`
+	ReputationScore float64      `json:"reputation_score"`
+	CompositeScore  float64      `json:"composite_score"`
+	Reason          string       `json:"reason"`
+	DecidedAt       time.Time    `json:"decided_at"`
+	EnvelopeVersion int          `json:"_envelope_version"`
+}
+
+// newNoiseDecisionRecordedPayload converts a Decision into its outbox
+// payload. AgentID and DuplicateOf are normalised to nil pointers so
+// the JSON-omitempty tags fire (humans / non-duplicates omit the fields).
+func newNoiseDecisionRecordedPayload(d Decision) NoiseDecisionRecordedPayload {
+	var agentPtr *uuid.UUID
+	if d.AgentID != uuid.Nil {
+		a := d.AgentID
+		agentPtr = &a
+	}
+	return NoiseDecisionRecordedPayload{
+		PRID:            d.PRID,
+		RepoID:          d.RepoID,
+		OrgID:           d.OrgID,
+		AgentID:         agentPtr,
+		DecisionCode:    d.Code,
+		DedupScore:      d.DedupScore,
+		DuplicateOf:     d.DuplicateOf,
+		QualityScore:    d.QualityScore,
+		ReputationScore: d.ReputationScore,
+		CompositeScore:  d.CompositeScore,
+		Reason:          d.Reason,
+		DecidedAt:       d.DecidedAt,
+		EnvelopeVersion: noiseDecisionEnvelopeVersion,
+	}
+}

--- a/plane/application/prnoise/models.go
+++ b/plane/application/prnoise/models.go
@@ -1,0 +1,128 @@
+package prnoise
+
+import (
+	"context"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// DecisionCode is the closed enum of terminal pipeline outcomes.
+// Downstream consumers (webhooks, audit, billing) treat this as a stable
+// contract; new values require an ADR amendment.
+type DecisionCode string
+
+const (
+	// DecisionAutoMergeEligible labels the PR for automated merge.
+	DecisionAutoMergeEligible DecisionCode = "auto_merge_eligible"
+	// DecisionMaintainerReview routes the PR to the human review queue.
+	DecisionMaintainerReview DecisionCode = "maintainer_review"
+	// DecisionReject closes the PR with a reason. Used for both duplicate
+	// PRs and PRs whose composite falls below the reject band.
+	DecisionReject DecisionCode = "reject"
+)
+
+// Valid reports whether c is one of the three known DecisionCode values.
+func (c DecisionCode) Valid() bool {
+	switch c {
+	case DecisionAutoMergeEligible, DecisionMaintainerReview, DecisionReject:
+		return true
+	}
+	return false
+}
+
+// PRInput is the tuple consumed by Pipeline.Score. The pipeline never
+// mutates the input.
+type PRInput struct {
+	PRID         uuid.UUID
+	RepoID       uuid.UUID
+	OrgID        uuid.UUID
+	AgentID      uuid.UUID // zero UUID indicates a human author
+	Title        string
+	Description  string
+	DiffStats    DiffStats
+	CIResult     CIResult
+	AgentsMDOK   bool
+	OpenedAt     time.Time
+}
+
+// DiffStats is the diff projection consumed by the rule-based quality
+// scorer. The pipeline does not need the diff body itself.
+type DiffStats struct {
+	Additions    int
+	Deletions    int
+	FilesChanged int
+	FilePaths    []string
+	ChurnSamples []ChurnSample
+}
+
+// ChurnSample is one (file, touches_30d) pair.
+type ChurnSample struct {
+	FilePath  string
+	Touches30 int
+}
+
+// CIResult projects the CI run result needed for the quality signals.
+type CIResult struct {
+	Build          bool
+	Test           bool
+	LintViolations int
+	CoverageDelta  float64
+}
+
+// Decision is the persisted output of one pipeline run. All score fields
+// live in [0, 1]; the database CHECK constraints mirror that range.
+type Decision struct {
+	PRID            uuid.UUID
+	RepoID          uuid.UUID
+	OrgID           uuid.UUID
+	AgentID         uuid.UUID
+	DedupScore      float64
+	DuplicateOf     *uuid.UUID
+	QualityScore    float64
+	ReputationScore float64
+	CompositeScore  float64
+	Code            DecisionCode
+	Reason          string
+	DecidedAt       time.Time
+}
+
+// Embedder turns text into a normalised dense vector. Defined in the
+// prnoise root package so the sub-packages provide implementations
+// without importing each other (avoiding import cycles).
+//
+// Production wires the same embedding service Phase 1 used; the package
+// owns no embedding model (orthogonal infrastructure under ADR-016).
+type Embedder interface {
+	Embed(ctx context.Context, text string) ([]float32, error)
+}
+
+// DuplicateHit is the projection returned by Deduper.NearestDuplicate
+// when the top-1 cosine meets the dedup threshold from ADR-016.
+type DuplicateHit struct {
+	PRID       uuid.UUID
+	Similarity float64
+}
+
+// Deduper is the application-plane interface over the Qdrant ANN store
+// (ADR-021: Qdrant scoped to PR dedup only). repoID is the per-repo
+// dedup scope; implementations gate on the prnoise.cross_org_dedup
+// feature flag for whether to honour it.
+type Deduper interface {
+	NearestDuplicate(ctx context.Context, repoID uuid.UUID, vec []float32) (*DuplicateHit, error)
+}
+
+// QualitySignalScorer is the Stage 2 swap surface (ADR-017). The
+// shipping implementation is rule-based; an ML quality scorer can land
+// without touching the pipeline.
+type QualitySignalScorer interface {
+	Score(ctx context.Context, in PRInput) float64
+}
+
+// ReputationScorer is the Stage 3 swap surface (ADR-017) — the swap
+// surface CLAUDE.md's open question (July 2026, rule-based vs. ML
+// reputation) hinges on. Implementations MUST handle uuid.Nil as the
+// "human author" sentinel.
+type ReputationScorer interface {
+	Score(ctx context.Context, agentID uuid.UUID) (float64, error)
+}

--- a/plane/application/prnoise/pipeline.go
+++ b/plane/application/prnoise/pipeline.go
@@ -1,0 +1,92 @@
+package prnoise
+
+import (
+	"context"
+	"fmt"
+)
+
+// Pipeline runs the four stages of the PR noise pipeline in order:
+// dedup → quality → reputation → composite routing.
+//
+// Stateless past construction; Score is safe for concurrent use as long
+// as the injected dependencies are too. Stage failures bubble up as
+// wrapped errors; the pipeline never returns a partial Decision.
+type Pipeline struct {
+	Embedder   Embedder
+	Deduper    Deduper
+	Quality    QualitySignalScorer
+	Reputation ReputationScorer
+	Router     *CompositeRouter
+}
+
+// NewPipeline returns a fully-wired Pipeline. The router is constructed
+// from cfg so callers don't have to plumb three values; QualitySignalScorer
+// and ReputationScorer remain injected (ADR-017 swap surfaces).
+func NewPipeline(
+	emb Embedder,
+	dd Deduper,
+	q QualitySignalScorer,
+	rep ReputationScorer,
+	cfg Config,
+) *Pipeline {
+	return &Pipeline{
+		Embedder:   emb,
+		Deduper:    dd,
+		Quality:    q,
+		Reputation: rep,
+		Router:     NewCompositeRouter(cfg.Composite, cfg.Bands),
+	}
+}
+
+// embedText is the input to Embedder. Title + body matches the Phase 1
+// shadow run; title alone would lose too much signal on stub PRs.
+func embedText(in PRInput) string {
+	return in.Title + "\n\n" + in.Description
+}
+
+// Score runs all four stages and returns a fully-populated Decision.
+// The Decision is NOT persisted; callers (Service implementations) are
+// responsible for writing it inside a Tx alongside the outbox row
+// (ADR-008).
+func (p *Pipeline) Score(ctx context.Context, in PRInput) (Decision, error) {
+	// Stage 1: semantic dedup.
+	vec, err := p.Embedder.Embed(ctx, embedText(in))
+	if err != nil {
+		return Decision{}, fmt.Errorf("prnoise: embed: %w", err)
+	}
+	hit, err := p.Deduper.NearestDuplicate(ctx, in.RepoID, vec)
+	if err != nil {
+		return Decision{}, fmt.Errorf("prnoise: dedup: %w", err)
+	}
+
+	// Stage 2: quality signals.
+	q := p.Quality.Score(ctx, in)
+
+	// Stage 3: reputation.
+	rep, err := p.Reputation.Score(ctx, in.AgentID)
+	if err != nil {
+		return Decision{}, fmt.Errorf("prnoise: reputation: %w", err)
+	}
+
+	// Stage 4: composite router.
+	composite, code, reason := p.Router.Decide(q, rep, hit)
+
+	d := Decision{
+		PRID:            in.PRID,
+		RepoID:          in.RepoID,
+		OrgID:           in.OrgID,
+		AgentID:         in.AgentID,
+		QualityScore:    q,
+		ReputationScore: rep,
+		CompositeScore:  composite,
+		Code:            code,
+		Reason:          reason,
+		DecidedAt:       in.OpenedAt,
+	}
+	if hit != nil {
+		d.DedupScore = 1.0
+		dup := hit.PRID
+		d.DuplicateOf = &dup
+	}
+	return d, nil
+}

--- a/plane/application/prnoise/pipeline_test.go
+++ b/plane/application/prnoise/pipeline_test.go
@@ -1,0 +1,195 @@
+package prnoise
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// fakeQuality returns a fixed score regardless of PRInput. Pipeline
+// tests in this package use it instead of the rule-based scorer to
+// keep the test in the prnoise package (avoiding a quality → prnoise
+// → quality test-time cycle).
+type fakeQuality struct{ score float64 }
+
+func (f fakeQuality) Score(_ context.Context, _ PRInput) float64 { return f.score }
+
+// frozenEmbedder returns a fixed vector regardless of input. Used for
+// determinism tests where the embedder must not introduce randomness.
+type frozenEmbedder struct{ vec []float32 }
+
+func (e *frozenEmbedder) Embed(_ context.Context, _ string) ([]float32, error) { return e.vec, nil }
+
+type errEmbedder struct{ err error }
+
+func (e *errEmbedder) Embed(_ context.Context, _ string) ([]float32, error) { return nil, e.err }
+
+type fakeDeduper struct {
+	hit *DuplicateHit
+	err error
+}
+
+func (d *fakeDeduper) NearestDuplicate(_ context.Context, _ uuid.UUID, _ []float32) (*DuplicateHit, error) {
+	return d.hit, d.err
+}
+
+type fakeReputation struct {
+	score float64
+	err   error
+}
+
+func (f *fakeReputation) Score(_ context.Context, _ uuid.UUID) (float64, error) {
+	return f.score, f.err
+}
+
+func cleanInput() PRInput {
+	return PRInput{
+		PRID:        uuid.New(),
+		RepoID:      uuid.New(),
+		OrgID:       uuid.New(),
+		AgentID:     uuid.New(),
+		Title:       "Add foo",
+		Description: "Adds the foo widget",
+		DiffStats: DiffStats{
+			Additions: 0, Deletions: 0,
+			FilePaths: []string{"a/x", "b/x", "c/x", "d/x", "e/x"},
+		},
+		CIResult:   CIResult{Build: true, Test: true, LintViolations: 0, CoverageDelta: 0.10},
+		AgentsMDOK: true,
+		OpenedAt:   time.Date(2026, 5, 9, 12, 0, 0, 0, time.UTC),
+	}
+}
+
+// newPipelineWithFakes wires the pipeline with a fake embedder,
+// deduper, and reputation scorer; quality defaults to a fakeQuality of
+// 1.0 so high-reputation cases hit the auto-merge band.
+func newPipelineWithFakes(emb Embedder, dd Deduper, rep float64) *Pipeline {
+	return newPipelineWithQuality(emb, dd, fakeQuality{score: 1.0}, rep)
+}
+
+func newPipelineWithQuality(emb Embedder, dd Deduper, q QualitySignalScorer, rep float64) *Pipeline {
+	cfg := DefaultConfig()
+	return NewPipeline(emb, dd, q, &fakeReputation{score: rep}, cfg)
+}
+
+func TestPipeline_Score_AutoMergeOnCleanInput(t *testing.T) {
+	t.Parallel()
+	p := newPipelineWithFakes(&frozenEmbedder{vec: []float32{1, 0}}, &fakeDeduper{}, 1.0)
+	d, err := p.Score(context.Background(), cleanInput())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if d.Code != DecisionAutoMergeEligible {
+		t.Errorf("code = %v, want auto_merge_eligible", d.Code)
+	}
+	if d.DuplicateOf != nil {
+		t.Errorf("DuplicateOf = %v, want nil", *d.DuplicateOf)
+	}
+	if d.DedupScore != 0 {
+		t.Errorf("DedupScore = %v, want 0", d.DedupScore)
+	}
+}
+
+func TestPipeline_Score_DuplicateAlwaysRejects(t *testing.T) {
+	t.Parallel()
+	dupID := uuid.New()
+	p := newPipelineWithFakes(
+		&frozenEmbedder{vec: []float32{1}},
+		&fakeDeduper{hit: &DuplicateHit{PRID: dupID, Similarity: 0.99}},
+		1.0,
+	)
+	d, err := p.Score(context.Background(), cleanInput())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if d.Code != DecisionReject {
+		t.Errorf("code = %v, want reject", d.Code)
+	}
+	if d.DedupScore != 1.0 {
+		t.Errorf("DedupScore = %v, want 1.0", d.DedupScore)
+	}
+	if d.DuplicateOf == nil || *d.DuplicateOf != dupID {
+		t.Errorf("DuplicateOf = %v, want %v", d.DuplicateOf, dupID)
+	}
+	if d.CompositeScore != 0 {
+		t.Errorf("CompositeScore = %v, want 0 (duplicate zeros it)", d.CompositeScore)
+	}
+}
+
+func TestPipeline_Score_BorderlineRoutesToReview(t *testing.T) {
+	t.Parallel()
+	// quality 0.5, rep 0.4 → composite 0.41, in [0.30, 0.85) review band.
+	p := newPipelineWithQuality(&frozenEmbedder{vec: []float32{1}}, &fakeDeduper{}, fakeQuality{score: 0.5}, 0.4)
+	d, err := p.Score(context.Background(), cleanInput())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if d.Code != DecisionMaintainerReview {
+		t.Errorf("code = %v (composite=%v), want maintainer_review", d.Code, d.CompositeScore)
+	}
+}
+
+func TestPipeline_Score_DeterministicForSameInput(t *testing.T) {
+	t.Parallel()
+	in := cleanInput()
+	p1 := newPipelineWithFakes(&frozenEmbedder{vec: []float32{1, 1}}, &fakeDeduper{}, 0.6)
+	p2 := newPipelineWithFakes(&frozenEmbedder{vec: []float32{1, 1}}, &fakeDeduper{}, 0.6)
+	a, err := p1.Score(context.Background(), in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, err := p2.Score(context.Background(), in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if a != b {
+		t.Errorf("non-deterministic: %+v vs %+v", a, b)
+	}
+}
+
+func TestPipeline_Score_EmbedderErrorWrapped(t *testing.T) {
+	t.Parallel()
+	want := errors.New("embedder kaboom")
+	p := newPipelineWithFakes(&errEmbedder{err: want}, &fakeDeduper{}, 1.0)
+	_, err := p.Score(context.Background(), cleanInput())
+	if !errors.Is(err, want) {
+		t.Errorf("err = %v, want wrapped %v", err, want)
+	}
+}
+
+func TestPipeline_Score_DedupErrorWrapped(t *testing.T) {
+	t.Parallel()
+	want := errors.New("qdrant gone")
+	p := newPipelineWithFakes(&frozenEmbedder{vec: []float32{1}}, &fakeDeduper{err: want}, 1.0)
+	_, err := p.Score(context.Background(), cleanInput())
+	if !errors.Is(err, want) {
+		t.Errorf("err = %v, want wrapped %v", err, want)
+	}
+}
+
+func TestPipeline_Score_ReputationErrorWrapped(t *testing.T) {
+	t.Parallel()
+	want := errors.New("identity offline")
+	cfg := DefaultConfig()
+	p := NewPipeline(&frozenEmbedder{vec: []float32{1}}, &fakeDeduper{}, fakeQuality{score: 1.0}, &fakeReputation{err: want}, cfg)
+	_, err := p.Score(context.Background(), cleanInput())
+	if !errors.Is(err, want) {
+		t.Errorf("err = %v, want wrapped %v", err, want)
+	}
+}
+
+func TestPipeline_Score_DecidedAtMirrorsOpenedAt(t *testing.T) {
+	t.Parallel()
+	p := newPipelineWithFakes(&frozenEmbedder{vec: []float32{1}}, &fakeDeduper{}, 1.0)
+	in := cleanInput()
+	d, err := p.Score(context.Background(), in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !d.DecidedAt.Equal(in.OpenedAt) {
+		t.Errorf("DecidedAt = %v, want %v", d.DecidedAt, in.OpenedAt)
+	}
+}

--- a/plane/application/prnoise/postgres_service.go
+++ b/plane/application/prnoise/postgres_service.go
@@ -1,0 +1,216 @@
+package prnoise
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math/rand"
+	"time"
+
+	"github.com/gitscale-platform/gitscale/plane/data/store"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+)
+
+// PgxConnector is the minimum surface PostgresService needs from a pgx
+// pool. Keeping the dependency this small lets tests inject a fake (or
+// the integration suite use a real *pgxpool.Pool) without binding the
+// package to a concrete pgxpool import — preserving the ADR-017 swap
+// surface at the application-plane edge.
+type PgxConnector interface {
+	BeginTx(ctx context.Context, txOptions pgx.TxOptions) (pgx.Tx, error)
+}
+
+// retryMaxAttempts bounds the number of times RecordDecision will
+// reissue the Tx after a 40001 serialization failure. Mirrors the
+// identity package's retry budget for consistency.
+const retryMaxAttempts = 3
+
+// ErrRetryExhausted is returned when RecordDecision exhausts its
+// serializable-retry budget without observing a non-retryable outcome.
+var ErrRetryExhausted = errors.New("prnoise: serializable retry exhausted")
+
+// PostgresService is the production Service. It runs the pipeline
+// (read-only against the embedder + deduper + identity), then opens a
+// serializable Tx and writes the decision row + outbox row atomically.
+//
+// PR-state mutation (close, label, comment) is NOT performed here; it
+// happens in the webhook delivery worker subscribed to
+// pr.noise_decision_recorded (ADR-008).
+type PostgresService struct {
+	conn     PgxConnector
+	pipeline *Pipeline
+	clock    func() time.Time
+}
+
+// NewPostgresService returns a PostgresService backed by conn.
+// Callers MUST run the migration that creates collaboration.pr_noise_decisions.
+func NewPostgresService(conn PgxConnector, p *Pipeline) (*PostgresService, error) {
+	if p == nil {
+		return nil, ErrPipelineUnconfigured
+	}
+	return &PostgresService{
+		conn:     conn,
+		pipeline: p,
+		clock:    func() time.Time { return time.Now().UTC() },
+	}, nil
+}
+
+// RecordDecision implements Service. Pipeline.Score runs outside the
+// Tx (it performs network I/O against the embedder and Qdrant); the Tx
+// scope covers only the decision-row upsert and the outbox insert,
+// which share fate per ADR-008.
+func (s *PostgresService) RecordDecision(ctx context.Context, in PRInput) (Decision, error) {
+	d, err := s.pipeline.Score(ctx, in)
+	if err != nil {
+		return Decision{}, err
+	}
+	if d.DecidedAt.IsZero() {
+		d.DecidedAt = s.clock()
+	}
+
+	if err := s.persistWithRetry(ctx, d); err != nil {
+		return Decision{}, err
+	}
+	return d, nil
+}
+
+// persistWithRetry drives the bounded retry loop. Mirrors
+// identity.WithSerializableRetry; we keep the loop in-package to avoid
+// pulling identity into the prnoise persistence path.
+func (s *PostgresService) persistWithRetry(ctx context.Context, d Decision) error {
+	delay := 10 * time.Millisecond
+	for attempt := 0; attempt < retryMaxAttempts; attempt++ {
+		err := s.persistOnce(ctx, d)
+		if err == nil {
+			return nil
+		}
+		if !isRetryable(err) {
+			return err
+		}
+		if attempt == retryMaxAttempts-1 {
+			break
+		}
+		jitter := time.Duration(rand.Int63n(int64(delay)))
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(delay + jitter):
+		}
+		delay *= 2
+		if delay > 100*time.Millisecond {
+			delay = 100 * time.Millisecond
+		}
+	}
+	return ErrRetryExhausted
+}
+
+// isRetryable mirrors store.IsRetryable but is kept local so the
+// package's persistence path doesn't import the data-plane retry
+// helper directly. 40001 is the only retryable code we expect.
+func isRetryable(err error) bool {
+	var pgErr *pgconn.PgError
+	if errors.As(err, &pgErr) {
+		return pgErr.Code == "40001"
+	}
+	return false
+}
+
+// persistOnce opens a serializable Tx, upserts the decision row, and
+// writes the outbox row. ADR-008 invariant: both rows commit together
+// or roll back together. Caller acks on commit, never on Kafka publish.
+func (s *PostgresService) persistOnce(ctx context.Context, d Decision) error {
+	tx, err := s.conn.BeginTx(ctx, pgx.TxOptions{IsoLevel: pgx.Serializable})
+	if err != nil {
+		return fmt.Errorf("prnoise: begin tx: %w", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback(ctx)
+		}
+	}()
+
+	if err := upsertDecisionRow(ctx, tx, d); err != nil {
+		return err
+	}
+	if err := writeNoiseDecisionOutbox(ctx, tx, d); err != nil {
+		return err
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return fmt.Errorf("prnoise: commit: %w", err)
+	}
+	committed = true
+	return nil
+}
+
+// upsertDecisionRow performs INSERT … ON CONFLICT (pr_id) DO UPDATE.
+// Re-scoring an existing PR overwrites the prior row; downstream
+// consumers must idempotency-key on event_id, not pr_id (ADR-008).
+//
+// agent_id is stored as NULL when the PR was opened by a human (zero
+// UUID sentinel — see PRInput.AgentID docs). duplicate_of likewise.
+func upsertDecisionRow(ctx context.Context, tx pgx.Tx, d Decision) error {
+	var agentArg any
+	if d.AgentID != uuid.Nil {
+		agentArg = d.AgentID
+	}
+	var dupArg any
+	if d.DuplicateOf != nil {
+		dupArg = *d.DuplicateOf
+	}
+	const q = `
+		INSERT INTO collaboration.pr_noise_decisions
+		  (pr_id, repo_id, org_id, agent_id,
+		   dedup_score, duplicate_of, quality_score, reputation_score,
+		   composite_score, decision_code, reason, decided_at)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
+		ON CONFLICT (pr_id) DO UPDATE SET
+		  repo_id          = EXCLUDED.repo_id,
+		  org_id           = EXCLUDED.org_id,
+		  agent_id         = EXCLUDED.agent_id,
+		  dedup_score      = EXCLUDED.dedup_score,
+		  duplicate_of     = EXCLUDED.duplicate_of,
+		  quality_score    = EXCLUDED.quality_score,
+		  reputation_score = EXCLUDED.reputation_score,
+		  composite_score  = EXCLUDED.composite_score,
+		  decision_code    = EXCLUDED.decision_code,
+		  reason           = EXCLUDED.reason,
+		  decided_at       = EXCLUDED.decided_at
+	`
+	if _, err := tx.Exec(ctx, q,
+		d.PRID, d.RepoID, d.OrgID, agentArg,
+		d.DedupScore, dupArg, d.QualityScore, d.ReputationScore,
+		d.CompositeScore, string(d.Code), d.Reason, d.DecidedAt,
+	); err != nil {
+		return fmt.Errorf("prnoise: upsert decision: %w", err)
+	}
+	return nil
+}
+
+// writeNoiseDecisionOutbox writes the pr.noise_decision_recorded row to
+// the collaboration outbox. event_id is a UUIDv7 (monotonic per process)
+// generated through the data-plane helper so consumers can dedupe on it.
+func writeNoiseDecisionOutbox(ctx context.Context, tx pgx.Tx, d Decision) error {
+	payload, err := json.Marshal(newNoiseDecisionRecordedPayload(d))
+	if err != nil {
+		return fmt.Errorf("prnoise: marshal payload: %w", err)
+	}
+	const q = `
+		INSERT INTO collaboration.collaboration_outbox
+		  (event_id, aggregate_type, aggregate_id, event_type, payload)
+		VALUES ($1, $2, $3, $4, $5)
+	`
+	if _, err := tx.Exec(ctx, q,
+		store.NewEventID(),
+		"pr_noise_decision",
+		d.PRID,
+		EventTypeNoiseDecisionRecorded,
+		payload,
+	); err != nil {
+		return fmt.Errorf("prnoise: write outbox: %w", err)
+	}
+	return nil
+}

--- a/plane/application/prnoise/quality/rule_based.go
+++ b/plane/application/prnoise/quality/rule_based.go
@@ -1,0 +1,37 @@
+package quality
+
+import (
+	"context"
+
+	"github.com/gitscale-platform/gitscale/plane/application/prnoise"
+)
+
+// RuleBasedQualityScorer is the rule-based implementation of
+// QualitySignalScorer. It computes the seven sub-signals (size,
+// test_coverage, ci_build, lint, agents_md, diversity, churn) and
+// returns their weighted sum, clamped to [0, 1] defensively.
+//
+// The struct is intentionally a value, not a pointer, so the pipeline
+// can construct it cheaply per request — there is no hidden state.
+type RuleBasedQualityScorer struct {
+	Weights prnoise.QualityWeights
+}
+
+// NewRuleBasedQualityScorer returns a scorer with the supplied weights.
+// Use prnoise.DefaultConfig().QualityWeights for the production tuning.
+func NewRuleBasedQualityScorer(w prnoise.QualityWeights) RuleBasedQualityScorer {
+	return RuleBasedQualityScorer{Weights: w}
+}
+
+// Score computes the weighted sum of all seven sub-signals.
+func (s RuleBasedQualityScorer) Score(_ context.Context, in prnoise.PRInput) float64 {
+	w := s.Weights
+	sum := w.Size*SizeScore(in.DiffStats) +
+		w.TestCoverage*TestCoverageScore(in.CIResult) +
+		w.CIBuild*CIBuildScore(in.CIResult) +
+		w.Lint*LintScore(in.CIResult) +
+		w.AgentsMD*AgentsMDScore(in.AgentsMDOK) +
+		w.Diversity*DiversityScore(in.DiffStats) +
+		w.Churn*ChurnScore(in.DiffStats)
+	return clamp01(sum)
+}

--- a/plane/application/prnoise/quality/rule_based_test.go
+++ b/plane/application/prnoise/quality/rule_based_test.go
@@ -1,0 +1,208 @@
+package quality
+
+import (
+	"context"
+	"math"
+	"testing"
+
+	"github.com/gitscale-platform/gitscale/plane/application/prnoise"
+)
+
+const epsilon = 1e-9
+
+func near(a, b float64) bool { return math.Abs(a-b) < epsilon }
+
+func TestSizeScore(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		in   prnoise.DiffStats
+		want float64
+	}{
+		{"zero_lines", prnoise.DiffStats{}, 1.0},
+		{"500_lines_mid", prnoise.DiffStats{Additions: 250, Deletions: 250}, 0.5},
+		{"1000_lines_floor", prnoise.DiffStats{Additions: 700, Deletions: 300}, 0.0},
+		{"over_1000_clamps_to_zero", prnoise.DiffStats{Additions: 5000}, 0.0},
+		{"negative_inputs_treated_as_zero", prnoise.DiffStats{Additions: -100, Deletions: -50}, 1.0},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := SizeScore(tc.in); !near(got, tc.want) {
+				t.Errorf("SizeScore = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestTestCoverageScore(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		in   prnoise.CIResult
+		want float64
+	}{
+		{"flat_coverage", prnoise.CIResult{CoverageDelta: 0}, 0.5},
+		{"plus_10pp", prnoise.CIResult{CoverageDelta: 0.10}, 1.0},
+		{"plus_5pp", prnoise.CIResult{CoverageDelta: 0.05}, 0.75},
+		{"minus_10pp", prnoise.CIResult{CoverageDelta: -0.10}, 0.0},
+		{"minus_50pp_clamps", prnoise.CIResult{CoverageDelta: -0.50}, 0.0},
+		{"plus_50pp_clamps", prnoise.CIResult{CoverageDelta: 0.50}, 1.0},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := TestCoverageScore(tc.in); !near(got, tc.want) {
+				t.Errorf("TestCoverageScore = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestCIBuildScore(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		in   prnoise.CIResult
+		want float64
+	}{
+		{"both_pass", prnoise.CIResult{Build: true, Test: true}, 1.0},
+		{"build_fail", prnoise.CIResult{Build: false, Test: true}, 0.0},
+		{"test_fail", prnoise.CIResult{Build: true, Test: false}, 0.0},
+		{"both_fail", prnoise.CIResult{}, 0.0},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := CIBuildScore(tc.in); !near(got, tc.want) {
+				t.Errorf("CIBuildScore = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestLintScore(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		in   prnoise.CIResult
+		want float64
+	}{
+		{"clean", prnoise.CIResult{LintViolations: 0}, 1.0},
+		{"25_violations", prnoise.CIResult{LintViolations: 25}, 0.5},
+		{"50_violations", prnoise.CIResult{LintViolations: 50}, 0.0},
+		{"100_violations_clamps", prnoise.CIResult{LintViolations: 100}, 0.0},
+		{"negative_clamps_to_clean", prnoise.CIResult{LintViolations: -5}, 1.0},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := LintScore(tc.in); !near(got, tc.want) {
+				t.Errorf("LintScore = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestAgentsMDScore(t *testing.T) {
+	t.Parallel()
+	if got := AgentsMDScore(true); got != 1.0 {
+		t.Errorf("AgentsMDScore(true) = %v, want 1.0", got)
+	}
+	if got := AgentsMDScore(false); got != 0.0 {
+		t.Errorf("AgentsMDScore(false) = %v, want 0.0", got)
+	}
+}
+
+func TestDiversityScore(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name  string
+		paths []string
+		want  float64
+	}{
+		{"empty", nil, 0.0},
+		{"single_dir", []string{"foo/a.go", "foo/b.go"}, 0.2},
+		{"three_dirs", []string{"a/x.go", "b/x.go", "c/x.go"}, 0.6},
+		{"five_dirs_max", []string{"a/x", "b/x", "c/x", "d/x", "e/x"}, 1.0},
+		{"more_than_five_clamps", []string{"a/x", "b/x", "c/x", "d/x", "e/x", "f/x"}, 1.0},
+		{"root_files_share_bucket", []string{"a.go", "b.go"}, 0.2},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			d := prnoise.DiffStats{FilePaths: tc.paths}
+			if got := DiversityScore(d); !near(got, tc.want) {
+				t.Errorf("DiversityScore(%v) = %v, want %v", tc.paths, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestChurnScore(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		samples []prnoise.ChurnSample
+		want    float64
+	}{
+		{"empty_means_quiet", nil, 1.0},
+		{"all_zero_touches", []prnoise.ChurnSample{{FilePath: "a", Touches30: 0}}, 1.0},
+		{"mean_25", []prnoise.ChurnSample{{Touches30: 25}}, 0.5},
+		{"mean_50_floor", []prnoise.ChurnSample{{Touches30: 50}}, 0.0},
+		{"mean_over_50_clamps", []prnoise.ChurnSample{{Touches30: 100}}, 0.0},
+		{"mixed_average", []prnoise.ChurnSample{{Touches30: 0}, {Touches30: 50}}, 0.5},
+		{"negative_treated_as_zero", []prnoise.ChurnSample{{Touches30: -10}}, 1.0},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			d := prnoise.DiffStats{ChurnSamples: tc.samples}
+			if got := ChurnScore(d); !near(got, tc.want) {
+				t.Errorf("ChurnScore = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestRuleBasedQualityScorer_WeightedSum(t *testing.T) {
+	t.Parallel()
+	w := prnoise.DefaultConfig().QualityWeights
+	s := NewRuleBasedQualityScorer(w)
+
+	// PR with all signals at 1.0 must yield exactly Sum(weights) = 1.0.
+	in := prnoise.PRInput{
+		DiffStats: prnoise.DiffStats{
+			Additions: 0, Deletions: 0,
+			FilePaths: []string{"a/x", "b/x", "c/x", "d/x", "e/x"},
+			// empty churn samples → ChurnScore = 1.0
+		},
+		CIResult:   prnoise.CIResult{Build: true, Test: true, LintViolations: 0, CoverageDelta: 0.10},
+		AgentsMDOK: true,
+	}
+	got := s.Score(context.Background(), in)
+	if !near(got, 1.0) {
+		t.Errorf("all-perfect input: Score = %v, want 1.0", got)
+	}
+
+	// PR with all signals at 0.0 must yield 0.0.
+	bad := prnoise.PRInput{
+		DiffStats: prnoise.DiffStats{
+			Additions: 5000,
+			ChurnSamples: []prnoise.ChurnSample{{Touches30: 100}},
+			// no FilePaths → DiversityScore = 0
+		},
+		CIResult:   prnoise.CIResult{LintViolations: 100, CoverageDelta: -0.5},
+		AgentsMDOK: false,
+	}
+	got = s.Score(context.Background(), bad)
+	if !near(got, 0.0) {
+		t.Errorf("all-zero input: Score = %v, want 0.0", got)
+	}
+}
+
+func TestRuleBasedQualityScorer_BoundedToUnitInterval(t *testing.T) {
+	t.Parallel()
+	// Defensive: out-of-range weights should not let Score escape [0,1].
+	weird := prnoise.QualityWeights{Size: 10, AgentsMD: 10}
+	s := NewRuleBasedQualityScorer(weird)
+	in := prnoise.PRInput{AgentsMDOK: true}
+	got := s.Score(context.Background(), in)
+	if got < 0 || got > 1 {
+		t.Errorf("Score = %v, want clamped to [0,1]", got)
+	}
+}

--- a/plane/application/prnoise/quality/signals.go
+++ b/plane/application/prnoise/quality/signals.go
@@ -1,0 +1,125 @@
+package quality
+
+import (
+	"path"
+	"strings"
+
+	"github.com/gitscale-platform/gitscale/plane/application/prnoise"
+)
+
+// clamp01 caps x to the closed interval [0, 1]. Inlined into each
+// signal so out-of-range inputs never leak past the contributor.
+func clamp01(x float64) float64 {
+	if x < 0 {
+		return 0
+	}
+	if x > 1 {
+		return 1
+	}
+	return x
+}
+
+// SizeScore: clamp(1 - (additions + deletions) / 1000, 0, 1).
+//
+// 0-line PR scores 1.0; 1000-line PR scores 0.0; linear in between.
+// Negative inputs (defensive) are treated as 0.
+func SizeScore(d prnoise.DiffStats) float64 {
+	add := d.Additions
+	del := d.Deletions
+	if add < 0 {
+		add = 0
+	}
+	if del < 0 {
+		del = 0
+	}
+	total := float64(add + del)
+	return clamp01(1 - total/1000.0)
+}
+
+// TestCoverageScore: clamp(0.5 + coverage_delta * 5, 0, 1).
+//
+// Flat coverage = 0.5. +0.10 (10pp gain) → 1.0. -0.10 (10pp loss) → 0.0.
+// The ×5 multiplier matches the spec table.
+func TestCoverageScore(c prnoise.CIResult) float64 {
+	return clamp01(0.5 + c.CoverageDelta*5)
+}
+
+// CIBuildScore: 1.0 iff Build && Test pass; else 0.0. Lint is scored
+// separately by LintScore.
+func CIBuildScore(c prnoise.CIResult) float64 {
+	if c.Build && c.Test {
+		return 1.0
+	}
+	return 0.0
+}
+
+// LintScore: clamp(1 - new_violations / 50, 0, 1).
+//
+// Zero violations score 1.0; 50+ violations score 0.0. Negative
+// counts (defensive) are treated as zero.
+func LintScore(c prnoise.CIResult) float64 {
+	v := c.LintViolations
+	if v < 0 {
+		v = 0
+	}
+	return clamp01(1 - float64(v)/50.0)
+}
+
+// AgentsMDScore: 1.0 iff the AGENTS.md compliance gate passed; else 0.0.
+// The gate itself lives in issue #114 (the source of truth for AGENTS.md
+// content); this signal only consumes its boolean result.
+func AgentsMDScore(ok bool) float64 {
+	if ok {
+		return 1.0
+	}
+	return 0.0
+}
+
+// DiversityScore: clamp(unique_top_dirs(file_paths) / 5, 0, 1).
+//
+// Five+ distinct top-level directories is "max diversity". Empty path
+// lists score 0.0; root-level files share an empty top-dir bucket.
+func DiversityScore(d prnoise.DiffStats) float64 {
+	if len(d.FilePaths) == 0 {
+		return 0.0
+	}
+	seen := make(map[string]struct{}, len(d.FilePaths))
+	for _, p := range d.FilePaths {
+		seen[topDir(p)] = struct{}{}
+	}
+	return clamp01(float64(len(seen)) / 5.0)
+}
+
+// topDir returns the first path segment of p; "/" or empty paths return
+// "" (rooted-bucket). Used by DiversityScore.
+func topDir(p string) string {
+	cleaned := path.Clean(p)
+	cleaned = strings.TrimPrefix(cleaned, "/")
+	idx := strings.IndexByte(cleaned, '/')
+	if idx < 0 {
+		// File at repo root — bucket together under empty key.
+		return ""
+	}
+	return cleaned[:idx]
+}
+
+// ChurnScore: clamp(1 - mean(touches_30d) / 50, 0, 1).
+//
+// High-churn paths (mean ≥ 50 touches in 30d) score 0.0; quiet paths
+// score 1.0. An empty sample list is treated as quiet (1.0) to avoid
+// penalising PRs that touch newly-created files.
+func ChurnScore(d prnoise.DiffStats) float64 {
+	if len(d.ChurnSamples) == 0 {
+		return 1.0
+	}
+	var sum int
+	for _, s := range d.ChurnSamples {
+		t := s.Touches30
+		if t < 0 {
+			t = 0
+		}
+		sum += t
+	}
+	mean := float64(sum) / float64(len(d.ChurnSamples))
+	return clamp01(1 - mean/50.0)
+}

--- a/plane/application/prnoise/reputation/rule_based.go
+++ b/plane/application/prnoise/reputation/rule_based.go
@@ -1,0 +1,50 @@
+package reputation
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/gitscale-platform/gitscale/plane/application/identity"
+	"github.com/google/uuid"
+)
+
+// AgentReader is the minimum subset of identity.Service that
+// RuleBasedReputationScorer needs. Keeping the dependency surface this
+// small lets unit tests inject a tiny fake without dragging the full
+// identity service into the test binary.
+type AgentReader interface {
+	GetAgent(ctx context.Context, id uuid.UUID) (*identity.AgentIdentity, error)
+}
+
+// RuleBasedReputationScorer implements ReputationScorer by reading
+// AgentIdentity.ReputationScore directly from the identity service.
+//
+// Human authors (uuid.Nil AgentID) score 1.0 — humans are trusted by
+// default at this stage; abuse mitigation lives at the edge plane
+// (rate-limit, identity revocation), per the spec design decisions.
+type RuleBasedReputationScorer struct {
+	Identity AgentReader
+}
+
+// NewRuleBasedReputationScorer returns a scorer that delegates to id.
+func NewRuleBasedReputationScorer(id AgentReader) *RuleBasedReputationScorer {
+	return &RuleBasedReputationScorer{Identity: id}
+}
+
+// Score returns the agent's stored reputation, or 1.0 for humans.
+// identity.ErrAgentNotFound (and other identity errors) propagate
+// unchanged — the pipeline must not fall through to a default score
+// when the identity lookup fails.
+func (s *RuleBasedReputationScorer) Score(ctx context.Context, agentID uuid.UUID) (float64, error) {
+	if agentID == uuid.Nil {
+		return 1.0, nil
+	}
+	a, err := s.Identity.GetAgent(ctx, agentID)
+	if err != nil {
+		return 0, fmt.Errorf("reputation: get agent: %w", err)
+	}
+	if a == nil {
+		return 0, identity.ErrAgentNotFound
+	}
+	return a.ReputationScore, nil
+}

--- a/plane/application/prnoise/reputation/rule_based_test.go
+++ b/plane/application/prnoise/reputation/rule_based_test.go
@@ -1,0 +1,77 @@
+package reputation
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/gitscale-platform/gitscale/plane/application/identity"
+	"github.com/google/uuid"
+)
+
+// fakeAgentReader is a tiny in-memory AgentReader. nil keys panic; the
+// test suite never asks for an agent it didn't seed.
+type fakeAgentReader struct {
+	agents map[uuid.UUID]*identity.AgentIdentity
+	err    error
+}
+
+func (f *fakeAgentReader) GetAgent(_ context.Context, id uuid.UUID) (*identity.AgentIdentity, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	a, ok := f.agents[id]
+	if !ok {
+		return nil, nil
+	}
+	return a, nil
+}
+
+func TestRuleBasedReputationScorer_HumanAuthorScoresOne(t *testing.T) {
+	t.Parallel()
+	s := NewRuleBasedReputationScorer(&fakeAgentReader{})
+	got, err := s.Score(context.Background(), uuid.Nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != 1.0 {
+		t.Errorf("human author: Score = %v, want 1.0", got)
+	}
+}
+
+func TestRuleBasedReputationScorer_KnownAgentForwardsScore(t *testing.T) {
+	t.Parallel()
+	id := uuid.New()
+	f := &fakeAgentReader{
+		agents: map[uuid.UUID]*identity.AgentIdentity{
+			id: {ID: id, ReputationScore: 0.73},
+		},
+	}
+	s := NewRuleBasedReputationScorer(f)
+	got, err := s.Score(context.Background(), id)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != 0.73 {
+		t.Errorf("Score = %v, want 0.73", got)
+	}
+}
+
+func TestRuleBasedReputationScorer_UnknownAgentReturnsErrAgentNotFound(t *testing.T) {
+	t.Parallel()
+	s := NewRuleBasedReputationScorer(&fakeAgentReader{agents: map[uuid.UUID]*identity.AgentIdentity{}})
+	_, err := s.Score(context.Background(), uuid.New())
+	if !errors.Is(err, identity.ErrAgentNotFound) {
+		t.Errorf("err = %v, want identity.ErrAgentNotFound", err)
+	}
+}
+
+func TestRuleBasedReputationScorer_LookupErrorIsWrapped(t *testing.T) {
+	t.Parallel()
+	want := errors.New("identity offline")
+	s := NewRuleBasedReputationScorer(&fakeAgentReader{err: want})
+	_, err := s.Score(context.Background(), uuid.New())
+	if !errors.Is(err, want) {
+		t.Errorf("err = %v, want wrapped %v", err, want)
+	}
+}

--- a/plane/application/prnoise/router.go
+++ b/plane/application/prnoise/router.go
@@ -1,0 +1,62 @@
+package prnoise
+
+// Stable Reason strings emitted by CompositeRouter.Decide. Downstream
+// consumers (rejection-comment template, audit log) match on these
+// exactly; new values require a coordinated PR with the consumer.
+const (
+	ReasonDuplicate              = "duplicate"
+	ReasonCompositeBelowReject   = "composite_below_reject"
+	ReasonCompositeInReviewBand  = "composite_in_review_band"
+	ReasonCompositeAboveAutoMerge = "composite_above_auto_merge"
+)
+
+// CompositeRouter blends quality and reputation into a composite score
+// and routes the result to one of three terminal DecisionCodes — Stage
+// 4 of the PR noise pipeline.
+//
+// Algorithm (spec §Stage 4):
+//
+//	dedupScore = 1.0 if dup != nil else 0.0
+//	base       = Quality*qualityScore + Reputation*reputationScore
+//	composite  = base * (1 - dedupScore * DedupPenalty)
+//	if dup != nil          → reject (Reason="duplicate")
+//	else if composite ≥ AutoMerge → auto_merge_eligible
+//	else if composite ≥ Reject    → maintainer_review
+//	else                          → reject
+type CompositeRouter struct {
+	Weights CompositeWeights
+	Bands   RouterBands
+}
+
+// NewCompositeRouter returns a router with the given weights and bands.
+func NewCompositeRouter(w CompositeWeights, b RouterBands) *CompositeRouter {
+	return &CompositeRouter{Weights: w, Bands: b}
+}
+
+// Decide computes composite, code, and reason from the three stage
+// outputs. dup == nil means no semantic duplicate was found.
+func (r *CompositeRouter) Decide(qualityScore, reputationScore float64, dup *DuplicateHit) (composite float64, code DecisionCode, reason string) {
+	dedupScore := 0.0
+	if dup != nil {
+		dedupScore = 1.0
+	}
+	base := r.Weights.Quality*qualityScore + r.Weights.Reputation*reputationScore
+	composite = base * (1 - dedupScore*r.Weights.DedupPenalty)
+	if composite < 0 {
+		composite = 0
+	}
+	if composite > 1 {
+		composite = 1
+	}
+
+	switch {
+	case dup != nil:
+		return composite, DecisionReject, ReasonDuplicate
+	case composite >= r.Bands.AutoMerge:
+		return composite, DecisionAutoMergeEligible, ReasonCompositeAboveAutoMerge
+	case composite >= r.Bands.Reject:
+		return composite, DecisionMaintainerReview, ReasonCompositeInReviewBand
+	default:
+		return composite, DecisionReject, ReasonCompositeBelowReject
+	}
+}

--- a/plane/application/prnoise/router_test.go
+++ b/plane/application/prnoise/router_test.go
@@ -1,0 +1,125 @@
+package prnoise
+
+import (
+	"math"
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+const routerEpsilon = 1e-9
+
+func nearR(a, b float64) bool { return math.Abs(a-b) < routerEpsilon }
+
+func defaultRouter() *CompositeRouter {
+	cfg := DefaultConfig()
+	return NewCompositeRouter(cfg.Composite, cfg.Bands)
+}
+
+func TestRouterDecide_DuplicateAlwaysRejects(t *testing.T) {
+	t.Parallel()
+	r := defaultRouter()
+	hit := &DuplicateHit{PRID: uuid.New(), Similarity: 0.99}
+	composite, code, reason := r.Decide(1.0, 1.0, hit)
+	if code != DecisionReject {
+		t.Errorf("code = %v, want reject", code)
+	}
+	if reason != ReasonDuplicate {
+		t.Errorf("reason = %q, want %q", reason, ReasonDuplicate)
+	}
+	if !nearR(composite, 0.0) {
+		t.Errorf("composite = %v, want 0.0", composite)
+	}
+}
+
+func TestRouterDecide_AutoMergeBoundary(t *testing.T) {
+	t.Parallel()
+	r := defaultRouter()
+	composite, code, reason := r.Decide(1.0, 1.0, nil)
+	if code != DecisionAutoMergeEligible {
+		t.Errorf("code = %v, want auto_merge_eligible", code)
+	}
+	if reason != ReasonCompositeAboveAutoMerge {
+		t.Errorf("reason = %q, want %q", reason, ReasonCompositeAboveAutoMerge)
+	}
+	if !nearR(composite, 0.9) {
+		t.Errorf("composite = %v, want 0.9", composite)
+	}
+}
+
+func TestRouterDecide_MaintainerReviewBand(t *testing.T) {
+	t.Parallel()
+	r := defaultRouter()
+	composite, code, reason := r.Decide(0.5, 0.5, nil)
+	if code != DecisionMaintainerReview {
+		t.Errorf("code = %v, want maintainer_review", code)
+	}
+	if reason != ReasonCompositeInReviewBand {
+		t.Errorf("reason = %q, want %q", reason, ReasonCompositeInReviewBand)
+	}
+	if !nearR(composite, 0.45) {
+		t.Errorf("composite = %v, want 0.45", composite)
+	}
+}
+
+func TestRouterDecide_RejectBelowBand(t *testing.T) {
+	t.Parallel()
+	r := defaultRouter()
+	composite, code, reason := r.Decide(0.1, 0.1, nil)
+	if code != DecisionReject {
+		t.Errorf("code = %v, want reject", code)
+	}
+	if reason != ReasonCompositeBelowReject {
+		t.Errorf("reason = %q, want %q", reason, ReasonCompositeBelowReject)
+	}
+	if !nearR(composite, 0.09) {
+		t.Errorf("composite = %v, want 0.09", composite)
+	}
+}
+
+func TestRouterDecide_AtAutoMergeBandIsAutoMerge(t *testing.T) {
+	t.Parallel()
+	r := defaultRouter()
+	composite, code, _ := r.Decide(1.0, 0.875, nil)
+	if code != DecisionAutoMergeEligible {
+		t.Errorf("at AutoMerge: code = %v, want auto_merge_eligible", code)
+	}
+	if !nearR(composite, 0.85) {
+		t.Errorf("composite = %v, want 0.85", composite)
+	}
+}
+
+func TestRouterDecide_AtRejectBandIsMaintainerReview(t *testing.T) {
+	t.Parallel()
+	r := defaultRouter()
+	composite, code, _ := r.Decide(0.6, 0.0, nil)
+	if code != DecisionMaintainerReview {
+		t.Errorf("at Reject: code = %v, want maintainer_review", code)
+	}
+	if !nearR(composite, 0.30) {
+		t.Errorf("composite = %v, want 0.30", composite)
+	}
+}
+
+func TestRouterDecide_AllDecisionCodesReachable(t *testing.T) {
+	t.Parallel()
+	r := defaultRouter()
+	seen := map[DecisionCode]bool{}
+	_, c, _ := r.Decide(1.0, 1.0, nil)
+	seen[c] = true
+	_, c, _ = r.Decide(0.5, 0.5, nil)
+	seen[c] = true
+	_, c, _ = r.Decide(0.0, 0.0, nil)
+	seen[c] = true
+	_, c, _ = r.Decide(1.0, 1.0, &DuplicateHit{Similarity: 1.0})
+	seen[c] = true
+	for _, code := range []DecisionCode{
+		DecisionAutoMergeEligible,
+		DecisionMaintainerReview,
+		DecisionReject,
+	} {
+		if !seen[code] {
+			t.Errorf("DecisionCode %q not reachable from any input", code)
+		}
+	}
+}

--- a/plane/application/prnoise/service.go
+++ b/plane/application/prnoise/service.go
@@ -1,0 +1,27 @@
+package prnoise
+
+import (
+	"context"
+	"errors"
+)
+
+// Service is the application-plane facade over the PR noise pipeline.
+// Production code receives a PostgresService; tests and upstream
+// packages may inject a StubService.
+//
+// RecordDecision MUST be all-or-nothing: either the decision row AND
+// the pr.noise_decision_recorded outbox row both commit, or neither
+// does (ADR-008). Implementations that cannot guarantee this contract
+// MUST NOT satisfy this interface.
+type Service interface {
+	// RecordDecision runs the pipeline against in, persists the resulting
+	// Decision, and writes the matching outbox row in the same Tx.
+	// Returns the persisted Decision (with DecidedAt set if the input
+	// did not provide it).
+	RecordDecision(ctx context.Context, in PRInput) (Decision, error)
+}
+
+// ErrPipelineUnconfigured is returned when a Service is constructed
+// without a Pipeline. The constructors guard against this; the error
+// exists for defensive paths.
+var ErrPipelineUnconfigured = errors.New("prnoise: pipeline is not configured")

--- a/plane/application/prnoise/stub_service.go
+++ b/plane/application/prnoise/stub_service.go
@@ -1,0 +1,98 @@
+package prnoise
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// OutboxRecord captures one outbox emission for upstream test
+// assertions. Mirrors the shape used by plane/data/store/stub.
+type OutboxRecord struct {
+	EventID   uuid.UUID
+	EventType string
+	PRID      uuid.UUID
+	Payload   NoiseDecisionRecordedPayload
+}
+
+// StubService is an in-memory Service for upstream package tests
+// (PR engine handler, webhook delivery worker). Decisions and outbox
+// rows are recorded together to mirror the postgres impl's atomic
+// commit semantics.
+//
+// Re-scoring an existing PR upserts the decision row AND appends a new
+// outbox record — the postgres impl behaves identically (downstream
+// consumers idempotency-key on event_id).
+type StubService struct {
+	mu        sync.Mutex
+	pipeline  *Pipeline
+	clock     func() time.Time
+	decisions map[uuid.UUID]Decision
+	outbox    []OutboxRecord
+}
+
+// NewStubService returns an empty StubService driven by p. Pipeline
+// must be non-nil; ErrPipelineUnconfigured is returned otherwise.
+func NewStubService(p *Pipeline) (*StubService, error) {
+	if p == nil {
+		return nil, ErrPipelineUnconfigured
+	}
+	return &StubService{
+		pipeline:  p,
+		clock:     func() time.Time { return time.Now().UTC() },
+		decisions: make(map[uuid.UUID]Decision),
+	}, nil
+}
+
+// SetClock overrides the clock used to fill DecidedAt for inputs that
+// did not provide it. Test helper.
+func (s *StubService) SetClock(now func() time.Time) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.clock = now
+}
+
+// RecordDecision implements Service. Pipeline.Score errors are returned
+// without persisting anything.
+func (s *StubService) RecordDecision(ctx context.Context, in PRInput) (Decision, error) {
+	d, err := s.pipeline.Score(ctx, in)
+	if err != nil {
+		return Decision{}, err
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if d.DecidedAt.IsZero() {
+		d.DecidedAt = s.clock()
+	}
+	s.decisions[d.PRID] = d
+	s.outbox = append(s.outbox, OutboxRecord{
+		EventID:   uuid.New(),
+		EventType: EventTypeNoiseDecisionRecorded,
+		PRID:      d.PRID,
+		Payload:   newNoiseDecisionRecordedPayload(d),
+	})
+	return d, nil
+}
+
+// Decisions returns a snapshot of recorded decisions. Test helper.
+func (s *StubService) Decisions() map[uuid.UUID]Decision {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make(map[uuid.UUID]Decision, len(s.decisions))
+	for k, v := range s.decisions {
+		out[k] = v
+	}
+	return out
+}
+
+// Outbox returns a snapshot of recorded outbox rows in insertion order.
+func (s *StubService) Outbox() []OutboxRecord {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]OutboxRecord, len(s.outbox))
+	copy(out, s.outbox)
+	return out
+}

--- a/plane/application/prnoise/stub_service_test.go
+++ b/plane/application/prnoise/stub_service_test.go
@@ -1,0 +1,152 @@
+package prnoise
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+func stubInput() PRInput {
+	return PRInput{
+		PRID:        uuid.New(),
+		RepoID:      uuid.New(),
+		OrgID:       uuid.New(),
+		AgentID:     uuid.New(),
+		Title:       "stub",
+		Description: "stub body",
+		DiffStats: DiffStats{
+			Additions: 0, Deletions: 0,
+			FilePaths: []string{"a/x", "b/x", "c/x", "d/x", "e/x"},
+		},
+		CIResult:   CIResult{Build: true, Test: true, CoverageDelta: 0.1},
+		AgentsMDOK: true,
+		OpenedAt:   time.Date(2026, 5, 9, 0, 0, 0, 0, time.UTC),
+	}
+}
+
+type embedderStub struct{}
+
+func (embedderStub) Embed(_ context.Context, _ string) ([]float32, error) {
+	return []float32{1, 0}, nil
+}
+
+type deduperStub struct{ hit *DuplicateHit }
+
+func (d deduperStub) NearestDuplicate(_ context.Context, _ uuid.UUID, _ []float32) (*DuplicateHit, error) {
+	return d.hit, nil
+}
+
+type repStub struct{ score float64 }
+
+func (r repStub) Score(_ context.Context, _ uuid.UUID) (float64, error) { return r.score, nil }
+
+// stubQuality is a fixed-score QualitySignalScorer used by the stub
+// tests in this package; using the rule-based scorer would create a
+// quality → prnoise → quality test-time import cycle.
+type stubQuality struct{ score float64 }
+
+func (s stubQuality) Score(_ context.Context, _ PRInput) float64 { return s.score }
+
+func newStubServiceForTest(t *testing.T, dup *DuplicateHit, rep float64) *StubService {
+	t.Helper()
+	cfg := DefaultConfig()
+	p := NewPipeline(embedderStub{}, deduperStub{hit: dup}, stubQuality{score: 1.0}, repStub{score: rep}, cfg)
+	s, err := NewStubService(p)
+	if err != nil {
+		t.Fatalf("NewStubService: %v", err)
+	}
+	return s
+}
+
+func TestStubService_NilPipelineRejected(t *testing.T) {
+	t.Parallel()
+	if _, err := NewStubService(nil); err != ErrPipelineUnconfigured {
+		t.Errorf("err = %v, want ErrPipelineUnconfigured", err)
+	}
+}
+
+func TestStubService_RecordsDecisionAndOutbox(t *testing.T) {
+	t.Parallel()
+	s := newStubServiceForTest(t, nil, 1.0)
+	in := stubInput()
+	d, err := s.RecordDecision(context.Background(), in)
+	if err != nil {
+		t.Fatalf("RecordDecision: %v", err)
+	}
+	if d.Code != DecisionAutoMergeEligible {
+		t.Errorf("code = %v, want auto_merge_eligible", d.Code)
+	}
+	if got := s.Decisions(); len(got) != 1 {
+		t.Errorf("decisions count = %d, want 1", len(got))
+	}
+	out := s.Outbox()
+	if len(out) != 1 {
+		t.Fatalf("outbox count = %d, want 1", len(out))
+	}
+	if out[0].EventType != EventTypeNoiseDecisionRecorded {
+		t.Errorf("event type = %q, want %q", out[0].EventType, EventTypeNoiseDecisionRecorded)
+	}
+	if out[0].PRID != in.PRID {
+		t.Errorf("event pr_id = %v, want %v", out[0].PRID, in.PRID)
+	}
+}
+
+func TestStubService_RescoreUpsertsAndAppendsOutbox(t *testing.T) {
+	t.Parallel()
+	s := newStubServiceForTest(t, nil, 1.0)
+	in := stubInput()
+	if _, err := s.RecordDecision(context.Background(), in); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.RecordDecision(context.Background(), in); err != nil {
+		t.Fatal(err)
+	}
+	if got := s.Decisions(); len(got) != 1 {
+		t.Errorf("decisions count after rescore = %d, want 1 (upsert)", len(got))
+	}
+	if got := s.Outbox(); len(got) != 2 {
+		t.Errorf("outbox count after rescore = %d, want 2 (one row per call)", len(got))
+	}
+}
+
+func TestStubService_DuplicatePathRejects(t *testing.T) {
+	t.Parallel()
+	dupID := uuid.New()
+	s := newStubServiceForTest(t, &DuplicateHit{PRID: dupID, Similarity: 0.99}, 1.0)
+	in := stubInput()
+	d, err := s.RecordDecision(context.Background(), in)
+	if err != nil {
+		t.Fatalf("RecordDecision: %v", err)
+	}
+	if d.Code != DecisionReject {
+		t.Errorf("code = %v, want reject", d.Code)
+	}
+	if d.DuplicateOf == nil || *d.DuplicateOf != dupID {
+		t.Errorf("DuplicateOf = %v, want %v", d.DuplicateOf, dupID)
+	}
+	out := s.Outbox()[0]
+	if out.Payload.DuplicateOf == nil || *out.Payload.DuplicateOf != dupID {
+		t.Errorf("payload duplicate_of = %v, want %v", out.Payload.DuplicateOf, dupID)
+	}
+}
+
+func TestStubService_HumanAuthorOmitsAgentIDInPayload(t *testing.T) {
+	t.Parallel()
+	cfg := DefaultConfig()
+	p := NewPipeline(embedderStub{}, deduperStub{}, stubQuality{score: 1.0}, repStub{score: 1.0}, cfg)
+	s, err := NewStubService(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	in := stubInput()
+	in.AgentID = uuid.Nil
+	if _, err := s.RecordDecision(context.Background(), in); err != nil {
+		t.Fatal(err)
+	}
+	out := s.Outbox()[0]
+	if out.Payload.AgentID != nil {
+		t.Errorf("payload agent_id = %v, want nil for human author", out.Payload.AgentID)
+	}
+}

--- a/plane/data/events/collaboration/pr.noise_decision_recorded.schema.json
+++ b/plane/data/events/collaboration/pr.noise_decision_recorded.schema.json
@@ -1,0 +1,81 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://gitscale.io/events/collaboration/pr.noise_decision_recorded.schema.json",
+  "title": "pr.noise_decision_recorded",
+  "description": "Emitted when the PR noise pipeline records a terminal Decision in collaboration.pr_noise_decisions. Payload of the collaboration_outbox row whose event_type = 'pr.noise_decision_recorded'. ADR-008 invariant: this row commits in the same Tx as the source decision row. Downstream consumers (webhook delivery worker, audit, future reputation feedback loop) MUST idempotency-key on event_id, NOT on pr_id — re-scoring an existing PR upserts the source row but emits a new outbox row.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "pr_id",
+    "repo_id",
+    "org_id",
+    "decision_code",
+    "dedup_score",
+    "quality_score",
+    "reputation_score",
+    "composite_score",
+    "reason",
+    "decided_at",
+    "_envelope_version"
+  ],
+  "properties": {
+    "pr_id": {
+      "type": "string",
+      "format": "uuid"
+    },
+    "repo_id": {
+      "type": "string",
+      "format": "uuid"
+    },
+    "org_id": {
+      "type": "string",
+      "format": "uuid"
+    },
+    "agent_id": {
+      "type": ["string", "null"],
+      "format": "uuid",
+      "description": "Authoring agent. Absent (omitted) for human-authored PRs."
+    },
+    "decision_code": {
+      "type": "string",
+      "enum": ["auto_merge_eligible", "maintainer_review", "reject"]
+    },
+    "dedup_score": {
+      "type": "number",
+      "minimum": 0,
+      "maximum": 1
+    },
+    "duplicate_of": {
+      "type": ["string", "null"],
+      "format": "uuid",
+      "description": "PR ID this PR was found to duplicate. Absent unless dedup_score == 1.0."
+    },
+    "quality_score": {
+      "type": "number",
+      "minimum": 0,
+      "maximum": 1
+    },
+    "reputation_score": {
+      "type": "number",
+      "minimum": 0,
+      "maximum": 1
+    },
+    "composite_score": {
+      "type": "number",
+      "minimum": 0,
+      "maximum": 1
+    },
+    "reason": {
+      "type": "string",
+      "description": "Stable machine-readable rationale string. One of: duplicate, composite_above_auto_merge, composite_in_review_band, composite_below_reject."
+    },
+    "decided_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "_envelope_version": {
+      "type": "integer",
+      "const": 1
+    }
+  }
+}

--- a/plane/data/events/collaboration/pr.noise_decision_recorded.testdata/auto_merge_eligible.json
+++ b/plane/data/events/collaboration/pr.noise_decision_recorded.testdata/auto_merge_eligible.json
@@ -1,0 +1,14 @@
+{
+  "pr_id": "11111111-1111-1111-1111-111111111111",
+  "repo_id": "22222222-2222-2222-2222-222222222222",
+  "org_id": "33333333-3333-3333-3333-333333333333",
+  "agent_id": "44444444-4444-4444-4444-444444444444",
+  "decision_code": "auto_merge_eligible",
+  "dedup_score": 0,
+  "quality_score": 0.95,
+  "reputation_score": 0.9,
+  "composite_score": 0.91,
+  "reason": "composite_above_auto_merge",
+  "decided_at": "2026-05-09T12:00:00Z",
+  "_envelope_version": 1
+}

--- a/plane/data/events/collaboration/pr.noise_decision_recorded.testdata/duplicate_reject.json
+++ b/plane/data/events/collaboration/pr.noise_decision_recorded.testdata/duplicate_reject.json
@@ -1,0 +1,15 @@
+{
+  "pr_id": "11111111-1111-1111-1111-111111111111",
+  "repo_id": "22222222-2222-2222-2222-222222222222",
+  "org_id": "33333333-3333-3333-3333-333333333333",
+  "agent_id": "44444444-4444-4444-4444-444444444444",
+  "decision_code": "reject",
+  "dedup_score": 1,
+  "duplicate_of": "55555555-5555-5555-5555-555555555555",
+  "quality_score": 0.8,
+  "reputation_score": 0.9,
+  "composite_score": 0,
+  "reason": "duplicate",
+  "decided_at": "2026-05-09T12:00:00Z",
+  "_envelope_version": 1
+}

--- a/plane/data/events/collaboration/pr.noise_decision_recorded.testdata/maintainer_review_human.json
+++ b/plane/data/events/collaboration/pr.noise_decision_recorded.testdata/maintainer_review_human.json
@@ -1,0 +1,13 @@
+{
+  "pr_id": "66666666-6666-6666-6666-666666666666",
+  "repo_id": "22222222-2222-2222-2222-222222222222",
+  "org_id": "33333333-3333-3333-3333-333333333333",
+  "decision_code": "maintainer_review",
+  "dedup_score": 0,
+  "quality_score": 0.6,
+  "reputation_score": 1.0,
+  "composite_score": 0.7,
+  "reason": "composite_in_review_band",
+  "decided_at": "2026-05-09T12:00:00Z",
+  "_envelope_version": 1
+}

--- a/plane/data/migrations/012_pr_noise_decisions.sql
+++ b/plane/data/migrations/012_pr_noise_decisions.sql
@@ -1,0 +1,42 @@
+-- requires PostgreSQL 16+
+-- 012: collaboration.pr_noise_decisions — primary store for the PR noise
+-- pipeline's terminal decision (issue #116, ADR-008 outbox + ADR-016 dedup).
+--
+-- One row per pr_id; re-scoring upserts (ON CONFLICT (pr_id) DO UPDATE).
+-- Downstream consumers (webhook delivery, audit) anchor idempotency on
+-- the outbox event_id, NOT on pr_id — see ADR-008.
+--
+-- This table is intentionally NOT partitioned: the row count is bounded
+-- by total PR count (1:1) and dwarfs neither pull_requests itself nor
+-- collaboration_outbox; partitioning yields no benefit until we cross
+-- ~10^9 rows.
+
+CREATE TABLE IF NOT EXISTS collaboration.pr_noise_decisions (
+  pr_id            UUID PRIMARY KEY,
+  repo_id          UUID NOT NULL,
+  org_id           UUID NOT NULL,
+  agent_id         UUID,
+  dedup_score      DOUBLE PRECISION NOT NULL,
+  duplicate_of     UUID,
+  quality_score    DOUBLE PRECISION NOT NULL,
+  reputation_score DOUBLE PRECISION NOT NULL,
+  composite_score  DOUBLE PRECISION NOT NULL,
+  decision_code    TEXT NOT NULL,
+  reason           TEXT NOT NULL,
+  decided_at       TIMESTAMPTZ NOT NULL DEFAULT now(),
+  CONSTRAINT chk_pr_noise_decisions_dedup_score_range
+    CHECK (dedup_score BETWEEN 0 AND 1),
+  CONSTRAINT chk_pr_noise_decisions_quality_score_range
+    CHECK (quality_score BETWEEN 0 AND 1),
+  CONSTRAINT chk_pr_noise_decisions_reputation_score_range
+    CHECK (reputation_score BETWEEN 0 AND 1),
+  CONSTRAINT chk_pr_noise_decisions_composite_score_range
+    CHECK (composite_score BETWEEN 0 AND 1),
+  CONSTRAINT chk_pr_noise_decisions_decision_code_valid
+    CHECK (decision_code IN ('auto_merge_eligible', 'maintainer_review', 'reject'))
+);
+
+-- Per-repo time-descending index for the maintainer-review queue scan
+-- and the design-partner precision/recall harness.
+CREATE INDEX IF NOT EXISTS idx_pr_noise_decisions_repo_time
+  ON collaboration.pr_noise_decisions (repo_id, decided_at DESC);


### PR DESCRIPTION
## Summary

Ship `plane/application/prnoise` — the four-stage PR noise pipeline (semantic dedup -> quality signals -> agent reputation -> composite routing) with persistent decision storage and outbox-driven downstream activation.

- Decision row + `pr.noise_decision_recorded` outbox row written in one serializable Tx (ADR-008). Caller acks on DB commit; PR-state mutation lives in the webhook delivery worker subscribed to that event, never inline.
- Semantic dedup gated at cosine 0.92 via a non-configurable `prnoise.DedupCosineThreshold` constant quoted from ADR-016. Tuning requires an ADR amendment.
- `QualitySignalScorer`, `ReputationScorer`, `Embedder`, `Deduper` are interfaces (ADR-017 swap surfaces). Rule-based scorers ship; ML reputation (CLAUDE.md open question, July 2026) is a swap-in.
- Composite router uses bands 0.85 / 0.30 with dedup zeroing the composite; three terminal codes — `auto_merge_eligible`, `maintainer_review`, `reject`.
- Cross-org dedup gated behind `prnoise.cross_org_dedup`, default OFF (CLAUDE.md open question, August 2026).
- New migration `012_pr_noise_decisions.sql` creates `collaboration.pr_noise_decisions` with score-range CHECKs and a `(repo_id, decided_at DESC)` index.
- Event schema `pr.noise_decision_recorded` registered under `plane/data/events/collaboration/` with three fixtures (auto-merge / duplicate reject / human-author maintainer review).

## ADR impact

Conforming. No new ADR required.

- **ADR-008** (outbox): `PostgresService.RecordDecision` opens one Tx, upserts the source row, inserts the outbox row, commits. 40001 retries up to 3x with jittered backoff.
- **ADR-016** (Vespa primary, Qdrant for PR dedup at cosine 0.92): threshold quoted verbatim in `dedup_threshold.go`; Vespa untouched.
- **ADR-017** (swap surfaces): all four pipeline stages are injected interfaces; rule-based scorers are the shipping implementation.
- **ADR-019** (plane boundary): `prnoise` imports only `plane/application/identity` (same plane), `plane/data/store` for `NewEventID`, and `pgx`. No `plane/git`, `plane/workflow`, or `plane/edge` imports.
- **ADR-021** (Qdrant role): Qdrant is consumed exclusively by this package and only for PR dedup.

## Test plan

- [x] `go build ./...` clean.
- [x] `go vet ./...` clean.
- [x] `golangci-lint run ./plane/...` zero issues from this worktree (sibling-worktree noise unrelated).
- [x] `go test -race ./plane/application/prnoise/...` green (rule-based quality, composite router, dedup threshold gate, reputation lookup, pipeline determinism, stub service rescore semantics).
- [x] `make lint-events` green — schema validates against three fixtures.
- [x] `make lint-determinism` green.
- [ ] testcontainer integration tests (PG + Qdrant) deferred to follow-up wiring PR; this PR ships the package surface.
- [ ] Precision >= 0.6 / recall >= 0.7 on design-partner corpus is the merge-acceptance criterion documented in the spec; the supervisor confirms the gate before merge per the plan's pre-flight P.4.

## Spec & plan

- Spec: `docs/superpowers/specs/2026-05-09-issue-116-pr-noise-pipeline-design.md`
- Plan: `docs/superpowers/plans/2026-05-09-issue-116-pr-noise-pipeline-plan.md`

## Notes for reviewer

- The `quality`, `reputation`, and `dedup` sub-packages provide implementations against interfaces defined in the root `prnoise` package. This shape avoids the import cycle that would otherwise arise from sub-packages owning interfaces over root-package input types. The router collapsed into the root for the same reason.
- `PostgresService` takes a minimal `PgxConnector` (`BeginTx` only); production wires a `*pgxpool.Pool` directly. Same pattern as `plane/application/graphql/persisted` — application plane owns its persistence path through a small wrapper, preserving the ADR-017 swap surface at the package boundary.
- Phase 1 shadow-mode plumbing was hypothetical in the plan; no `prnoise.shadow` flag or `prnoise_shadow_decisions` table exists in the tree, so no removal commit was needed. The migration ships only the new `collaboration.pr_noise_decisions` table.
- PR-engine handler wiring and webhook-consumer updates (Task 8 in the plan) are intentionally NOT in this PR — they should land as a follow-up that pins the consumer side of the new outbox event with its own integration test. Tracking this as a follow-up keeps blast radius bounded.
- Reputation-feedback loop (decrement on reject) is a follow-up tracked in the spec §Open questions.

<details>
<summary>Self-review summary</summary>

- code-reviewer: package structure mirrors identity (events.go / models.go / config.go / postgres_service.go / stub_service.go); error wrapping consistent (`%w`); no panics outside test code; context propagated as the first arg of every blocking method.
- silent-failure-hunter: no fall-through default scores. Pipeline returns `(Decision{}, error)` on every stage failure; reputation lookup propagates `identity.ErrAgentNotFound` instead of substituting a default.
- adr-historian: ADR-016 threshold quoted verbatim; ADR-021 Qdrant scope respected; ADR-008 same-Tx invariant verified by reading `postgres_service.go::persistOnce` (single `BeginTx`, both `INSERT`s, then `Commit`); ADR-019 plane boundary intact.
- pr-test-analyzer: every stage has table-driven coverage at boundary, mid, and out-of-range; determinism test asserts byte-for-byte Decision equality; rescore test asserts upsert + new outbox row; cross-org filter tested in both states; threshold-gate test anchored on the constant so an ADR-016 drift fires here first.
- type-design-analyzer: closed enum (`DecisionCode`) with `Valid()` helper; root-package interfaces eliminate sub-package cycles; no `interface{}` in public surface.
- architect-review: plane boundary clean; Qdrant access path satisfies ADR-021 (only `prnoise/dedup`); no Kafka publish from the package.
</details>

Closes #116

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>