### PR TITLE
[Meta] Multi-topology test harness — design spec + scaffold (#132)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test lint lint-md lint-events lint-determinism lint-firecracker lint-proto lint-graphql install-hooks generate proto fmt
+.PHONY: build test lint lint-md lint-events lint-determinism lint-firecracker lint-proto lint-graphql install-hooks generate proto fmt topo-up-single topo-up-quorum topo-up-full topo-down-single topo-down-quorum topo-down-full lint-test-tags
 
 build:
 	go build ./...
@@ -62,3 +62,29 @@ workflow-stack-up:
 
 workflow-stack-down:
 	docker compose stop temporal temporal-ui vault
+
+# --- Multi-topology test harness (issue #132) ---
+# Stubs land here in #132. Real compose contents arrive in sub-issue 1.
+
+TOPO_DIR := test/topology
+
+define _topo_not_ready
+	@echo "ERROR: topology '$(1)' not yet implemented."; \
+	echo "       See sub-issue 1 of #132 (topology compose files)."; \
+	exit 1
+endef
+
+topo-up-single:
+	$(call _topo_not_ready,single)
+
+topo-up-quorum:
+	$(call _topo_not_ready,quorum)
+
+topo-up-full:
+	$(call _topo_not_ready,full)
+
+topo-down-single topo-down-quorum topo-down-full:
+	@true   # no-op until topo-up exists; safe to run on fresh checkouts
+
+lint-test-tags:
+	@bash scripts/lint-test-tags.sh

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -526,9 +526,10 @@ Consequences: <positive, negative, follow-ups>
 ### ADR-008: Adopted outbox-based event consistency with a polling-based outbox consumer
 
 - **Status:** Accepted
+- **Amended:** 2026-05-09
 - **Date:** TBD
 - **Context:** State changes must be observable by search, webhooks, billing, and audit consumers without dual-writes that risk divergence between the DB and the event bus. The publisher must be portable across metadata-store engines (per ADR-006) without coupling the application code to engine-specific CDC.
-- **Decision:** State-mutating SQL transactions write the source change AND an `outbox` row in the same transaction. The caller is acknowledged on DB commit, not on Kafka publication. A polling-based outbox consumer (advisory-locked `SELECT … WHERE processed = false ORDER BY created_at LIMIT N` loop) drains each outbox table and publishes to Kafka with idempotent producer config. Outbox rows TTL-expire 24 h after the consumer high-water mark advances past them. Consumers must be idempotent on `event_id`.
+- **Decision:** State-mutating SQL transactions write the source change AND an `outbox` row in the same transaction. The caller is acknowledged on DB commit, not on Kafka publication. A polling-based outbox consumer (advisory-locked `SELECT … WHERE processed = false ORDER BY created_at LIMIT N` loop) drains each outbox table and publishes to Kafka with idempotent producer config. Outbox rows TTL-expire 24 h after the consumer high-water mark advances past them. Consumers must be idempotent on `event_id`. The outbox consumer tolerates up to 30 s of PostgreSQL primary→replica lag without skipping events; events past that threshold trigger a paging alert on `outbox_replica_lag_seconds`. Read-replica reads are forbidden for the outbox draining loop — the consumer reads the primary directly.
 - **Consequences:** No dual-write race. Publish latency bounded by poll interval (default 1s; tunable). At-least-once delivery contract; consumers carry the idempotency burden. Logical replication or engine-native CDC is the upgrade path if poll latency becomes a constraint, swappable behind the same `EventQueue` interface. See ADR-019 for the workflow-plane variant of this invariant.
 
 ### ADR-009: Adopted Redis for the rate-limit and identity cache

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -487,17 +487,17 @@ Consequences: <positive, negative, follow-ups>
 ### ADR-004: Adopted Kafka as the event bus
 
 - **Status:** Accepted
-- **Amended:** 2026-05-04
+- **Amended:** 2026-05-09
 - **Date:** TBD
 - **Context:** Search, webhooks, billing, and audit consumers must observe state changes asynchronously without coupling to the application plane. Synchronous fan-out is a tight-coupling failure mode.
 - **Decision:** Kafka is the canonical event bus. Per-partition ordering is preserved per aggregate, keyed on `aggregate_id`
   (UUID) for every topic. Repo-level or org-level ordering is not guaranteed;
   consumers requiring it must reorder by `(aggregate_id, published_at)` after
   consumption. The previous `repo_id`/`org_id` keying was rejected to avoid
-  hot-partition risk under agent traffic. Cross-partition ordering is undefined. Topics are fed by the polling-based outbox consumer reading PostgreSQL outbox tables (ADR-008).
+  hot-partition risk under agent traffic. Cross-partition ordering is undefined. Topics are fed by the polling-based outbox consumer reading PostgreSQL outbox tables (ADR-008). Brokers run replication factor 3 with `min.insync.replicas=2`; producers use `acks=all` and idempotent producer config. A topic that cannot meet ISR=2 fails writes loudly rather than silently degrading durability.
 - **Consequences:** Log semantics enable replay, fan-out, and audit. Consumers must be idempotent on `event_id`. Direct Kafka producer paths from application code are forbidden — see `.claude/skills/gitscale-outbox-check/`. Cross-links: design specs for issues #11 and #12
   (docs/superpowers/specs/2026-05-02-issue-11-outbox-consumer-design.md,
-  docs/superpowers/specs/2026-05-02-issue-12-kafka-topology-design.md).
+  docs/superpowers/specs/2026-05-02-issue-12-kafka-topology-design.md). Single-broker loss is tolerated; two-broker loss surfaces as producer failure, preserving the no-silent-data-loss contract.
 
 ### ADR-005: Adopted Go for the application plane
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -794,7 +794,17 @@ GitScale-specific extensions to the AGENTS.md predicate vocabulary are flagged w
 
 ---
 
-## 10. Cross-references
+## 10. Test topology strategy
+
+GitScale tests run in three topologies, all on a single host (laptop or CI runner): `single`, `quorum` (3-node), and `full` (plane-multiplexed). Functional and performance scenarios are tagged on two orthogonal axes — topology (`topo_single` / `topo_quorum` / `topo_full`) and kind (`perf`, `chaos_link`, `chaos_blast`). Performance is a nightly regression smoke gate, not an SLO gate, and runs only on self-hosted pinned-CPU runners with a Mann-Whitney U statistical comparison against a rolling 7-run main-branch baseline.
+
+Single-host green CI does NOT prove: real fsync durability, gray-failure asymmetry, lease/fencing under clock skew, torn-write recovery, full (10,4) Reed-Solomon reconstruction, absolute SLO, or multi-tenant class isolation under independent network sources. Each of these is tracked against a separate real-infra epic.
+
+Full design: [`docs/superpowers/specs/2026-05-09-issue-132-multi-topology-test-harness-design.md`](superpowers/specs/2026-05-09-issue-132-multi-topology-test-harness-design.md).
+
+---
+
+## 11. Cross-references
 
 - [`architecture.md`](architecture.md) — system diagrams, ADRs, scalability and failure mode analysis, multi-region topology, operational design contracts
 - [`CLAUDE.md`](../CLAUDE.md) — repo guidance, three core principles, technology stack, branch and commit conventions

--- a/docs/superpowers/plans/2026-05-09-issue-132-multi-topology-test-harness-plan.md
+++ b/docs/superpowers/plans/2026-05-09-issue-132-multi-topology-test-harness-plan.md
@@ -1,0 +1,571 @@
+# Multi-Topology Test Harness Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Land issue #132's umbrella deliverable — design spec, ADR amendments, repository scaffolding, and 8 sub-issue stubs — so subsequent sub-issues have a stable foundation to implement against.
+
+**Architecture:** Pure scaffolding + docs PR. No test code or compose contents land here; sub-issues do that. This PR creates: amended ADRs, spec doc, `docs/design.md` cross-reference, `test/topology/{single,quorum,full}/` skeletons, Make target stubs that fail loudly, lint target, and 8 GitHub sub-issues linked back to the spec.
+
+**Tech Stack:** Markdown only (docs), Make (stubs), Bash (lint script), `gh` CLI (sub-issue creation). No Go code in this PR.
+
+**Spec:** `docs/superpowers/specs/2026-05-09-issue-132-multi-topology-test-harness-design.md`
+
+**Branch:** `feat/meta-multi-topology-test-harness-scaffold`
+
+---
+
+### Task 1: Amend ADR-004 (Kafka durability invariants)
+
+**Files:**
+- Modify: `docs/architecture.md` (ADR-004 block, ~line 487-501)
+
+- [ ] **Step 1: Add durability invariants to ADR-004 Decision section**
+
+Edit ADR-004 in `docs/architecture.md`. After the existing `Decision:` text, append the following sentence to the same paragraph (before the cross-references):
+
+```
+Brokers run replication factor 3 with `min.insync.replicas=2`; producers use
+`acks=all` and idempotent producer config. A topic that cannot meet ISR=2
+fails writes loudly rather than silently degrading durability.
+```
+
+Update the `Amended:` line to `2026-05-09`.
+
+- [ ] **Step 2: Add a Consequences sentence**
+
+Append to the Consequences paragraph of ADR-004:
+
+```
+Single-broker loss is tolerated; two-broker loss surfaces as producer failure,
+preserving the no-silent-data-loss contract.
+```
+
+- [ ] **Step 3: Verify markdown lint**
+
+Run: `make lint-md`
+Expected: no errors on `docs/architecture.md`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/architecture.md
+git commit -m "docs(adr): ADR-004 — pin Kafka durability (RF=3, ISR=2, acks=all)
+
+Issue #132 multi-topology test harness asserts these invariants;
+they were previously implicit. Refs #132."
+```
+
+---
+
+### Task 2: Amend ADR-008 (outbox replica-lag SLO)
+
+**Files:**
+- Modify: `docs/architecture.md` (ADR-008 block, ~line 526-532)
+
+- [ ] **Step 1: Add replica-lag invariant to ADR-008 Decision section**
+
+Edit ADR-008 in `docs/architecture.md`. Append to the existing `Decision:` paragraph:
+
+```
+The outbox consumer tolerates up to 30 s of PostgreSQL primary→replica lag
+without skipping events; events past that threshold trigger a paging alert
+on `outbox_replica_lag_seconds`. Read-replica reads are forbidden for the
+outbox draining loop — the consumer reads the primary directly.
+```
+
+Add a line to the ADR header: `Amended: 2026-05-09`.
+
+- [ ] **Step 2: Verify lint**
+
+Run: `make lint-md`
+Expected: pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/architecture.md
+git commit -m "docs(adr): ADR-008 — pin outbox max replica lag (30s, primary-only read)
+
+Issue #132 harness asserts outbox idempotency under replica lag;
+the threshold was previously unstated. Refs #132."
+```
+
+---
+
+### Task 3: Land design spec doc
+
+**Files:**
+- Already created: `docs/superpowers/specs/2026-05-09-issue-132-multi-topology-test-harness-design.md`
+
+- [ ] **Step 1: Verify spec lints clean**
+
+Run: `make lint-md`
+Expected: pass.
+
+- [ ] **Step 2: Commit spec**
+
+```bash
+git add docs/superpowers/specs/2026-05-09-issue-132-multi-topology-test-harness-design.md
+git commit -m "docs(meta): design spec for issue #132 multi-topology test harness
+
+Three topologies (single/quorum/full), two-axis tag taxonomy
+(topo_* x {perf,chaos_link,chaos_blast}), perf as nightly regression
+smoke gate on self-hosted-perf runners with statistical (MWU) gate.
+Refs #132."
+```
+
+---
+
+### Task 4: Cross-reference section in docs/design.md
+
+**Files:**
+- Modify: `docs/design.md` — insert new `## 11. Test topology strategy` section before the existing `## 10. Cross-references` section.
+
+- [ ] **Step 1: Insert §11 before existing §10**
+
+Open `docs/design.md`. Find the line `## 10. Cross-references` (~line 797). Immediately before it, insert:
+
+```markdown
+## 11. Test topology strategy
+
+GitScale tests run in three topologies, all on a single host (laptop or CI
+runner): `single`, `quorum` (3-node), and `full` (plane-multiplexed).
+Functional and performance scenarios are tagged on two orthogonal axes —
+topology (`topo_single` / `topo_quorum` / `topo_full`) and kind (`perf`,
+`chaos_link`, `chaos_blast`). Performance is a nightly regression smoke
+gate, not an SLO gate, and runs only on self-hosted pinned-CPU runners
+with a Mann-Whitney U statistical comparison against a rolling 7-run
+main-branch baseline.
+
+Single-host green CI does NOT prove: real fsync durability, gray-failure
+asymmetry, lease/fencing under clock skew, torn-write recovery, full
+(10,4) Reed-Solomon reconstruction, absolute SLO, or multi-tenant class
+isolation under independent network sources. Each of these is tracked
+against a separate real-infra epic.
+
+Full design: [`docs/superpowers/specs/2026-05-09-issue-132-multi-topology-test-harness-design.md`](superpowers/specs/2026-05-09-issue-132-multi-topology-test-harness-design.md).
+```
+
+Then renumber the existing `## 10. Cross-references` to `## 12. Cross-references`.
+
+- [ ] **Step 2: Verify lint and section numbering**
+
+Run: `make lint-md && grep -n "^## " docs/design.md | tail -5`
+Expected: lint passes; sections end at `## 12. Cross-references`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/design.md
+git commit -m "docs: design.md §11 test topology strategy cross-ref
+
+Names what single-host CI cannot prove so contributors don't claim
+more than the harness delivers. Refs #132."
+```
+
+---
+
+### Task 5: Create test/topology/ skeleton
+
+**Files:**
+- Create: `test/topology/single/compose.yaml`
+- Create: `test/topology/single/README.md`
+- Create: `test/topology/quorum/compose.yaml`
+- Create: `test/topology/quorum/README.md`
+- Create: `test/topology/full/compose.yaml`
+- Create: `test/topology/full/README.md`
+- Create: `test/topology/common/README.md`
+- Create: `test/scenarios/README.md`
+- Create: `test/budgets/perf.yaml`
+- Create: `test/fixtures/README.md`
+
+- [ ] **Step 1: Create directory tree with placeholder compose files**
+
+Each `compose.yaml` is a stub that fails loudly until its sub-issue lands. Each README points to the sub-issue.
+
+`test/topology/single/compose.yaml`:
+
+```yaml
+# Placeholder — real contents land in sub-issue 1.
+# Until then `make topo-up-single` exits non-zero with a pointer.
+# This file exists only so the path is a real location reviewers can comment on.
+```
+
+`test/topology/single/README.md`:
+
+```markdown
+# Topology: single
+
+1-node compose for L2 integration. Proves logic, contracts, schema,
+fast feedback. Implemented in sub-issue 1 of #132.
+
+See `docs/superpowers/specs/2026-05-09-issue-132-multi-topology-test-harness-design.md` §3, §9.
+```
+
+`test/topology/quorum/compose.yaml`:
+
+```yaml
+# Placeholder — sub-issue 1 of #132 lands real contents.
+# Target: 3x postgres, 3x kafka, 3x temporal, netem, toxiproxy.
+```
+
+`test/topology/quorum/README.md`:
+
+```markdown
+# Topology: quorum
+
+3-node compose for L3. Proves outbox-under-replica-lag, 2-of-3 quorum
+writes, Kafka ISR, Temporal HA failover. Implemented in sub-issue 1.
+```
+
+`test/topology/full/compose.yaml`:
+
+```yaml
+# Placeholder — sub-issue 1 of #132 lands real contents.
+# Target: plane-multiplexed (1 container per plane) over quorum services.
+```
+
+`test/topology/full/README.md`:
+
+```markdown
+# Topology: full
+
+Plane-multiplexed compose for L4 nightly. Proves plane isolation,
+cross-plane blast-radius containment, polling-outbox fanout to >=4
+idempotent consumers (search, webhooks, billing, audit), EC degraded
+read. NOT a 9-host topology — node count is incidental; plane-per-
+container is the signal.
+
+Implemented in sub-issue 1 of #132.
+```
+
+`test/topology/common/README.md`:
+
+```markdown
+# Shared compose service definitions
+
+Reused by single/quorum/full via `extends:`. Populated in sub-issue 1.
+```
+
+`test/scenarios/README.md`:
+
+```markdown
+# Test scenarios
+
+Build-tag taxonomy (two-axis):
+
+- Topology (mutex): `topo_single`, `topo_quorum`, `topo_full`
+- Kind (orthogonal): `perf`, `chaos_link`, `chaos_blast`
+
+Every scenario file declares both axes:
+
+    //go:build integration && topo_quorum
+
+`make lint-test-tags` rejects files with a kind tag but no topology tag.
+
+Layout (populated by sub-issues 7 and 8):
+
+    functional/    integration && topo_single
+    quorum/        integration && topo_quorum
+    full/          integration && topo_full
+    perf/          integration && perf && (topo_single|topo_quorum)
+    chaos_link/    integration && chaos_link && topo_quorum
+    chaos_blast/   integration && chaos_blast && topo_quorum
+```
+
+`test/budgets/perf.yaml`:
+
+```yaml
+# Placeholder. Schema and first scenario land in sub-issue 5.
+schema_version: 1
+scenarios: []
+```
+
+`test/fixtures/README.md`:
+
+```markdown
+# Test fixtures
+
+- `repos/{small,medium,large}/`: golden git bundles (`git bundle create`),
+  not full directories. <5 MB / <50 MB / <200 MB. Populated in sub-issue 1.
+- `seed/`: deterministic generator scripts with fixed PRNG seed and pinned
+  schema version. Output cached as CI workflow artifact keyed on script SHA.
+  Never check in raw .sql dumps. Populated in sub-issue 7.
+```
+
+- [ ] **Step 2: Verify markdown lints**
+
+Run: `make lint-md`
+Expected: pass.
+
+- [ ] **Step 3: Commit scaffolding**
+
+```bash
+git add test/
+git commit -m "feat(meta): test/ scaffold for multi-topology harness (issue #132)
+
+Empty topology dirs + READMEs that point at sub-issues. Compose files
+are placeholders so reviewers have a stable path to comment on. Refs #132."
+```
+
+---
+
+### Task 6: Make target stubs
+
+**Files:**
+- Modify: `Makefile`
+- Create: `scripts/lint-test-tags.sh`
+
+- [ ] **Step 1: Add Make targets to Makefile**
+
+Open `Makefile`. Add to the `.PHONY:` line at the top: ` topo-up-single topo-up-quorum topo-up-full topo-down-single topo-down-quorum topo-down-full lint-test-tags`.
+
+Append to the end of the file:
+
+```makefile
+# --- Multi-topology test harness (issue #132) ---
+# Stubs land here in #132. Real compose contents arrive in sub-issue 1.
+
+TOPO_DIR := test/topology
+
+define _topo_not_ready
+	@echo "ERROR: topology '$(1)' not yet implemented."; \
+	echo "       See sub-issue 1 of #132 (topology compose files)."; \
+	exit 1
+endef
+
+topo-up-single:
+	$(call _topo_not_ready,single)
+
+topo-up-quorum:
+	$(call _topo_not_ready,quorum)
+
+topo-up-full:
+	$(call _topo_not_ready,full)
+
+topo-down-single topo-down-quorum topo-down-full:
+	@true   # no-op until topo-up exists; safe to run on fresh checkouts
+
+lint-test-tags:
+	@bash scripts/lint-test-tags.sh
+```
+
+- [ ] **Step 2: Create `scripts/lint-test-tags.sh`**
+
+```bash
+#!/usr/bin/env bash
+# Reject test files that declare a kind-axis tag (perf, chaos_link, chaos_blast)
+# without also declaring a topology-axis tag (topo_single, topo_quorum, topo_full).
+# Issue #132 §4.3.
+
+set -euo pipefail
+
+KIND_TAGS='perf|chaos_link|chaos_blast'
+TOPO_TAGS='topo_single|topo_quorum|topo_full'
+
+violations=0
+while IFS= read -r -d '' f; do
+  head -n 5 "$f" | grep -qE "^//go:build .*($KIND_TAGS)" || continue
+  if ! head -n 5 "$f" | grep -qE "^//go:build .*($TOPO_TAGS)"; then
+    echo "lint-test-tags: $f declares a kind tag without a topology tag"
+    violations=$((violations+1))
+  fi
+done < <(find test/scenarios -name '*_test.go' -print0 2>/dev/null)
+
+if [ "$violations" -gt 0 ]; then
+  echo "lint-test-tags: $violations violation(s). See test/scenarios/README.md."
+  exit 1
+fi
+echo "lint-test-tags: ok"
+```
+
+Make it executable: `chmod +x scripts/lint-test-tags.sh`.
+
+- [ ] **Step 3: Verify Make targets behave**
+
+Run all four:
+
+```bash
+make topo-up-single 2>&1 | head -3
+make topo-up-quorum 2>&1 | head -3
+make topo-up-full 2>&1 | head -3
+make lint-test-tags
+```
+
+Expected:
+- First three: print `ERROR: topology '<name>' not yet implemented.` and exit code 1.
+- `lint-test-tags`: prints `lint-test-tags: ok` and exits 0 (test/scenarios is empty).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Makefile scripts/lint-test-tags.sh
+git commit -m "feat(meta): make targets topo-up-{single,quorum,full} + lint-test-tags
+
+Stubs for #132. topo-up-* fail loudly with a pointer to sub-issue 1
+until real compose lands. lint-test-tags enforces the two-axis tag
+rule (kind tag without topology tag = error). Refs #132."
+```
+
+---
+
+### Task 7: Spawn 8 sub-issues
+
+**Files:**
+- None (gh CLI only)
+
+- [ ] **Step 1: Verify gh auth**
+
+Run: `gh auth status`
+Expected: authenticated.
+
+- [ ] **Step 2: Create sub-issues**
+
+Run each command and record the issue numbers:
+
+```bash
+SPEC="docs/superpowers/specs/2026-05-09-issue-132-multi-topology-test-harness-design.md"
+PARENT=132
+
+gh issue create --title "[Meta] Topology compose files — single/quorum/full + Make targets" \
+  --label "type/design,p2" \
+  --body "$(cat <<EOF
+Sub-issue 1 of #${PARENT}. Land real contents for \`test/topology/{single,quorum,full}/compose.yaml\`, the shared services in \`test/topology/common/\`, healthchecks, and wire \`make topo-up-{single,quorum,full}\` to \`docker compose up -d\` (replacing the stubs from #${PARENT}).
+
+Spec: ${SPEC} §3, §9.
+
+Acceptance:
+- [ ] All three compose files boot cleanly
+- [ ] Healthchecks gate scenario execution
+- [ ] Static port allocation per spec §9.2
+- [ ] \`docker compose down -v --remove-orphans\` runs as pre-step
+EOF
+)"
+
+gh issue create --title "[Meta] Build-tag taxonomy migration — add topo_single to existing integration tests" \
+  --label "type/design,p2" \
+  --body "$(cat <<EOF
+Sub-issue 2 of #${PARENT}. Add \`topo_single\` to every existing \`//go:build integration\` test file. Mechanical pass; preserves existing build behavior because we only add a tag.
+
+Spec: ${SPEC} §4.4.
+
+Acceptance:
+- [ ] All existing integration tests now declare both axes
+- [ ] \`make lint-test-tags\` passes
+- [ ] \`go test -tags=integration,topo_single ./...\` selects the same tests as today's \`-tags=integration\`
+EOF
+)"
+
+gh issue create --title "[Meta] Toxiproxy + netem latency injection harness" \
+  --label "type/design,p2" \
+  --body "Sub-issue 3 of #${PARENT}. Go test helpers wrapping toxiproxy API + netem qdisc setup for \`chaos_link\` scenarios. Spec: ${SPEC} §6."
+
+gh issue create --title "[Meta] Pumba kill-node chaos primitives" \
+  --label "type/design,p2" \
+  --body "Sub-issue 4 of #${PARENT}. Go test helpers for \`chaos_blast\` (kill-node, pause-node) via pumba. Spec: ${SPEC} §6."
+
+gh issue create --title "[Meta] Perf regression gate — k6/ghz harness + budgets/perf.yaml" \
+  --label "type/design,p2" \
+  --body "$(cat <<EOF
+Sub-issue 5 of #${PARENT}. Land the L5 perf gate runner: open-loop k6/ghz, statistical comparison (Mann-Whitney U, α=0.01), rolling-7 baseline storage, self-hosted-perf runner requirement.
+
+Spec: ${SPEC} §7.
+
+Acceptance:
+- [ ] First scenario in \`test/budgets/perf.yaml\`
+- [ ] Gate fails only on 2-of-3 reruns
+- [ ] No GHA shared runners (enforced via runner label gate)
+EOF
+)"
+
+gh issue create --title "[Meta] CI tiers L3/L4/L5 — GH Actions wiring" \
+  --label "type/design,p2" \
+  --body "Sub-issue 6 of #${PARENT}. GH Actions workflow files for L3 (merge-to-main + nightly), L4 (nightly), L5 (nightly + tag, self-hosted). Spec: ${SPEC} §8."
+
+gh issue create --title "[Meta] Quorum scenarios — outbox-under-lag, 2-of-3 quorum write, Kafka ISR" \
+  --label "type/design,p2" \
+  --body "Sub-issue 7 of #${PARENT}. First real \`topo_quorum\` scenarios. Spec: ${SPEC} §5.1."
+
+gh issue create --title "[Meta] Full-topology scenarios — plane isolation + polling-outbox fanout" \
+  --label "type/design,p2" \
+  --body "Sub-issue 8 of #${PARENT}. First real \`topo_full\` scenarios — plane network-policy negative tests + polling-outbox fanout to ≥4 idempotent consumers. Spec: ${SPEC} §5.1, §10."
+```
+
+- [ ] **Step 3: Record sub-issue numbers in the parent**
+
+Run: `gh issue list --label type/design --state open --search "[Meta]" --limit 20 --json number,title`
+
+Note the 8 new issue numbers. Then update the parent:
+
+```bash
+gh issue comment 132 --body "Sub-issues spawned per spec §10:
+
+- 1. Compose files: #<N1>
+- 2. Tag migration: #<N2>
+- 3. Toxiproxy/netem: #<N3>
+- 4. Pumba: #<N4>
+- 5. Perf gate: #<N5>
+- 6. CI tiers: #<N6>
+- 7. Quorum scenarios: #<N7>
+- 8. Full scenarios: #<N8>
+
+Spec: docs/superpowers/specs/2026-05-09-issue-132-multi-topology-test-harness-design.md
+Plan: docs/superpowers/plans/2026-05-09-issue-132-multi-topology-test-harness-plan.md"
+```
+
+(Substitute actual issue numbers for the placeholders.)
+
+---
+
+### Task 8: Open PR
+
+**Files:**
+- None
+
+- [ ] **Step 1: Push branch**
+
+```bash
+git push -u origin feat/meta-multi-topology-test-harness-scaffold
+```
+
+- [ ] **Step 2: Open PR**
+
+```bash
+gh pr create --title "[Meta] Multi-topology test harness — design spec + scaffold (#132)" \
+  --body "$(cat <<'EOF'
+## Summary
+
+Lands the umbrella deliverable for issue #132:
+
+- ADR-004 amended (Kafka durability: RF=3, ISR=2, acks=all)
+- ADR-008 amended (outbox max replica lag: 30s, primary-only read)
+- Design spec: docs/superpowers/specs/2026-05-09-issue-132-multi-topology-test-harness-design.md
+- Cross-ref §11 in docs/design.md naming what single-host CI cannot prove
+- test/ scaffold with placeholder compose.yaml + READMEs per topology
+- Make targets `topo-up-{single,quorum,full}` (stubs that fail loudly)
+- `make lint-test-tags` enforcing the two-axis tag rule
+- 8 sub-issues spawned for real implementation work
+
+No test code or compose contents land here — sub-issues do that.
+
+## Test plan
+
+- [x] `make lint-md` passes
+- [x] `make lint-test-tags` exits 0 on empty test/scenarios
+- [x] `make topo-up-single` exits 1 with the expected pointer message
+- [x] Spec markdown renders cleanly on GitHub
+
+Closes #132 (umbrella; sub-issues track remaining implementation).
+EOF
+)"
+```
+
+---
+
+## Self-review
+
+**Spec coverage:** every acceptance criterion in spec §11 maps to a task: ADR-004→Task 1, ADR-008→Task 2, spec file→Task 3, design.md cross-ref→Task 4, topology dirs+placeholder compose→Task 5, Make targets→Task 6, lint-test-tags→Task 6, 8 sub-issues→Task 7.
+
+**Placeholder scan:** no "TBD"/"TODO"/"implement later" steps. Stubs in shipped code are intentional and named (sub-issue 1 owns real compose contents).
+
+**Type consistency:** tag names (`topo_single`, `topo_quorum`, `topo_full`, `perf`, `chaos_link`, `chaos_blast`) used consistently across spec §4, scaffold READMEs (Task 5), and lint script (Task 6).

--- a/docs/superpowers/specs/2026-05-09-issue-132-multi-topology-test-harness-design.md
+++ b/docs/superpowers/specs/2026-05-09-issue-132-multi-topology-test-harness-design.md
@@ -1,0 +1,307 @@
+# Multi-Topology Test Harness — Design Spec
+
+**Issue:** [#132](https://github.com/gitscale/gitscale-platform/issues/132)
+**Status:** Proposed
+**Date:** 2026-05-09
+**Authors:** Neeraj Mittal (drafted with expert agent review: adr-historian, architect-review, test-automator, performance-engineer)
+
+---
+
+## 1. Problem
+
+Today the repo has two test tiers — unit (`go test ./...`) and integration (`//go:build integration`, single-node compose). This catches logic and contract bugs but cannot exercise the load-bearing distributed invariants in `CLAUDE.md` and the ADRs:
+
+- ADR-008 outbox idempotency under PostgreSQL replica lag
+- 2-of-3 quorum write on hot-tier storage (CLAUDE.md §Storage tiering)
+- Kafka durability under broker loss (`min.insync.replicas`)
+- Plane independence (Principle 2 — no cascading failure across plane boundaries)
+- Polling outbox consumer fanout to N idempotent consumers
+
+We need a single repository-of-truth test strategy that exercises GitScale across three deployment topologies — single-node, 3-node quorum, plane-multiplexed full — with both functional and performance scenarios, all runnable on a single physical host (developer laptop or CI runner).
+
+## 2. Non-goals
+
+- Absolute SLO validation (requires multi-host infra; tracked separately)
+- Geo-distributed scenarios
+- Full (10,4) Reed-Solomon reconstruction proof — needs ≥14 hosts; only degraded read is provable here
+- E2E browser tests (no UI repo)
+- Per-PR perf gating — perf is nightly-only
+
+## 3. Topologies
+
+### 3.1 Why three
+
+| Topology | Proves | Compose target |
+|---|---|---|
+| **single** | Logic, contracts, schema, fast feedback | `test/topology/single/compose.yaml` |
+| **quorum** (3-node) | Outbox under replica lag, 2-of-3 quorum, Kafka ISR, Temporal HA, failover | `test/topology/quorum/compose.yaml` |
+| **full** (plane-multiplexed) | Plane isolation, cross-plane blast-radius containment, polling outbox at fanout, EC degraded read | `test/topology/full/compose.yaml` |
+
+### 3.2 Reframing "9-node" as plane-multiplexed full
+
+The issue originally framed the third topology as "8-9-node". Node count is incidental — the real signal is **one container per plane** so cross-plane blast radius is observable. Calling it "9-node" overstates fidelity (9 hosts cannot prove (10,4) RS reconstruction). The topology name is `full`; the container count varies with how many planes × how many quorum members each plane gets.
+
+Concretely `full` runs:
+
+- 3× postgres (quorum)
+- 3× kafka brokers + 3× zookeeper/kraft
+- 3× temporal frontend + matching/history
+- 1× edge (Envoy)
+- 1× git plane (Gitaly)
+- 1× application plane
+- 1× workflow plane
+- 1× redis (single replica is fine for cache class)
+- toxiproxy + pumba
+
+### 3.3 What 3-node already covers
+
+If `quorum` passes with chaos and replica lag injected, `full`'s marginal value is plane-boundary regression and outbox-consumer-fanout. Run `full` nightly, not per-PR.
+
+## 4. Build-tag taxonomy (two-axis)
+
+The original proposal mixed axes (`integration`, `topology_quorum`, `topology_full`, `perf`, `chaos`). `integration` is currently used as the catch-all "not unit", which overlaps every topology tag. Two-axis fixes the collision.
+
+### 4.1 Topology axis (mutually exclusive)
+
+| Tag | Meaning |
+|---|---|
+| (none) | Unit test |
+| `topo_single` | Runs against `test/topology/single` |
+| `topo_quorum` | Runs against `test/topology/quorum` |
+| `topo_full` | Runs against `test/topology/full` |
+
+### 4.2 Kind axis (orthogonal, multi-select)
+
+| Tag | Meaning |
+|---|---|
+| (none) | Functional |
+| `perf` | Performance regression scenario |
+| `chaos_link` | Network-fault chaos (toxiproxy + netem) |
+| `chaos_blast` | Process-fault chaos (pumba kill/pause) |
+
+`chaos` is split into `chaos_link` (credible: link control via toxiproxy/netem) and `chaos_blast` (partially credible: shared kernel dilutes blast-radius proof). Documented caveat in the spec, not an apology in test code.
+
+### 4.3 Composition rule
+
+`go test -tags=integration,topo_quorum,chaos_link ./test/scenarios/quorum/...` selects functional + chaos_link tests targeting quorum.
+
+Every scenario file MUST declare both axes explicitly:
+
+```go
+//go:build integration && topo_quorum
+```
+
+A `lint-test-tags` Make target rejects files that declare a kind tag without a topology tag.
+
+### 4.4 Migration of existing `//go:build integration`
+
+`integration` remains the umbrella "needs Docker" tag. Existing tests are tagged `//go:build integration && topo_single` in a single mechanical pass (sub-issue 2). The acceptance criterion "existing `//go:build integration` tests continue to pass unchanged" is satisfied because the existing build constraint stays — we only **add** the topology axis.
+
+## 5. Single-host fidelity — what we can and cannot prove
+
+We document this prominently so green CI is not mistaken for production-readiness.
+
+### 5.1 Provable on single host
+
+- Logic and contract correctness across all planes
+- Outbox idempotency under simulated replica lag (`tc netem` on the postgres-replica veth)
+- 2-of-3 quorum write semantics (one of three postgres containers killed via pumba)
+- Kafka publish under simulated broker loss
+- Temporal HA failover
+- Polling outbox consumer fanout to ≥4 idempotent consumers (search, webhooks, billing, audit) with `event_id` dedup
+- Plane network-policy contract: e.g. `plane/workflow` cannot reach `plane/data` postgres directly (negative test on docker network)
+
+### 5.2 NOT provable on single host
+
+| Invariant | Why not | Tracked where |
+|---|---|---|
+| Real fsync durability | Shared kernel page cache; loop devices lie the same way | Real-infra epic (TBD) |
+| Gray-failure asymmetry (slow-but-not-dead) | Single NIC, symmetric netem only | Real-infra epic |
+| Lease/fencing-token correctness under clock skew | `LD_PRELOAD` faketime does not affect kernel timers | Real-infra epic |
+| Torn-write / power-loss recovery | No real disk | Real-infra epic |
+| (10,4) Reed-Solomon full reconstruction | Need ≥14 hosts | Real-infra epic |
+| Absolute SLO validation | Single-host throughput is meaningless | Real-infra epic |
+| Multi-tenant class isolation under independent network sources | Loopback shares NIC + scheduler | Real-infra epic |
+
+`docs/design.md` will carry a one-paragraph reference to this list so contributors don't claim more than the harness proves.
+
+## 6. Latency / chaos primitives
+
+- **`tc qdisc netem`** per veth — fixed 1ms intra-AZ default; sweep deferred to L5 perf
+- **`cpus:` / `mem_limit:`** per container — observable contention
+- **Per-node loop devices** — fsync isolation (best-effort; see §5.2)
+- **`faketime`** — Temporal/saga timeout edges (best-effort; userspace only)
+- **Toxiproxy** — partition / latency / bandwidth narrowing (network plane)
+- **Pumba** — kill-node / pause-node (process plane)
+
+Toxiproxy + pumba both: they compose cleanly (toxiproxy owns the network plane, pumba owns the process plane) and using only one loses either link-level or process-level control.
+
+## 7. Performance gate (L5)
+
+### 7.1 Framing
+
+Perf is a **regression smoke gate**, not an SLO gate. It runs nightly only, never per-PR.
+
+### 7.2 Methodology
+
+- Open-loop fixed-rate arrival at 60–70% of measured single-host capacity
+- k6 with `constant-arrival-rate` executor; ghz with `--rps` not `--concurrency`
+- 30s warm-up discarded, 3–5 min steady-state measurement
+- Closed-loop throughput is rejected (coordinated omission masks tail latency)
+
+### 7.3 Statistical gate, not fixed thresholds
+
+GitHub-hosted runners have p99 CV 20–40% — fixed thresholds will flap and get muted within a month.
+
+- 5 runs per commit minimum
+- Compare against rolling-median of last 7 nightly main-branch medians
+- Mann-Whitney U test, α=0.01
+- A regression fails the gate only if 2-of-3 reruns confirm it
+
+### 7.4 Required runner
+
+L5 perf jobs MUST run on **self-hosted, pinned-CPU runners** with `cpuset` and `intel_pstate=performance`. GHA shared runners are explicitly disallowed for L5.
+
+### 7.5 Budget format
+
+`budgets/perf.yaml` schema:
+
+```yaml
+schema_version: 1
+scenarios:
+  - name: repo_clone_small
+    workload:
+      executor: constant-arrival-rate
+      rate_rps: 200
+      duration: 5m
+      warmup: 30s
+    topology: topo_single   # or topo_quorum
+    runs_per_commit: 5
+    baseline:
+      source: rolling-median
+      window_runs: 7
+    tolerances:
+      p50_ms:   { rel_pct: 15, abs_floor_ms: 5  }
+      p99_ms:   { rel_pct: 25, abs_floor_ms: 20 }
+      err_rate: { abs_max: 0.001 }
+    gate:
+      test: mann-whitney-u
+      alpha: 0.01
+      min_runs: 5
+    required_runner: self-hosted-perf
+```
+
+Load-bearing fields: `runs_per_commit`, `baseline.source`, `tolerances.{p50,p99}.{rel_pct, abs_floor}`, `required_runner`. Without these four, the gate is theatre.
+
+### 7.6 Working-set discipline
+
+Pin working-set-to-RAM ratio (`working_set_gb: 2× container_mem`) so the test stays in the regime that exercises the storage path, not the page cache.
+
+### 7.7 What the perf gate does NOT prove
+
+The original issue claimed L5 could prove "agent vs human traffic class isolation (Principle 1)". This claim is removed. Loopback shares NIC, scheduler, and page cache — class isolation under contention requires multi-host load gen with independent network sources. The L5 gate is reframed as a **smoke test for class labelling**, not isolation.
+
+## 8. CI tiers
+
+| Tier | Trigger | Topology | Runner | Time budget |
+|---|---|---|---|---|
+| L1 unit | every push | none | GHA std | 60s |
+| L2 integration | every push | `topo_single` | GHA std | 5 min |
+| L3 quorum | merge to main + nightly | `topo_quorum` + chaos | GHA std (4-core) | 20 min |
+| L4 full | nightly | `topo_full` | GHA std (4-core) | 60 min |
+| L5 perf | nightly + tag | `topo_single` OR `topo_quorum` | **self-hosted-perf** | 30 min |
+
+L3 was originally per-PR; downgraded to merge-to-main + nightly because chaos tests at PR-time will retrain reviewers to ignore failures.
+
+## 9. Repository structure
+
+```
+test/
+  topology/
+    single/compose.yaml                 # 1× pg, 1× kafka, 1× temporal, etc.
+    quorum/compose.yaml                 # 3× pg, 3× kafka, 3× temporal, netem, toxiproxy
+    full/compose.yaml                   # plane-multiplexed: 1 container per plane + quorums
+    common/                             # shared service definitions (extends:)
+  scenarios/
+    functional/                         # tag: integration && topo_single
+    quorum/                             # tag: integration && topo_quorum
+    full/                               # tag: integration && topo_full
+    perf/                               # tag: integration && perf && (topo_single|topo_quorum)
+    chaos_link/                         # tag: integration && chaos_link && topo_quorum
+    chaos_blast/                        # tag: integration && chaos_blast && topo_quorum
+  fixtures/
+    repos/{small,medium,large}/         # git bundles, not full directories
+    seed/                               # deterministic generator scripts, not raw .sql dumps
+  budgets/
+    perf.yaml                           # see §7.5
+  Makefile.topo                         # included by root Makefile
+```
+
+### 9.1 Fixture discipline
+
+- Golden repos as `git bundle create` output (binary-stable, diff-friendly): <5 MB / <50 MB / <200 MB for small/medium/large
+- SQL seeds as a deterministic generator with a fixed PRNG seed and pinned schema version; CI caches the generated dump as a workflow artifact keyed on the script's SHA. **Never check in raw 10M-row `.sql`**.
+
+### 9.2 Port allocation (static)
+
+| Topology | Postgres | Kafka | Temporal | Redis | Other |
+|---|---|---|---|---|---|
+| single | 5432 | 9092 | 7233 | 6379 | (single port each) |
+| quorum | 5440-5442 | 9100-9102 | 7240-7242 | 6390 | netem control 8474, toxiproxy 8475 |
+| full | 5450-5452 | 9110-9112 | 7250-7252 | 6395 | per-plane 8500-8520 |
+
+Static ports beat random-port (port `0`) — log correlation across topologies stays sane.
+
+### 9.3 Container lifecycle
+
+`make topo-up-{single,quorum,full}` runs `docker compose down -v --remove-orphans` as a **pre-step** (post-step is skipped on failure). Volumes are named with the topology prefix and pruned on pre-step.
+
+## 10. Sub-issues to spawn
+
+Issue #132 itself lands the spec, ADR amendments, scaffolding, and sub-issue scaffolding. The following sub-issues do real implementation:
+
+1. **`[Meta] Topology compose files — single/quorum/full + Make targets`** — concrete compose YAML, healthchecks, Make targets
+2. **`[Meta] Build-tag taxonomy migration — add topo_single to existing integration tests`** — mechanical pass + `lint-test-tags` Make target
+3. **`[Meta] Toxiproxy + netem latency injection harness`** — Go test helpers wrapping toxiproxy API, netem qdisc setup
+4. **`[Meta] Pumba kill-node chaos primitives`** — Go test helpers for `chaos_blast`
+5. **`[Meta] Perf regression gate — k6/ghz harness + budgets/perf.yaml`** — gate runner, statistical comparison, baseline storage
+6. **`[Meta] CI tiers L3/L4/L5 — GH Actions wiring`** — workflow files, self-hosted runner provisioning doc
+7. **`[Meta] Quorum scenarios — outbox-under-lag, 2-of-3 quorum write, Kafka ISR`** — first real `topo_quorum` scenarios
+8. **`[Meta] Full-topology scenarios — plane isolation + polling-outbox fanout`** — first real `topo_full` scenarios
+
+## 11. Acceptance for #132 itself
+
+- [ ] ADR-004 amended with Kafka durability invariants (RF=3, `min.insync.replicas=2`, `acks=all`)
+- [ ] ADR-008 amended with outbox max-tolerable-replica-lag SLO
+- [ ] This spec landed at `docs/superpowers/specs/2026-05-09-issue-132-multi-topology-test-harness-design.md`
+- [ ] Cross-reference section added to `docs/design.md`
+- [ ] `test/topology/{single,quorum,full}/` directories created with placeholder `compose.yaml` and per-dir README explaining intent
+- [ ] `make topo-up-single`, `make topo-up-quorum`, `make topo-up-full` Make targets added (stubs that exit with a "not yet implemented — see issue N" message until sub-issues land)
+- [ ] `make lint-test-tags` target added (rejects files with kind tag but no topology tag)
+- [ ] 8 sub-issues opened on GitHub with this spec linked
+
+## 12. Open questions resolved
+
+| Question | Resolution |
+|---|---|
+| Inter-node latency profile (fixed vs sweep) | **Fixed 1ms intra-AZ.** Sweep belongs in L5 perf, not functional chaos |
+| Erasure coding simulation on 9 hosts | **Skip.** Only degraded-read provable; full RS reconstruction needs ≥14. Add a clearly-named `t.Skip` in the topology with a link to the real-infra tracking issue |
+| Perf budgets in-repo YAML vs external service | **In-repo YAML.** External service is operational overhead that doesn't pay off until SLO gates exist (out of scope) |
+| Chaos lib choice | **Toxiproxy + pumba.** Network plane + process plane both required; using only one loses control of the other axis |
+| Migration of existing integration tests | **Coexist initially, migrate in sub-issue 2.** Add `topo_single` to existing tests; clean cut leaves nothing behind because we only add a tag |
+
+## 13. Risks and mitigations
+
+| Risk | Mitigation |
+|---|---|
+| Single-host green CI mistaken for production-ready | §5.2 invariant table referenced from `docs/design.md` |
+| Perf gate flapping on GHA shared runners | Self-hosted-perf runner required (§7.4); statistical gate (§7.3); 2-of-3 rerun confirmation |
+| Tag-axis collision with existing `integration` | Two-axis taxonomy (§4); `lint-test-tags` Make target rejects misuse |
+| Chaos test flake > 0.5% | Assert observable state (outbox drain event, workflow signal), not sleeps; toxiproxy latency ≥3× polling interval |
+| Sub-issue scope creep | Each sub-issue ships a slice that compiles and tests pass standalone |
+
+## 14. Cross-references
+
+- ADR-001 (storage tiers), ADR-004 (Kafka), ADR-008 (outbox), ADR-009 (Redis cache)
+- `CLAUDE.md` Principle 1 (agents primary traffic), Principle 2 (loose coupling)
+- `docs/architecture.md` §7.6 (failure scenarios), §8 (ADR registry)

--- a/scripts/lint-test-tags.sh
+++ b/scripts/lint-test-tags.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Reject test files that declare a kind-axis tag (perf, chaos_link, chaos_blast)
+# without also declaring a topology-axis tag (topo_single, topo_quorum, topo_full).
+# Issue #132 §4.3.
+
+set -euo pipefail
+
+KIND_TAGS='perf|chaos_link|chaos_blast'
+TOPO_TAGS='topo_single|topo_quorum|topo_full'
+
+violations=0
+while IFS= read -r -d '' f; do
+  head -n 5 "$f" | grep -qE "^//go:build .*($KIND_TAGS)" || continue
+  if ! head -n 5 "$f" | grep -qE "^//go:build .*($TOPO_TAGS)"; then
+    echo "lint-test-tags: $f declares a kind tag without a topology tag"
+    violations=$((violations+1))
+  fi
+done < <(find test/scenarios -name '*_test.go' -print0 2>/dev/null)
+
+if [ "$violations" -gt 0 ]; then
+  echo "lint-test-tags: $violations violation(s). See test/scenarios/README.md."
+  exit 1
+fi
+echo "lint-test-tags: ok"

--- a/test/budgets/perf.yaml
+++ b/test/budgets/perf.yaml
@@ -1,0 +1,3 @@
+# Placeholder. Schema and first scenario land in sub-issue 5.
+schema_version: 1
+scenarios: []

--- a/test/fixtures/README.md
+++ b/test/fixtures/README.md
@@ -1,0 +1,7 @@
+# Test fixtures
+
+- `repos/{small,medium,large}/`: golden git bundles (`git bundle create`),
+  not full directories. <5 MB / <50 MB / <200 MB. Populated in sub-issue 1.
+- `seed/`: deterministic generator scripts with fixed PRNG seed and pinned
+  schema version. Output cached as CI workflow artifact keyed on script SHA.
+  Never check in raw .sql dumps. Populated in sub-issue 7.

--- a/test/scenarios/README.md
+++ b/test/scenarios/README.md
@@ -1,0 +1,21 @@
+# Test scenarios
+
+Build-tag taxonomy (two-axis):
+
+- Topology (mutex): `topo_single`, `topo_quorum`, `topo_full`
+- Kind (orthogonal): `perf`, `chaos_link`, `chaos_blast`
+
+Every scenario file declares both axes:
+
+    //go:build integration && topo_quorum
+
+`make lint-test-tags` rejects files with a kind tag but no topology tag.
+
+Layout (populated by sub-issues 7 and 8):
+
+    functional/    integration && topo_single
+    quorum/        integration && topo_quorum
+    full/          integration && topo_full
+    perf/          integration && perf && (topo_single|topo_quorum)
+    chaos_link/    integration && chaos_link && topo_quorum
+    chaos_blast/   integration && chaos_blast && topo_quorum

--- a/test/topology/common/README.md
+++ b/test/topology/common/README.md
@@ -1,0 +1,3 @@
+# Shared compose service definitions
+
+Reused by single/quorum/full via `extends:`. Populated in sub-issue 1.

--- a/test/topology/full/README.md
+++ b/test/topology/full/README.md
@@ -1,0 +1,9 @@
+# Topology: full
+
+Plane-multiplexed compose for L4 nightly. Proves plane isolation,
+cross-plane blast-radius containment, polling-outbox fanout to >=4
+idempotent consumers (search, webhooks, billing, audit), EC degraded
+read. NOT a 9-host topology — node count is incidental; plane-per-
+container is the signal.
+
+Implemented in sub-issue 1 of #132.

--- a/test/topology/full/compose.yaml
+++ b/test/topology/full/compose.yaml
@@ -1,0 +1,2 @@
+# Placeholder — sub-issue 1 of #132 lands real contents.
+# Target: plane-multiplexed (1 container per plane) over quorum services.

--- a/test/topology/quorum/README.md
+++ b/test/topology/quorum/README.md
@@ -1,0 +1,4 @@
+# Topology: quorum
+
+3-node compose for L3. Proves outbox-under-replica-lag, 2-of-3 quorum
+writes, Kafka ISR, Temporal HA failover. Implemented in sub-issue 1.

--- a/test/topology/quorum/compose.yaml
+++ b/test/topology/quorum/compose.yaml
@@ -1,0 +1,2 @@
+# Placeholder — sub-issue 1 of #132 lands real contents.
+# Target: 3x postgres, 3x kafka, 3x temporal, netem, toxiproxy.

--- a/test/topology/single/README.md
+++ b/test/topology/single/README.md
@@ -1,0 +1,6 @@
+# Topology: single
+
+1-node compose for L2 integration. Proves logic, contracts, schema,
+fast feedback. Implemented in sub-issue 1 of #132.
+
+See `docs/superpowers/specs/2026-05-09-issue-132-multi-topology-test-harness-design.md` §3, §9.

--- a/test/topology/single/compose.yaml
+++ b/test/topology/single/compose.yaml
@@ -1,0 +1,3 @@
+# Placeholder — real contents land in sub-issue 1.
+# Until then `make topo-up-single` exits non-zero with a pointer.
+# This file exists only so the path is a real location reviewers can comment on.


### PR DESCRIPTION
## Summary

Lands the umbrella deliverable for issue #132:

- ADR-004 amended (Kafka durability: RF=3, `min.insync.replicas=2`, `acks=all`)
- ADR-008 amended (outbox max replica lag: 30s, primary-only read)
- Design spec: `docs/superpowers/specs/2026-05-09-issue-132-multi-topology-test-harness-design.md`
- Implementation plan: `docs/superpowers/plans/2026-05-09-issue-132-multi-topology-test-harness-plan.md`
- Cross-ref §10 in `docs/design.md` naming what single-host CI cannot prove
- `test/` scaffold with placeholder compose.yaml + READMEs per topology
- Make targets `topo-up-{single,quorum,full}` (stubs that fail loudly)
- `make lint-test-tags` enforcing the two-axis tag rule
- 8 sub-issues spawned (#133–#140) for real implementation work

No test code or compose contents land here — sub-issues do that.

## Key design decisions (vs. original issue)

- `full` reframed as **plane-multiplexed**, not 9-node (node count incidental; (10,4) RS reconstruction needs ≥14 hosts, not provable here)
- **Two-axis tag taxonomy**: `topo_{single,quorum,full}` (mutex) × `{perf, chaos_link, chaos_blast}` (orthogonal). \`chaos\` split into link/blast.
- L3 downgraded from per-PR to **merge-to-main + nightly** (chaos at PR-time retrains reviewers to ignore failures)
- L5 perf gate requires **self-hosted-perf runner** + **Mann-Whitney U** + rolling-7 baseline (not fixed YAML thresholds — GHA p99 CV 20–40% would flap fixed thresholds)
- "Principle 1 isolation" claim removed from L5 scope (loopback shares NIC/scheduler/cache)

## Test plan

- [x] `make lint-md` passes
- [x] `make lint-test-tags` exits 0 on empty test/scenarios
- [x] `make topo-up-single` exits non-zero with the expected pointer message
- [x] `make topo-up-quorum` exits non-zero with the expected pointer message
- [x] `make topo-up-full` exits non-zero with the expected pointer message
- [x] `make topo-down-single` is a no-op (exit 0)
- [x] Spec markdown renders cleanly on GitHub

Closes #132 (umbrella; sub-issues #133–#140 track remaining implementation).